### PR TITLE
fix(debt): /debt/broader caching, projection-year, and page hierarchy

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8466,7 +8466,6 @@ IMF_BROADER_USD_KES = float(os.environ.get("IMF_BROADER_USD_KES", "130"))
 
 
 @app.get("/api/v1/debt/broader")
-@cached(key_prefix="debt:broader", ttl=86400)  # IMF WEO updates twice a year
 async def get_debt_broader(db: Session = Depends(get_db)):
     """IMF's General-Government Gross Debt for Kenya.
 
@@ -8482,6 +8481,11 @@ async def get_debt_broader(db: Session = Depends(get_db)):
     ``IMF_BROADER_USD_KES``. The last-fetched vintage is included so
     the frontend can mark the value "stale" when the seeder has not
     run recently.
+
+    **Caching**: the "unavailable" branch is NOT cached, so the first
+    hit after the seeder finishes will see fresh data without waiting
+    for a TTL to expire. Successful payloads are cached 24h since IMF
+    WEO only publishes twice a year.
     """
     if not DATABASE_AVAILABLE:
         return {"status": "unavailable", "reason": "database_not_configured"}
@@ -8500,7 +8504,21 @@ async def get_debt_broader(db: Session = Depends(get_db)):
     )
     if latest_vintage_subq is None:
         # Seeder has never populated the table. Frontend hides the card.
+        # Do NOT cache — otherwise the first seeder run leaves users
+        # stuck with "unavailable" for up to 24h.
         return {"status": "unavailable", "reason": "not_seeded_yet"}
+    # Pass vintage as kwarg so @cached bakes it into the key —
+    # a new vintage invalidates the cache automatically.
+    return await _get_debt_broader_cached(
+        db=db, vintage=latest_vintage_subq.isoformat()
+    )
+
+
+@cached(key_prefix="debt:broader", ttl=86400)  # IMF WEO updates twice a year
+async def _get_debt_broader_cached(db: Session, vintage: str):
+    from models import ImfWeoObservation  # local — avoids circular import
+
+    latest_vintage_subq = datetime.datetime.fromisoformat(vintage)
 
     rows = (
         db.query(ImfWeoObservation)

--- a/backend/main.py
+++ b/backend/main.py
@@ -8564,10 +8564,17 @@ async def _get_debt_broader_cached(db: Session, vintage: str):
             }
         )
 
-    # "Latest" = most recent year that has BOTH debt% and GDP, so the
-    # frontend always has a complete tuple to render.
+    # "Latest" = most recent ACTUAL (non-projection) year that has both
+    # debt% and GDP. The timeseries includes IMF forecasts out to 2030;
+    # picking the furthest year would show a 5-6 year projection as the
+    # "current" figure, which overstates debt (debt and USD GDP both
+    # grow over time) and confuses readers comparing against CBK's
+    # "as-of-today" total. Fall back to the latest projection only when
+    # no non-projection rows exist (i.e. a very old vintage or brand-new
+    # country with only forecasts available).
     complete = [t for t in timeseries if t["value_kes"] is not None]
-    latest = complete[-1] if complete else None
+    actuals = [t for t in complete if not t.get("is_projection")]
+    latest = (actuals or complete)[-1] if complete else None
 
     # Stale = vintage > 60 days old. IMF WEO publishes twice a year
     # (April/October) — 60 days after either release is a reasonable

--- a/frontend/app/debt/DebtPageClient.tsx
+++ b/frontend/app/debt/DebtPageClient.tsx
@@ -695,26 +695,54 @@ export default function NationalDebtPage() {
             • 11.85T — sum of every line item in CBK's Public Debt Bulletin
               (live-fetched, used as the headline everywhere on this site)
             • 12.5T — CBK/Treasury's published annual aggregate stock
-          They disagree by ~5% because of consolidation adjustments. Rather
-          than pick silently and confuse users who spot both numbers in the
-          press, we show both with their provenance and explain the gap. */}
-      {d.reconciliation && (
-        <DebtSourceReconciliation
-          reconciliation={d.reconciliation}
-          lastUpdated={d.lastUpdated}
-        />
-      )}
+          They disagree by ~5% because of consolidation adjustments.
 
