### PR TITLE
fix: population endpoint 404 + DB connection pre-warming

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -832,6 +832,15 @@ async def startup_event():
     logger.info("Main Backend API starting up...")
     logger.info(f"Working directory: {os.getcwd()}")
     logger.info("Initializing database connections...")
+
+    # Pre-warm the database connection pool so the first user request isn't slow
+    try:
+        with next(get_db()) as db:
+            db.execute("SELECT 1")
+        logger.info("Database connection pool warmed up successfully")
+    except Exception as e:
+        logger.warning(f"Database pre-warm failed (non-fatal): {e}")
+
     logger.info("Main Backend API startup complete!")
 
 

--- a/backend/routers/economic.py
+++ b/backend/routers/economic.py
@@ -200,12 +200,37 @@ async def get_population_latest(db: Session = Depends(get_db)):
         raise HTTPException(status_code=503, detail="Database not available")
 
     try:
+        # Try national-level record first (entity_id IS NULL)
         row = (
             db.query(PopulationData)
             .filter(PopulationData.entity_id.is_(None))
             .order_by(desc(PopulationData.year))
             .first()
         )
+
+        # Fallback: aggregate county populations if no national record exists
+        if not row:
+            from sqlalchemy import func as sqlfunc
+            agg = (
+                db.query(
+                    sqlfunc.sum(PopulationData.total_population),
+                    sqlfunc.max(PopulationData.year),
+                )
+                .filter(PopulationData.entity_id.isnot(None))
+                .first()
+            )
+            if agg and agg[0]:
+                # Create a synthetic response (don't save to DB)
+                class _SyntheticPop:
+                    total_population = int(agg[0])
+                    year = agg[1]
+                    male_population = None
+                    female_population = None
+                    urban_population = None
+                    rural_population = None
+                    population_density = None
+                    source_document_id = None
+                row = _SyntheticPop()
     except OperationalError as e:
         logger.error("Database connection error on /population/latest: %s", e)
         raise HTTPException(status_code=503, detail="Database unavailable")


### PR DESCRIPTION
Fixes /economic/population/latest 404 (aggregates county data as fallback) and pre-warms DB connection pool on startup to reduce first-request latency.