### PR TITLE
fix(county-detail): regression follow-ups + Follow-the-Money credibility

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2434,7 +2434,6 @@ async def get_county_details(county_id: str, fiscal_year: Optional[str] = None):
 async def get_county_comprehensive(
     county_id: str,
     fiscal_year: Optional[str] = None,
-    include_findings: bool = False,
 ):
     """Comprehensive county detail — one-stop aggregation of every data dimension.
 
@@ -2855,32 +2854,21 @@ async def get_county_comprehensive(
                     "per_capita_debt": per_capita_debt,
                     "breakdown": debt_breakdown,
                 },
-                # Audit — findings list is ONLY included when the caller
-                # passes `?include_findings=true`. By default the endpoint
-                # ships headline counts; the full list (which can be
-                # 5+ KB per county) is fetched lazily by the Audit tab
-                # via `/api/v1/counties/{id}/audits`. Keeps the comprehensive
-                # payload small for pages that only render badges.
-                "audit": (
-                    {
-                        "status": audit_status,
-                        "grade": grade,
-                        "health_score": round(health_score, 1),
-                        "findings_count": len(audits),
-                        "total_amount_involved": total_audit_amount,
-                        "by_severity": by_severity,
-                        "findings": audit_findings,
-                    }
-                    if include_findings
-                    else {
-                        "status": audit_status,
-                        "grade": grade,
-                        "health_score": round(health_score, 1),
-                        "findings_count": len(audits),
-                        "total_amount_involved": total_audit_amount,
-                        "by_severity": by_severity,
-                    }
-                ),
+                # Audit — findings array is always included so downstream
+                # tab components can iterate safely. An earlier experiment
+                # gated this behind `?include_findings=true` for a ~5KB
+                # payload saving; that broke the Audit tab (iterated
+                # `audit.findings` directly) so the saving wasn't worth
+                # the correctness cost. Kept shipping the full list.
+                "audit": {
+                    "status": audit_status,
+                    "grade": grade,
+                    "health_score": round(health_score, 1),
+                    "findings_count": len(audits),
+                    "total_amount_involved": total_audit_amount,
+                    "by_severity": by_severity,
+                    "findings": audit_findings,
+                },
                 # Health score over time (oldest → newest)
                 "health_history": health_history,
                 # Missing funds

--- a/backend/routers/money_flow.py
+++ b/backend/routers/money_flow.py
@@ -275,14 +275,38 @@ async def county_money_flow(
 ):
     """Trace the full money flow for a county in a fiscal year.
 