-      {/* ═══════════ SECTION 1C — BROADER (IMF) MEASURE ═══════════
-          Placed right after the Treasury reconciliation so the progression
-          is: Treasury's numbers → IMF's broader number → the rest of the
-          debt page. That reading order mirrors "what the government
-          reports → what credit-rating agencies and citizens actually
-          carry → how it's composed". */}
+          Hidden behind a disclosure because it's a methodology-audit story,
+          not a headline one — most readers don't need the provenance dive.
+          The *real* "how big is Kenya's debt?" question is CBK-vs-IMF (next
+          section), so we lead with that and keep this available for anyone
+          who spotted 11.85 vs 12.5 in the press and wants to square them. */}
+
+      {/* ═══════════ SECTION 1B — BROADER (IMF) MEASURE ═══════════
+          Leads the "what does public debt actually mean?" story: Treasury's
+          narrow Central-Government number vs IMF's General-Government
+          measure (adds counties, SOE guarantees, arrears, pending bills).
+          For Kenya the gap is modest — the component's copy acknowledges
+          that rather than overselling it. */}
       <BroaderDebtCard
         cbkTotalKes={d.totalDebt}
         cbkAsOf={d.lastUpdated}
       />
+
+      {/* ═══════════ SECTION 1C — AUDIT TRAIL (collapsed by default) ═══════════
+          Compact disclosure: "How we got to 11.85T" — click to expand the
+          full Sources & Reconciliation card. Uses native <details> so it
+          works without client state and is keyboard-accessible by default. */}
+      {d.reconciliation && d.reconciliation.primary_value_kes != null && (
+        <details className='group rounded-xl border border-neutral-border/40 bg-white/60 overflow-hidden'>
+          <summary className='flex items-center justify-between gap-3 px-5 py-3.5 cursor-pointer list-none hover:bg-neutral-50/50 transition-colors'>
+            <div className='flex items-center gap-2.5 min-w-0'>
+              <span className='text-[10px] uppercase tracking-widest font-semibold text-neutral-muted shrink-0'>
+                Audit trail
+              </span>
+              <span className='text-sm text-gov-dark/85 truncate'>
+                How we got to the headline 11.85T — Treasury reports a
+                slightly different 12.50T; we reconcile the {((d.reconciliation.percent_diff) ?? 0).toFixed(1)}% gap.
+              </span>
+            </div>
+            <ChevronDown
+              size={16}
+              className='text-neutral-muted group-open:rotate-180 transition-transform shrink-0'
+            />
+          </summary>
+          <div className='border-t border-neutral-border/40'>
+            <DebtSourceReconciliation
+              reconciliation={d.reconciliation}
+              lastUpdated={d.lastUpdated}
+            />
+          </div>
+        </details>
+      )}
 
       {/* ═══════════ SECTION 2 — WHO KENYA OWES ═══════════ */}
       <motion.section

