### PR TITLE
fix(seeder): imf_weo writer must not manage its own transaction

### DIFF
--- a/backend/seeding/domains/imf_weo/writer.py
+++ b/backend/seeding/domains/imf_weo/writer.py
@@ -45,6 +45,15 @@ def persist_imf_weo(
     The unique constraint on (country, indicator, year, vintage) means
     re-runs within the same vintage are no-ops. Skipped counts reflect
     rows that already existed.
+
+    **Transaction management is the CLI's job, not ours.** Do NOT call
+    ``session.commit()`` or ``session.rollback()`` here — the outer
+    ``seeding/cli.py`` wraps this handler in a single transaction that
+    also writes the ``ingestion_jobs`` tracking row. If we commit early
+    the CLI's tracking update writes to a new txn; if we rollback on
+    error we take the IngestionJob row down with us, leaving the run
+    invisible in the admin dashboard. Let exceptions propagate so the
+    CLI can handle them consistently with every other domain.
     """
     stats = WriteStats()
     stats.processed = len(records)
@@ -57,30 +66,23 @@ def persist_imf_weo(
         logger.info("[dry-run] would upsert %d IMF WEO rows", len(records))
         return stats
 
-    try:
-        stmt = (
-            insert(ImfWeoObservation)
-            .values(records)
-            .on_conflict_do_nothing(
-                index_elements=[
-                    "country_code",
-                    "indicator",
-                    "year",
-                    "vintage",
-                ]
-            )
+    stmt = (
+        insert(ImfWeoObservation)
+        .values(records)
+        .on_conflict_do_nothing(
+            index_elements=[
+                "country_code",
+                "indicator",
+                "year",
+                "vintage",
+            ]
         )
-        result = session.execute(stmt)
-        session.commit()
-        # `rowcount` returns inserts; anything not inserted was a conflict.
-        inserted = result.rowcount or 0
-        stats.created = inserted
-        stats.skipped = len(records) - inserted
-    except Exception as exc:  # pragma: no cover
-        session.rollback()
-        logger.exception("Failed to persist IMF WEO rows")
-        stats.errors.append(str(exc))
-
+    )
+    result = session.execute(stmt)
+    # `rowcount` returns inserts; anything not inserted was a conflict.
+    inserted = result.rowcount or 0
+    stats.created = inserted
+    stats.skipped = len(records) - inserted
     return stats
 
 


### PR DESCRIPTION
## Symptom

After merging PR #61 and running the seeding workflow against `main`, the ingestion pipeline reported success ("All domains completed successfully.") — but:

- `/api/v1/debt/broader` still returns `{"status": "unavailable", "reason": "not_seeded_yet"}`
- No rows in `imf_weo_observations`
- No `IngestionJob` row for the `imf_weo` domain — the run-summary loop printed zero job entries despite running

Both the IMF data AND the tracking row are missing, which is impossible under normal error flows.

## Root cause

My writer was calling `session.commit()` on success and `session.rollback()` on error:

```python
try:
    result = session.execute(stmt)
    session.commit()   # ← premature
    ...
except Exception as exc:
    session.rollback()  # ← also premature
    stats.errors.append(str(exc))
```

But `backend/seeding/cli.py` already manages each domain's transaction centrally. The flow is:

1. CLI inserts an `IngestionJob` row (session.add + flush) — **not yet committed**
2. CLI calls `handler()` (my `run()`)
3. My writer does its thing, then commits internally OR rolls back on error
4. CLI updates the IngestionJob with results, then commits/rolls back

On a Postgres-side insert error (bulk-insert type mismatch, I suspect), my writer's `session.rollback()` **rolls back the in-progress IngestionJob INSERT** that was pending in the same transaction. The CLI's final commit then has nothing left to persist. **Silent data loss.**

No other writer in the codebase (`audits`, `population`, `debt_timeline`, `counties_budget`, `national_debt`, `fiscal_summary`, ...) calls commit/rollback. They all just add objects and let the CLI manage the transaction.

## Fix

Remove the `session.commit()` / `session.rollback()` from the writer. If the insert fails, the exception propagates up to the CLI's existing handler — which records the error on the `IngestionJob`, rolls back cleanly, and makes the failure **visible** in the run summary and admin dashboard.

Added a prominent docstring block warning future editors not to re-introduce the commit. Matches the pattern every other writer already follows.

## Expected outcome after merge + re-run

One of two things:

1. **✅ Green**: insert succeeds with the transaction intact. `/api/v1/debt/broader` returns real data within a few minutes of the re-run.
2. **🟡 Visible failure**: if the bulk insert still has a Postgres-specific issue (my original hypothesis), the error now propagates cleanly. The `[FAIL] imf_weo` line in the run summary will pinpoint exactly what's wrong, rather than silently swallowing it.

Either outcome is actionable — the current silent-success state is the worst possible.

## Test plan

- [ ] Merge this PR
- [ ] Trigger "Database Seeding & Data Refresh" workflow with `Domain: imf_weo`
- [ ] Check the run-summary section — expect `[OK] imf_weo: completed | created=52 updated=0 processed=52` (4 indicators × 13 years)
- [ ] `curl https://auditgava.com/api/v1/debt/broader | jq '.latest'` — expect non-null values
- [ ] Visit `/debt` — the new dual-card section appears under the reconciliation section
- [ ] Visit `/` — the IMF one-liner callout appears in the debt card

🤖 Generated with [Claude Code](https://claude.com/claude-code)