-    ``county_id`` accepts either the numeric ``Entity.id`` or the county
-    ``slug`` (e.g. ``nairobi-city``) so the frontend can link by either.
+    ``county_id`` accepts any of:
+      * the 3-digit Kenyan county code ("001" → Nairobi, "047" → Mombasa),
+      * the raw numeric ``Entity.id`` (database primary key),
+      * the county ``slug`` (e.g. ``nairobi-city``).
+    The 3-digit-code path is what the frontend actually links from, so
+    resolve it first via the canonical COUNTY_MAPPING.
     """
     q = db.query(Entity).filter(Entity.type == EntityType.COUNTY)
-    if county_id.isdigit():
-        entity = q.filter(Entity.id == int(county_id)).first()
-    else:
-        entity = q.filter(Entity.slug == county_id).first()
+    entity = None
+
+    # 3-digit county-code lookup (most common path from the UI).
+    if county_id.isdigit() and len(county_id) == 3:
+        try:
+            from main import COUNTY_MAPPING  # avoid circular import at module load
+        except ImportError:
+            COUNTY_MAPPING = {}
+        county_name = COUNTY_MAPPING.get(county_id)
+        if county_name:
+            entity = q.filter(
+                Entity.canonical_name == f"{county_name} County"
+            ).first()
+            if not entity:
+                slug = county_name.lower().replace(" ", "-") + "-county"
+                entity = q.filter(Entity.slug == slug).first()
+
+    # Fallbacks: raw Entity.id then slug.
+    if not entity:
+        if county_id.isdigit():
+            entity = q.filter(Entity.id == int(county_id)).first()
+        else:
+            entity = q.filter(Entity.slug == county_id).first()
+
     if not entity:
         raise HTTPException(status_code=404, detail="County not found")
 

--- a/backend/routers/money_flow.py
+++ b/backend/routers/money_flow.py
@@ -150,8 +150,6 @@ def _money_flow_for_entity(
             "stages": [
                 _build_stage("Allocated", "Budget Allocation", None,
                              source="CRA Allocation + Conditional Grants", data_unavailable=True),
-                _build_stage("Released", "Funds Released", None,
-                             gap_label="Withheld/Delayed", data_unavailable=True),
                 _build_stage("Spent", "Actual Expenditure", None,
                              gap_label="Unspent Funds", data_unavailable=True),
                 _build_stage("Flagged", "Auditor Flagged", None,
@@ -174,22 +172,32 @@ def _money_flow_for_entity(
         # would misleadingly render as "100% unspent" in the waterfall.
         spent_vals = [b.actual_spent for b in budget_lines if b.actual_spent is not None]
         spent = sum(float(s) for s in spent_vals) if spent_vals else None
-        # COB data doesn't have a separate "released" column – use committed_amount
-        # as a proxy for releases if available, otherwise mark unavailable.
+        # "Committed" = procurement encumbrances (contracts awarded but
+        # not yet paid out). This is NOT the same as "exchequer release"
+        # — Treasury disbursements aren't currently captured in the COB
+        # reports we ingest. Kept for future-use but deliberately NOT
+        # surfaced as a waterfall stage: an earlier version rendered this
+        # as "Funds Released" which was actively misleading (committed
+        # << spent for most counties, which is impossible to read as
+        # "received < paid").
         committed_amounts = [b.committed_amount for b in budget_lines if b.committed_amount is not None]
-        if committed_amounts:
-            released = sum(float(c) for c in committed_amounts)
-        else:
-            released = None
+        committed = sum(float(c) for c in committed_amounts) if committed_amounts else None
 
-        # Source doc URL from first budget line
+        # Source doc URL + label from first budget line. The CoB budget
+        # implementation review reports are often H1 (half-year) or Q-
+        # specific, so we surface the exact title rather than implying
+        # a full-year snapshot.
         first_doc = budget_lines[0].source_document if budget_lines else None
         source_doc_url = first_doc.url if first_doc and hasattr(first_doc, "url") else None
+        source_doc_title = (
+            first_doc.title if first_doc and hasattr(first_doc, "title") else None
+        )
     else:
         allocated = None
-        released = None
+        committed = None
         spent = None
         source_doc_url = None
+        source_doc_title = None
 
     # --- Audit flagged amounts ---
     audit_q = db.query(func.sum(Audit.amount)).filter(
@@ -200,6 +208,16 @@ def _money_flow_for_entity(
     flagged = float(flagged) if flagged else None
 
     # --- Build stages ---
+    # We surface three stages from data we ACTUALLY have:
+    #   • Allocated — from COB `allocated_amount` per budget line
+    #   • Spent     — from COB `actual_spent`
+    #   • Flagged   — from OAG audit findings with a KES amount
+    # An older version also rendered a "Funds Released" stage between
+    # allocated and spent, using `committed_amount` as a proxy. That's a
+    # different quantity (procurement encumbrances, not Treasury
+    # disbursements) and produced impossible-looking figures like
+    # "spent > released". Removed until we parse the real exchequer-
+    # release column from CoB.
     stages: List[Dict[str, Any]] = []
 
     # 1. Allocated
@@ -212,24 +230,9 @@ def _money_flow_for_entity(
         data_unavailable=allocated is None,
     ))
 
-    # 2. Released
-    if released is not None and allocated is not None:
-        gap = round(allocated - released, 2)
-    else:
-        gap = None
-    stages.append(_build_stage(
-        stage="Released",
-        label="Funds Released",
-        amount=released,
-        gap_from_prev=gap,
-        gap_label="Withheld/Delayed",
-        data_unavailable=released is None,
-    ))
-
-    # 3. Spent
-    prev_for_spent = released if released is not None else allocated
-    if spent is not None and prev_for_spent is not None:
-        gap_spent = round(prev_for_spent - spent, 2)
+    # 2. Spent
+    if spent is not None and allocated is not None:
+        gap_spent = round(allocated - spent, 2)
     else:
         gap_spent = None
     stages.append(_build_stage(
@@ -260,6 +263,14 @@ def _money_flow_for_entity(
         "stages": stages,
         "total_waste_estimate": flagged,
         "efficiency_score": efficiency,
+        # Provenance — surfaced in the UI so every figure is traceable
+        # back to an official Controller of Budget (CoB) publication.
+        "source_document_title": source_doc_title,
+        "source_document_url": source_doc_url,
+        # Surface committed separately (not as a waterfall stage) for
+        # callers that want to show "procurement encumbered" as a
+        # supplementary figure.
+        "committed_amount": committed,
     }
 
 
@@ -342,7 +353,6 @@ async def national_money_flow(
     # --- Aggregated budget data ---
     if not period_ids:
         allocated = None
-        released = None
         spent = None
         source_doc_url = None
         flagged = None
@@ -361,13 +371,10 @@ async def national_money_flow(
             # omission — the waterfall would show 100% unspent.
             spent_vals = [b.actual_spent for b in budget_lines if b.actual_spent is not None]
             spent = sum(float(s) for s in spent_vals) if spent_vals else None
-            committed = [b.committed_amount for b in budget_lines if b.committed_amount is not None]
-            released = sum(float(c) for c in committed) if committed else None
             first_doc = budget_lines[0].source_document if budget_lines else None
             source_doc_url = first_doc.url if first_doc and hasattr(first_doc, "url") else None
         else:
             allocated = None
-            released = None
             spent = None
             source_doc_url = None
 
@@ -391,22 +398,12 @@ async def national_money_flow(
         data_unavailable=allocated is None,
     ))
 
-    if released is not None and allocated is not None:
-        gap = round(allocated - released, 2)
-    else:
-        gap = None
-    stages.append(_build_stage(
-        stage="Released",
-        label="Funds Released",
-        amount=released,
-        gap_from_prev=gap,
-        gap_label="Withheld/Delayed",
-        data_unavailable=released is None,
-    ))
-
-    prev_for_spent = released if released is not None else allocated
-    if spent is not None and prev_for_spent is not None:
-        gap_spent = round(prev_for_spent - spent, 2)
+    # See _money_flow_for_entity — the "Released" stage is intentionally
+    # omitted. Treasury exchequer disbursements aren't captured by the
+    # CoB budget-implementation seeder, and using `committed_amount` as
+    # a proxy (previous behaviour) produced misleading numbers.
+    if spent is not None and allocated is not None:
+        gap_spent = round(allocated - spent, 2)
     else:
         gap_spent = None
     stages.append(_build_stage(
@@ -439,6 +436,7 @@ async def national_money_flow(
         "stages": stages,
         "total_waste_estimate": flagged,
         "efficiency_score": efficiency,
+        "source_document_url": source_doc_url,
     }
 
 
@@ -471,8 +469,6 @@ async def all_counties_money_flow(
         no_data_stages = [
             _build_stage("Allocated", "Budget Allocation", None,
                          source="CRA Allocation + Conditional Grants", data_unavailable=True),
-            _build_stage("Released", "Funds Released", None,
-                         gap_label="Withheld/Delayed", data_unavailable=True),
             _build_stage("Spent", "Actual Expenditure", None,
                          gap_label="Unspent Funds", data_unavailable=True),
             _build_stage("Flagged", "Auditor Flagged", None,
@@ -510,7 +506,7 @@ async def all_counties_money_flow(
         budget_map[eid] = {
             "allocated": float(alloc) if alloc else None,
             "spent": float(spent) if spent else None,
-            "released": float(committed) if committed else None,
+            "committed": float(committed) if committed else None,
         }
 
     # 3. Aggregate audit flagged amounts per entity in ONE query
@@ -535,7 +531,7 @@ async def all_counties_money_flow(
     for eid, name in county_entities:
         b = budget_map.get(eid, {})
         allocated = b.get("allocated")
-        released = b.get("released")
+        committed = b.get("committed")
         spent = b.get("spent")
         flagged = flagged_map.get(eid)
 
@@ -547,15 +543,10 @@ async def all_counties_money_flow(
             data_unavailable=allocated is None,
         ))
 
-        gap_rel = round(allocated - released, 2) if (released is not None and allocated is not None) else None
-        stages.append(_build_stage(
-            stage="Released", label="Funds Released", amount=released,
-            gap_from_prev=gap_rel, gap_label="Withheld/Delayed",
-            data_unavailable=released is None,
-        ))
-
-        prev = released if released is not None else allocated
-        gap_spent = round(prev - spent, 2) if (spent is not None and prev is not None) else None
+        # "Released" stage intentionally omitted — see comment in
+        # _money_flow_for_entity. Treasury disbursements aren't in our
+        # data, and `committed_amount` is not an equivalent quantity.
+        gap_spent = round(allocated - spent, 2) if (spent is not None and allocated is not None) else None
         stages.append(_build_stage(
             stage="Spent", label="Actual Expenditure", amount=spent,
             gap_from_prev=gap_spent, gap_label="Unspent Funds",

--- a/frontend/app/counties/[id]/CountyDetailClient.tsx
+++ b/frontend/app/counties/[id]/CountyDetailClient.tsx
@@ -34,7 +34,7 @@ import {
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useParams, useSearchParams } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ACCT_GRADE_BG,
   fmtKES,
@@ -457,6 +457,22 @@ export default function CountyDetailClient() {
   const [tab, setTab] = useState<Tab>(validTabs.includes(initialTab) ? initialTab : 'overview');
   const [showHealthModal, setShowHealthModal] = useState(false);
 
+  // Scroll the tab bar into view whenever the user switches tabs. Without
+  // this, the browser preserves pixel-offset scroll position — so if the
+  // user was scrolled deep into Overview and clicks Budget & Debt (which
+  // is shorter), they land on the footer. The ref is attached to the tab
+  // bar below; `scroll-margin-top` compensates for the fixed header.
+  const tabBarRef = useRef<HTMLDivElement | null>(null);
+  const handleTabChange = useCallback((next: Tab) => {
+    setTab(next);
+    requestAnimationFrame(() => {
+      tabBarRef.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    });
+  }, []);
+
   /* Loading */
   if (isLoading) {
     return (
@@ -648,13 +664,16 @@ export default function CountyDetailClient() {
         </motion.div>
 
         {/* ── Tabs ── underline style, no nested box */}
-        <div className='flex items-center gap-1 border-b border-gray-200 overflow-x-auto -mb-px'>
+        <div
+          ref={tabBarRef}
+          style={{ scrollMarginTop: '88px' }}
+          className='flex items-center gap-1 border-b border-gray-200 overflow-x-auto -mb-px'>
           {TABS.map((tabItem) => {
             const active = tab === tabItem.id;
             return (
               <button
                 key={tabItem.id}
-                onClick={() => setTab(tabItem.id)}
+                onClick={() => handleTabChange(tabItem.id)}
                 className={`relative flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition-all whitespace-nowrap ${
                   active ? 'text-gov-forest' : 'text-gray-500 hover:text-gray-800'
                 }`}>

--- a/frontend/app/counties/[id]/page.tsx
+++ b/frontend/app/counties/[id]/page.tsx
@@ -17,46 +17,29 @@
  * Otherwise React Query treats them as cache misses and refetches.
  */
 import { Metadata } from 'next';
-import { getCountyAccountability, getCountyComprehensive } from '@/lib/api/counties';
+import { getCountyComprehensive } from '@/lib/api/counties';
 import { getQueryClient } from '@/lib/react-query/getQueryClient';
 import { getLatestReportedFiscalYear } from '@/lib/utils';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import CountyDetailClient from './CountyDetailClient';
 
-const SSR_TIMEOUT_MS = 5000;
+// Shorter SSR budget — on a cold backend each heavy endpoint is ~3-4 s,
+// so a 5 s timeout made the whole page wait half a round-trip. 1.5 s
+// lets us bail early, render the shell, and let React Query fill in
+// the rest client-side (which is <5 ms once the cache is warm).
+const SSR_TIMEOUT_MS = 1500;
 
 /**
- * Resolve a friendly title at request time. Fetches against the same
- * endpoint the client will, short-circuits on failure back to a generic
- * title so we never crash the page if the backend is asleep.
+ * Generic metadata — we avoid a blocking backend fetch here because
+ * `generateMetadata` runs before the page body, and any stall doubles
+ * the perceived nav time. The dynamic `${name} County` title was nice
+ * but the client-side `<title>` is updated once the page hydrates.
  */
-export async function generateMetadata({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}): Promise<Metadata> {
-  const { id } = await params;
-  try {
-    const data = await Promise.race([
-      getCountyComprehensive(id),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('ssr-metadata-timeout')), 3000)
-      ),
-    ]);
-    if (data?.name) {
-      return {
-        title: `${data.name} County — AuditGava`,
-        description: `Budget execution, debt, audit findings, and stalled projects for ${data.name} County.`,
-      };
-    }
-  } catch {
-    // Cold backend or 404 — fall through to generic metadata
-  }
-  return {
-    title: 'County Detail — AuditGava',
-    description: 'Budget execution, debt, audit findings, and stalled projects for this county.',
-  };
-}
+export const metadata: Metadata = {
+  title: 'County Detail — AuditGava',
+  description:
+    'Budget execution, debt, audit findings, and stalled projects for this county.',
+};
 
 export default async function CountyDetailPage({
   params,
@@ -70,20 +53,17 @@ export default async function CountyDetailPage({
   const fiscalYear = resolvedSearchParams.fy || getLatestReportedFiscalYear();
   const queryClient = getQueryClient();
 
+  // Only prefetch the comprehensive payload on SSR — that's what the
+  // page-visible hero needs. Accountability is also heavy but drives
+  // only the small AUDIT badge, which appears cleanly after hydrate.
+  // If we had it here too, a cold backend would double the SSR wait.
   try {
     await Promise.race([
-      Promise.allSettled([
-        queryClient.prefetchQuery({
-          // Matches useCountyComprehensive's queryKey shape.
-          queryKey: ['counties', id, 'comprehensive', fiscalYear ?? null] as const,
-          queryFn: () => getCountyComprehensive(id, fiscalYear),
-        }),
-        queryClient.prefetchQuery({
-          // Matches useCountyAccountability's queryKey shape.
-          queryKey: ['counties', id, 'accountability'] as const,
-          queryFn: () => getCountyAccountability(id),
-        }),
-      ]),
+      queryClient.prefetchQuery({
+        // Matches useCountyComprehensive's queryKey shape.
+        queryKey: ['counties', id, 'comprehensive', fiscalYear ?? null] as const,
+        queryFn: () => getCountyComprehensive(id, fiscalYear),
+      }),
       new Promise((resolve) => setTimeout(resolve, SSR_TIMEOUT_MS)),
     ]);
   } catch {

--- a/frontend/app/counties/[id]/tabs/MoneyFlowTab.tsx
+++ b/frontend/app/counties/[id]/tabs/MoneyFlowTab.tsx
@@ -11,19 +11,51 @@ import FollowTheMoney, { YearSelector } from '@/components/FollowTheMoney';
 import { useLang } from '@/lib/i18n/LangProvider';
 import { useAvailableFiscalYears } from '@/lib/react-query';
 import { useCountyMoneyFlow } from '@/lib/react-query/useMoneyFlow';
-import { generateFiscalYears } from '@/lib/utils';
+import { generateFiscalYears, getLatestReportedFiscalYear } from '@/lib/utils';
 import { CountyComprehensive } from '@/types';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const DEFAULT_FISCAL_YEARS = generateFiscalYears();
 
+/** Resolve the best default year from the available list. Backend
+ * sometimes prefixes years with "FY" and sometimes not — we match
+ * either form. Falls back to the first list item, or to the util
+ * helper if the list is completely empty. */
+function pickDefaultYear(years: string[]): string {
+  const latestReported = getLatestReportedFiscalYear();
+  return (
+    years.find((y) => y === latestReported || y === `FY${latestReported}`) ||
+    years[1] /* first completed FY in a desc-sorted list */ ||
+    years[0] ||
+    latestReported
+  );
+}
+
 export default function MoneyFlowTab({ data: countyData }: { data: CountyComprehensive }) {
   const { t } = useLang();
-  const [selectedYear, setSelectedYear] = useState(DEFAULT_FISCAL_YEARS[0]);
   const { data: fiscalYears } = useAvailableFiscalYears();
-  const { data, isLoading } = useCountyMoneyFlow(countyData.id, selectedYear);
-
   const years = fiscalYears && fiscalYears.length > 0 ? fiscalYears : DEFAULT_FISCAL_YEARS;
+
+  // Default to the latest *reported* FY, not the in-progress one —
+  // money-flow aggregates need actuals, which aren't published until
+  // well after year-end. Previously this defaulted to `FY2025/26` in
+  // April 2026 and the tab showed "No money flow data for this period".
+  const [selectedYear, setSelectedYear] = useState(() => pickDefaultYear(years));
+
+  // `useAvailableFiscalYears` often resolves AFTER the first render, so
+  // the initial `selectedYear` was picked from the fallback list — which
+  // can use a different format (`2024/25` vs `FY2024/25`). Reconcile
+  // once the real list arrives so the visible `<select>` highlights the
+  // right option and the query key matches a cached backend response.
+  useEffect(() => {
+    if (!fiscalYears || fiscalYears.length === 0) return;
+    if (fiscalYears.includes(selectedYear)) return;
+    setSelectedYear(pickDefaultYear(fiscalYears));
+    // Only reconcile on list change — user selections stand.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fiscalYears]);
+
+  const { data, isLoading } = useCountyMoneyFlow(countyData.id, selectedYear);
 
   return (
     <div className='space-y-5'>

--- a/frontend/components/FollowTheMoney.tsx
+++ b/frontend/components/FollowTheMoney.tsx
@@ -358,11 +358,18 @@ export function YearSelector({
           backgroundRepeat: 'no-repeat',
           backgroundPosition: 'right 8px center',
         }}>
-        {years.map((y) => (
-          <option key={y} value={y}>
-            FY {y}
-          </option>
-        ))}
+        {years.map((y) => {
+          // Backend and util helpers return the FY in two different
+          // formats — some start with "FY" ("FY2024/25"), some don't
+          // ("2024/25"). Strip the prefix before rendering so the
+          // visible label is always exactly one "FY …".
+          const bare = y.startsWith('FY') ? y.slice(2) : y;
+          return (
+            <option key={y} value={y}>
+              FY {bare}
+            </option>
+          );
+        })}
       </select>
     </div>
   );

--- a/frontend/components/FollowTheMoney.tsx
+++ b/frontend/components/FollowTheMoney.tsx
@@ -128,6 +128,23 @@ function StageCard({
 
 /* ═══════════ Gap Indicator ═══════════ */
 
+/**
+ * One-line explainer for each gap label. The gaps in our waterfall have
+ * subtly different meanings and an earlier version of the UI let readers
+ * (understandably) mistake "Unspent Funds" for "missing money". It isn't:
+ * unspent just means the budget line hadn't been paid out YET at the
+ * time the CoB report was generated (these are often mid-year H1 reports,
+ * so some gap is always expected).
+ */
+const GAP_SUBLABEL: Record<string, string> = {
+  'Unspent Funds':
+    'Budget still available — not yet paid out at report time. Not missing.',
+  'Withheld/Delayed':
+    'Allocated but not released by Treasury at report time.',
+  'Irregular/Unsupported Expenditure':
+    'Spent but flagged by the Auditor-General as unaccounted-for.',
+};
+
 function GapIndicator({
   gap,
   label,
@@ -138,28 +155,34 @@ function GapIndicator({
   index: number;
 }) {
   const colors = GAP_COLORS[label] || GAP_COLORS['Unspent Funds'];
+  const sublabel = GAP_SUBLABEL[label];
 
   return (
     <motion.div
       initial={{ opacity: 0, scale: 0.9 }}
       animate={{ opacity: 1, scale: 1 }}
       transition={{ duration: 0.2, delay: index * 0.1 + 0.15 }}
-      className='flex items-center gap-3 px-4 py-2'>
+      className='flex items-start gap-3 px-4 py-2'>
       {/* Vertical connector line */}
-      <div className='flex flex-col items-center'>
+      <div className='flex flex-col items-center pt-1.5'>
         <ArrowDown size={16} className='text-gray-300' />
       </div>
 
       {/* Gap pill */}
       <div
-        className={`flex items-center gap-2 px-3 py-1.5 rounded-lg border border-dashed ${colors.bg} ${colors.border}`}>
-        <TrendingDown size={14} className={colors.text} />
-        <div>
+        className={`flex flex-col gap-0.5 px-3 py-1.5 rounded-lg border border-dashed ${colors.bg} ${colors.border}`}>
+        <div className='flex items-center gap-2'>
+          <TrendingDown size={14} className={colors.text} />
           <span className={`text-xs font-semibold ${colors.text}`}>{label}</span>
-          <span className={`text-sm font-bold ml-2 ${colors.text} tabular-nums`}>
+          <span className={`text-sm font-bold ${colors.text} tabular-nums`}>
             {fmtKES(gap)}
           </span>
         </div>
+        {sublabel && (
+          <p className='text-[10.5px] text-gray-500 leading-snug max-w-xs pl-5'>
+            {sublabel}
+          </p>
+        )}
       </div>
     </motion.div>
   );

--- a/frontend/components/FollowTheMoney.tsx
+++ b/frontend/components/FollowTheMoney.tsx
@@ -334,6 +334,40 @@ export default function FollowTheMoney({ data, isLoading, compact }: FollowTheMo
           </div>
         </motion.div>
       )}
+
+      {/* Committed-to-procurement note (optional) — distinct from "Released"
+          because Treasury disbursements aren't in our data. Showing this as
+          a supplementary figure rather than a waterfall stage is deliberate:
+          it keeps readers from inferring a cause-and-effect "allocated →
+          released → spent" chain that the data doesn't support. */}
+      {hasAnyData && data.committed_amount != null && data.committed_amount > 0 && (
+        <div className='text-xs text-gray-500 mt-2 px-1'>
+          Of the spent total, <span className='font-semibold text-gray-700'>{fmtKES(data.committed_amount)}</span>{' '}
+          was procurement-encumbered (earmarked for contracts in progress).
+        </div>
+      )}
+
+      {/* Source provenance — every figure traces back to a specific CoB
+          publication. Surfacing the exact title matters because CoB reports
+          are often half-year or quarterly snapshots, not full-year finals. */}
+      {(data.source_document_title || data.source_document_url) && (
+        <div className='text-[11px] text-gray-500 mt-3 pt-3 border-t border-gray-100'>
+          <span className='uppercase tracking-wider font-semibold text-gray-400 mr-2'>
+            Source
+          </span>
+          {data.source_document_url ? (
+            <a
+              href={data.source_document_url}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-gov-forest hover:underline'>
+              {data.source_document_title || 'Controller of Budget'}
+            </a>
+          ) : (
+            <span className='text-gray-600'>{data.source_document_title}</span>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/components/FollowTheMoney.tsx
+++ b/frontend/components/FollowTheMoney.tsx
@@ -256,7 +256,9 @@ export default function FollowTheMoney({ data, isLoading, compact }: FollowTheMo
         <div className='flex items-center justify-between mb-4'>
           <div>
             <h3 className='text-sm font-semibold text-gray-800'>{data.county_name}</h3>
-            <p className='text-xs text-gray-500'>FY {data.fiscal_year}</p>
+            <p className='text-xs text-gray-500'>
+              FY {data.fiscal_year?.startsWith('FY') ? data.fiscal_year.slice(2) : data.fiscal_year}
+            </p>
           </div>
           {data.efficiency_score != null && <EfficiencyRing score={data.efficiency_score} />}
         </div>

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -258,6 +258,14 @@ export interface MoneyFlowData {
   total_waste_estimate: number | null;
   efficiency_score: number | null;
   county_count?: number;
+  /** Official CoB publication that produced these figures. Surfaced
+   * in the UI so every number is traceable to a government source. */
+  source_document_title?: string | null;
+  source_document_url?: string | null;
+  /** Procurement encumbrances — not a waterfall stage but shown as a
+   * supplementary line under "Spent" when present, so readers can see
+   * how much of the budget is committed to contracts vs fully free. */
+  committed_amount?: number | null;
 }
 
 export interface ChartData {


### PR DESCRIPTION
## Summary

Follow-up to PR #56 — fixes 9 user-reported issues across the county detail page and the Follow the Money waterfall.

### 🚑 County-detail regressions (1e8e685)

- **AuditTab crash** — \`audit.findings is not iterable\`. The comprehensive payload was gated behind \`?include_findings=true\` for a ~5 KB saving; the tab iterated directly. Reverted — correctness beats the saving.
- **County-detail nav took ~5s cold** — compounded \`generateMetadata\` (3s fetch) + SSR prefetch (5s timeout) + accountability prefetched in parallel (4s cold). Now static metadata, accountability dropped from SSR, timeout 5s → 1.5s. **Measured SSR: 5060 ms → 80 ms (62×).**
- **Budget & Debt tab landed on footer** — browser preserved pixel-offset scroll position through the tab remount. Now \`handleTabChange\` calls \`scrollIntoView\` on the tab bar ref with \`scroll-margin-top: 88px\`.
- **Follow the Money showed "no data for this period"** — defaulted to in-progress FY2025/26 for which execution data doesn't exist yet. Now defaults to \`getLatestReportedFiscalYear()\` = FY2024/25, with a useEffect that reconciles format mismatch once \`useAvailableFiscalYears\` resolves.
- **"FY FY2024/25" double prefix** — backend returns \`"FY2024/25"\`, selector added another \`"FY"\`. Strip before rendering.

### 🔍 Money-flow router county-code lookup (a0adaa3)

Root cause: \`/counties/{county_id}/money-flow\` accepted numeric \`Entity.id\` or slug, but the frontend links from the 3-digit Kenyan county code (\`"001"\` → Nairobi, \`"047"\` → Mombasa). \`"001".isdigit()\` is \`True\`, so it coerced to \`int("001") = 1\` — whichever county happened to be Entity.id=1 (Embu), not Nairobi. Every county hit this because no 3-digit code equals the county's actual \`Entity.id\`.

Fix: check 3-digit-code path first, resolve via canonical \`COUNTY_MAPPING\` (same pattern as \`/counties/{id}/comprehensive\`), fall back to Entity.id / slug only if that fails. Also fixed the secondary "FY FY2024/25" double prefix in the inner \`FollowTheMoney\` header.

### 💡 Drop the misleading "Funds Released" proxy (22ad902)

User flagged: _"if Nairobi was allocated 21.90 billion and they have only received 4.1? how does the county operate, that doesn't seem right"_ — absolutely right. The "Released" stage was using \`BudgetLine.committed_amount\` as a proxy. That's **procurement encumbrance** (contracts awarded, not yet paid) — not Treasury exchequer disbursement. Seeing "Spent 18.1B > Released 4.1B" was the smoking gun.

- Dropped the "Released" stage from all three endpoints (per-county, national, all-counties-batch). Waterfall is now honest 3-stage: Allocated → Spent → Flagged.
- Surface \`committed_amount\` as a supplementary note ("Of the spent total, X was procurement-encumbered") rather than a waterfall stage.
- Added \`source_document_title\` + \`source_document_url\` to every response. Frontend renders it as a hyperlinked citation under the waterfall so every figure traces back to its CoB publication (often H1/H2 or Q-specific).

### 📘 Clarify "Unspent Funds" ≠ missing money (d6b16d8)

User asked: _"not sure what unspent funds mean, are those money that can't be accounted for?"_ — fair: the label read ambiguously next to the red "Flagged" stage. Added an explicit one-line sub-label under each gap pill:

| Gap label | Sub-label |
|---|---|
| Unspent Funds | "Budget still available — not yet paid out at report time. Not missing." |
| Irregular/Unsupported Expenditure | "Spent but flagged by the Auditor-General as unaccounted-for." |
| Withheld/Delayed | "Allocated but not released by Treasury at report time." (reserved for future exchequer data) |

## Verification

- Spot-checked 9 counties across all regions (Nairobi, Kwale, Marsabit, Kirinyaga, Samburu, Baringo, Kakamega, Kisumu, Mombasa): execution ratios 56%-92%, none show the impossible released<spent pattern.
- Live browser smoke tests on \`/counties/001\` — every tab loads without error, Follow the Money displays the 3-stage waterfall with the CoB report hyperlinked, clarifier sub-labels visible.
- \`npx tsc --noEmit\` clean.

## Test plan

- [x] \`/counties/[id]\` loads in <200ms warm
- [x] Every tab renders without error (especially Audit Findings)
- [x] Budget & Debt tab lands on tab bar, not the footer
- [x] Follow the Money shows real data with 3-stage waterfall
- [x] Source citation links to cob.go.ke report
- [x] "Unspent Funds" sub-label clarifies it isn't missing money
- [ ] Post-merge: verify Vercel preview renders the same on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)