### PR TITLE
fix(seeder): drop IMF regional aggregates + widen country_code

### DIFF
--- a/backend/alembic/versions/f6a7b8c9d0e1_widen_imf_country_code.py
+++ b/backend/alembic/versions/f6a7b8c9d0e1_widen_imf_country_code.py
@@ -1,0 +1,50 @@
+"""widen_imf_country_code
+
+Widens ``imf_weo_observations.country_code`` from VARCHAR(3) to VARCHAR(16).
+
+IMF's DataMapper REST API ignores the country filter in the URL and
+returns the ENTIRE dataset — all ISO3 countries plus regional aggregate
+codes like WEOWORLD (8 chars), ADVEC (5), EURO (4), EU (2). The parser
+now filters those out, but the column was VARCHAR(3) and the seeder
+crashed with ``StringDataRightTruncation`` on the first non-3-char code
+before the filter fix landed.
+
+Widening the column to VARCHAR(16) is defense-in-depth: if a parser
+regression ever reintroduces aggregates, we get garbage rows rather
+than a crashed seeding job.
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-04-22
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "f6a7b8c9d0e1"
+down_revision = "e5f6a7b8c9d0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "imf_weo_observations",
+        "country_code",
+        existing_type=sa.String(length=3),
+        type_=sa.String(length=16),
+        existing_nullable=False,
+    )
+
+
+def downgrade():
+    # Only safe if all existing rows fit in VARCHAR(3); after the parser
+    # filter fix they do (only "KEN"), but a future operator who has
+    # somehow stored longer codes would need to clean up first.
+    op.alter_column(
+        "imf_weo_observations",
+        "country_code",
+        existing_type=sa.String(length=16),
+        type_=sa.String(length=3),
+        existing_nullable=False,
+    )

--- a/backend/models.py
+++ b/backend/models.py
@@ -601,7 +601,11 @@ class ImfWeoObservation(Base):
     )
 
     id = Column(Integer, primary_key=True, index=True)
-    country_code = Column(String(3), nullable=False)  # e.g. "KEN"
+    # ISO3 is 3 chars, but IMF DataMapper also returns regional aggregate
+    # codes (WEOWORLD, ADVEC, EURO, EU) that can reach ~8 chars. We filter
+    # them out in the parser, but widen the column as defense-in-depth so
+    # a parser regression surfaces as garbage data rather than a crash.
+    country_code = Column(String(16), nullable=False)  # e.g. "KEN"
     indicator = Column(String(32), nullable=False)  # e.g. "GGXWDG_NGDP"
     year = Column(Integer, nullable=False)
     # Can be NULL — some years have no IMF value (especially for recently

--- a/backend/seeding/domains/imf_weo/__init__.py
+++ b/backend/seeding/domains/imf_weo/__init__.py
@@ -50,7 +50,13 @@ def run(
                 .model_copy(update={"finished_at": datetime.now(timezone.utc)})
             )
 
-    records = parser.parse_imf_weo(payload, vintage=started_at)
+    # Restrict to the countries we actually want in the DB. IMF's
+    # DataMapper returns the global dataset regardless of URL filter,
+    # which would otherwise flood us with ~200 countries and aggregate
+    # codes (some of which exceed VARCHAR(3)).
+    records = parser.parse_imf_weo(
+        payload, vintage=started_at, only_countries=fetcher.COUNTRIES
+    )
     stats = writer.persist_imf_weo(session, records, context)
     errors.extend(stats.errors)
 

--- a/backend/seeding/domains/imf_weo/parser.py
+++ b/backend/seeding/domains/imf_weo/parser.py
@@ -27,17 +27,31 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Optional
 
 logger = logging.getLogger("seeding.imf_weo.parser")
 
 
 def parse_imf_weo(
-    payload: Dict[str, Dict[str, Any]], vintage: datetime
+    payload: Dict[str, Dict[str, Any]],
+    vintage: datetime,
+    only_countries: Optional[Iterable[str]] = None,
 ) -> List[Dict[str, Any]]:
-    """Flatten IMF responses into per-(country, indicator, year) rows."""
+    """Flatten IMF responses into per-(country, indicator, year) rows.
+
+    IMF's DataMapper REST API ignores the country filter in the URL
+    and returns the ENTIRE dataset — all ~190 ISO3 countries plus
+    regional aggregates like ``WEOWORLD`` (8 chars), ``ADVEC`` (5),
+    ``EURO`` (4), ``EU`` (2), etc. We only store the countries listed
+    in ``only_countries`` and silently drop everything else, so the
+    table stays scoped to what the app displays and ``VARCHAR(3)`` is
+    sufficient for ISO3 codes. ``None`` means "store everything".
+    """
     rows: List[Dict[str, Any]] = []
     projection_cutoff = vintage.year
+    allowed: Optional[set[str]] = (
+        {c.upper() for c in only_countries} if only_countries is not None else None
+    )
     for indicator, response in payload.items():
         values = response.get("values", {}).get(indicator, {})
         if not isinstance(values, dict):
@@ -46,6 +60,8 @@ def parse_imf_weo(
             )
             continue
         for country_code, year_vals in values.items():
+            if allowed is not None and country_code.upper() not in allowed:
+                continue
             if not isinstance(year_vals, dict):
                 continue
             for year_str, raw in year_vals.items():

--- a/backend/tests/test_imf_weo_domain.py
+++ b/backend/tests/test_imf_weo_domain.py
@@ -159,6 +159,36 @@ def test_parser_tolerates_missing_values_node():
     assert rows == []
 
 
+def test_parser_filters_out_regional_aggregates():
+    """IMF DataMapper ignores the URL country filter and returns every
+    country plus aggregates like WEOWORLD, ADVEC, EURO. The parser must
+    drop anything not in ``only_countries`` so the DB stays scoped and
+    we never overflow VARCHAR(3/16) with 8-char aggregate codes."""
+    vintage = datetime.now(timezone.utc)
+    payload = {
+        "GGXWDG_NGDP": {
+            "values": {
+                "GGXWDG_NGDP": {
+                    "KEN": {"2024": 67.3},
+                    "USA": {"2024": 122.1},
+                    "WEOWORLD": {"2024": 92.5},  # 8-char aggregate
+                    "ADVEC": {"2024": 110.8},  # 5-char aggregate
+                    "EURO": {"2024": 88.2},  # 4-char aggregate
+                }
+            }
+        }
+    }
+    rows = imf_parser.parse_imf_weo(
+        payload, vintage=vintage, only_countries=("KEN",)
+    )
+    assert len(rows) == 1
+    assert rows[0]["country_code"] == "KEN"
+
+    # None means "store everything" — opt-in filter, not default.
+    rows_all = imf_parser.parse_imf_weo(payload, vintage=vintage)
+    assert len(rows_all) == 5
+
+
 # ── domain integration ───────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- IMF DataMapper ignores the URL country filter and returns ~190 countries plus regional aggregates (`WEOWORLD`=8 chars, `ADVEC`=5, `EURO`=4). That overflowed `imf_weo_observations.country_code VARCHAR(3)` on the first aggregate and crashed the seeding job with `StringDataRightTruncation`.
- Parser now takes `only_countries=("KEN",)` and silently drops everything else. Aggregates never reach the DB.
- Column widened `VARCHAR(3) → VARCHAR(16)` (new alembic migration) as defense-in-depth: a future parser regression would produce garbage rows, not a crashed nightly seeder.
- Test covers both paths — filtered when `only_countries` is set, kept when `None`.

## Test plan
- [ ] CI green (test-backend exercises the new parser test)
- [ ] Re-run the seeding GitHub workflow and confirm `imf_weo` domain produces non-zero rows
- [ ] Spot-check `/api/v1/debt/broader` returns Kenya figures after seeding completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)