--- a/frontend/components/debt/BroaderDebtCard.tsx
+++ b/frontend/components/debt/BroaderDebtCard.tsx
@@ -154,31 +154,44 @@ export default function BroaderDebtCard({ cbkTotalKes, cbkAsOf }: Props) {
         </div>
       </div>
 
-      {/* Accountability explainer */}
+      {/* Accountability explainer. Copy adjusts when the gap is small
+          (< 1T) so we don't oversell a 200–500B delta as a scandal — for
+          Kenya the counties/SOE/arrears overhang turns out to be modest
+          compared to what it is in, say, Brazil or South Africa. */}
       <div className='rounded-xl bg-gov-forest/[0.04] border border-gov-forest/15 p-4 flex gap-3'>
         <Info size={16} className='text-gov-forest mt-0.5 shrink-0' />
         <div className='text-sm text-gov-dark/85 leading-relaxed'>
-          <strong className='text-gov-dark'>What Treasury leaves out.</strong>{' '}
-          The CBK figure is what the National Treasury directly admits to
-          owing — loans on its own balance sheet. The IMF's broader measure
-          is the standard credit-rating agencies and international
-          institutions use, and it captures obligations Treasury leaves off
-          its headline:{' '}
+          <strong className='text-gov-dark'>What each number counts.</strong>{' '}
+          The CBK figure is Central-Government debt — loans Treasury owes
+          directly. IMF's figure is General-Government, the measure
+          credit-rating agencies and IMF Article IV use: it adds{' '}
           <strong>
-            county government debt, state-owned enterprise exposures Treasury
-            has guaranteed, pension arrears, and accumulated pending bills
+            county debt, state-owned enterprise guarantees, pension arrears,
+            and pending bills
           </strong>
           .{' '}
-          {gap != null && gap > 0 && (
+          {gap != null && gap > 0 && gap >= 1e12 ? (
             <>
               The{' '}
               <span className='font-semibold text-gov-dark'>
                 ~{fmtT(gap)} gap
               </span>{' '}
-              is public debt Kenyans will pay for — it's just not on
-              Treasury's preferred scorecard.
+              is public debt Kenyans will pay for — it&apos;s just not on
+              Treasury&apos;s preferred scorecard.
             </>
-          )}
+          ) : gap != null && gap > 0 ? (
+            <>
+              For Kenya the gap is modest — about{' '}
+              <span className='font-semibold text-gov-dark'>
+                {fmtT(gap)}
+              </span>
+              . That&apos;s a good sign: county and SOE exposures off
+              Treasury&apos;s book are smaller here than in many peer
+              economies. The number to watch is whether the gap
+              <em> widens</em> over time as pending bills and guarantees
+              accumulate.
+            </>
+          ) : null}
         </div>
       </div>
     </motion.section>

--- a/frontend/components/debt/DebtSourceReconciliation.tsx
+++ b/frontend/components/debt/DebtSourceReconciliation.tsx
@@ -205,11 +205,13 @@ export default function DebtSourceReconciliation({ reconciliation, lastUpdated }
               headline because it&apos;s tied directly to the CBK bulletin our ETL parses
               daily — so the number you see moves when CBK publishes fresh data.
             </p>
-            {reconciliation.note && (
-              <p className='text-[11px] text-neutral-muted/80 italic mt-2 pl-3 border-l-2 border-gov-gold/30'>
-                Backend reconciliation note: {reconciliation.note}
-              </p>
-            )}
+            {/* The backend may attach a `note` string describing the
+                reconciliation state (divergent / consistent / which table
+                won), but it's phrased for developers — it references
+                internal table names like `DebtTimeline` and `loans_table`.
+                Keep it out of the UI; it belongs in logs. The paragraph
+                above already explains the gap in plain language, and the
+                percent-diff chip signals severity. */}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Three fixes to the IMF broader-debt feature shipped earlier this week:

1. **Caching** ([ca6ca4c](https://github.com/Rodgers31/audit_app/commit/ca6ca4c)) — `GET /api/v1/debt/broader` used `@cached(ttl=86400)` on the whole function, which baked a pre-seeding \`{\"status\":\"unavailable\"}\` response into a 24h cache. Split the endpoint so the unavailable branch is uncached; vintage is part of the cache key so new WEO releases also auto-invalidate.
2. **Latest year** ([18d2e2c](https://github.com/Rodgers31/audit_app/commit/18d2e2c)) — `latest = complete[-1]` was picking IMF's 2031 projection, producing 19.14T at 75.1% GDP. Now prefers the most recent actual (`is_projection == false`) year, falling back to projection only when no actuals exist.
3. **Page hierarchy** ([47cbff0](https://github.com/Rodgers31/audit_app/commit/47cbff0)) — `/debt` was showing three near-identical totals (11.85T CBK live, 12.50T Treasury aggregate, 12.29T IMF) with the CBK number repeating. Promoted CBK-vs-IMF to the headline story, moved CBK-live-vs-Treasury-aggregate reconciliation behind a collapsed "Audit trail" disclosure, rewrote the accountability copy to be honest when the gap is modest, and dropped a dev-facing \"Backend reconciliation note:\" leak.

## Test plan
- [ ] Merge + Render redeploy — `curl /api/v1/debt/broader` returns `status: success` with `latest.year == 2025`, `debt_to_gdp ~= 69.3`, `value_kes ~= 12.29e12`.
- [ ] [auditgava.com/debt](https://auditgava.com/debt): IMF card shows ~KES 12.29T (69.3% GDP) — not 19T; audit-trail disclosure collapsed by default.
- [ ] Homepage: \"IMF broader measure\" one-liner shows ~12.29T at 69.3%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)