### PR TITLE
feat(map,county,learn): polish map tooltip, detail-page return flow, learn copy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,14 @@ on:
 
 permissions:
   contents: read
+  # Trivy's upload-sarif step uploads results here.
   security-events: write
+  # upload-sarif@v4 calls the workflow-runs API under the hood to
+  # fingerprint SARIF entries (so re-runs don't create duplicate
+  # alerts). Without actions:read it logs "Resource not accessible by
+  # integration" and the step exits non-zero, which fails the
+  # security-scan job and blocks the quality-gate.
+  actions: read
 
 jobs:
   test-backend:

--- a/frontend/app/counties/[id]/CountyDetailClient.tsx
+++ b/frontend/app/counties/[id]/CountyDetailClient.tsx
@@ -25,9 +25,11 @@ import {
   CircleDollarSign,
   Clock,
   ExternalLink,
+  Grid3x3,
   HardHat,
   Info,
   Landmark,
+  Map as MapIcon,
   ShieldAlert,
   X,
 } from 'lucide-react';
@@ -535,6 +537,13 @@ export default function CountyDetailClient() {
   }[tab];
 
   const fromParam = searchParams.get('from');
+  // from=home-map is set by InteractiveKenyaMap's tooltip CTA. It
+  // means "the user arrived here by clicking a county on the home
+  // dashboard map" — render two explicit shortcuts (back to that
+  // map, or jump to the all-counties explorer) instead of the single
+  // SmartBackLink. Other from= values keep the existing single-link
+  // behaviour.
+  const fromHomeMap = fromParam === 'home-map';
   const topBackHref = fromParam === 'transparency' ? '/transparency' : '/counties';
   const topBackLabel =
     fromParam === 'transparency'
@@ -546,15 +555,36 @@ export default function CountyDetailClient() {
       <PageShell
         title={`${data.name} ${t('county.page.name_suffix')}`}
         subtitle={t('county.page.subtitle')}>
-        {/* Back — uses SmartBackLink so coming from /counties?p=2 pops
-            history (restoring pagination, filters, scroll) instead of
-            pushing a fresh /counties. */}
-        <SmartBackLink
-          href={topBackHref}
-          className='inline-flex items-center gap-1.5 text-sm text-gov-forest hover:text-gov-dark transition-colors'>
-          <ArrowLeft size={14} />
-          {topBackLabel}
-        </SmartBackLink>
+        {/* Back — default flow uses SmartBackLink so coming from
+            /counties?p=2 pops history (restoring pagination, filters,
+            scroll) instead of pushing a fresh /counties. The home-map
+            arrival path is different: we want an explicit "rewind to
+            the exact scroll position of the map" (via /#home-map) AND
+            a separate shortcut to the full list — so we render two
+            dedicated buttons instead. */}
+        {fromHomeMap ? (
+          <div className='flex flex-wrap items-center gap-2'>
+            <Link
+              href='/#home-map'
+              className='inline-flex items-center gap-1.5 rounded-full border border-gov-forest/20 bg-gov-forest/5 px-3 py-1.5 text-sm text-gov-forest hover:bg-gov-forest/10 hover:border-gov-forest/40 transition-colors'>
+              <MapIcon size={14} />
+              {t('county.page.back_to_home_map')}
+            </Link>
+            <Link
+              href='/counties'
+              className='inline-flex items-center gap-1.5 rounded-full border border-neutral-border/60 bg-white px-3 py-1.5 text-sm text-neutral-muted hover:text-gov-dark hover:border-neutral-border transition-colors'>
+              <Grid3x3 size={14} />
+              {t('county.page.all_counties_short')}
+            </Link>
+          </div>
+        ) : (
+          <SmartBackLink
+            href={topBackHref}
+            className='inline-flex items-center gap-1.5 text-sm text-gov-forest hover:text-gov-dark transition-colors'>
+            <ArrowLeft size={14} />
+            {topBackLabel}
+          </SmartBackLink>
+        )}
 
         {/* ── Hero ── */}
         <motion.div

--- a/frontend/app/counties/[id]/CountyDetailClient.tsx
+++ b/frontend/app/counties/[id]/CountyDetailClient.tsx
@@ -29,7 +29,6 @@ import {
   HardHat,
   Info,
   Landmark,
-  Map as MapIcon,
   ShieldAlert,
   X,
 } from 'lucide-react';
@@ -564,10 +563,14 @@ export default function CountyDetailClient() {
             dedicated buttons instead. */}
         {fromHomeMap ? (
           <div className='flex flex-wrap items-center gap-2'>
+            {/* Primary action: solid forest fill + back arrow so it
+                reads as "rewind to where I came from". The all-counties
+                shortcut next to it is deliberately secondary (outlined
+                + muted) so the eye lands on the return path first. */}
             <Link
               href='/#home-map'
-              className='inline-flex items-center gap-1.5 rounded-full border border-gov-forest/20 bg-gov-forest/5 px-3 py-1.5 text-sm text-gov-forest hover:bg-gov-forest/10 hover:border-gov-forest/40 transition-colors'>
-              <MapIcon size={14} />
+              className='inline-flex items-center gap-1.5 rounded-full bg-gov-forest px-3.5 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-gov-dark transition-colors'>
+              <ArrowLeft size={14} />
               {t('county.page.back_to_home_map')}
             </Link>
             <Link

--- a/frontend/app/learn/LearnPageClient.tsx
+++ b/frontend/app/learn/LearnPageClient.tsx
@@ -18,7 +18,11 @@ import PageShell from '@/components/layout/PageShell';
 import ConstitutionBook from '@/components/learn/constitution/ConstitutionBook';
 import LearnHero from '@/components/learn/LearnHero';
 import PopularQuestions from '@/components/learn/PopularQuestions';
-import { findChapterForArticle } from '@/data/constitution';
+import {
+  CONSTITUTION_META,
+  findChapterForArticle,
+  TOTAL_ARTICLES,
+} from '@/data/constitution';
 import { motion } from 'framer-motion';
 import {
   ArrowRight,
@@ -166,7 +170,7 @@ export default function LearningHubPage() {
               The Constitution, as a book you can actually read
             </h2>
             <p className='text-sm text-neutral-muted'>
-              Six chapters, dozens of articles, every one with a plain-English note.
+              {CONSTITUTION_META.length} chapters, {TOTAL_ARTICLES} articles, every one with a plain-English note.
             </p>
           </div>
           <Link

--- a/frontend/components/InteractiveKenyaMap.tsx
+++ b/frontend/components/InteractiveKenyaMap.tsx
@@ -72,6 +72,18 @@ export default function InteractiveKenyaMap({
   }, []);
   const isOverlayHoveredRef = useRef(false);
   const isProcessingLeaveRef = useRef(false);
+  // Short "hover intent" window after the cursor leaves a county path.
+  // While this is true, a neighbouring county's onMouseEnter is ignored
+  // so the user can travel across the SVG gap to the tooltip without
+  // the hover state flipping to a neighbor mid-transit. Released either
+  // when the cursor reaches the tooltip's hit zone (see
+  // handleOverlayMouseEnter) or when the timer below expires naturally.
+  // This targets the Meru-style case where the tooltip straddles
+  // dense-neighbour territory — large isolated counties are unaffected.
+  const transitLockoutRef = useRef(false);
+  const transitLockoutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   // Must be a ref, not useState. State reads close over the render that
   // created the handler — if a mouseenter runs BEFORE React commits the
   // render after a mouseleave's `setHideTimeoutId(tid)`, the closure
@@ -156,6 +168,20 @@ export default function InteractiveKenyaMap({
 
   /* ── hover handlers ── */
   const handleCountyMouseEnter = (countyName: string, county: any, e?: React.MouseEvent) => {
+    // Hover-intent lockout: if the cursor just left another county,
+    // ignore neighbouring paths for a brief window so the user has
+    // time to reach the tooltip. Same-county re-entries (cursor
+    // wobbling inside Meru's bounds) aren't blocked — only swaps to a
+    // *different* county. If the cursor never reaches the tooltip,
+    // the timer releases the lockout and the neighbour takes over
+    // naturally. See transitLockoutRef declaration for full rationale.
+    if (
+      transitLockoutRef.current &&
+      hoveredCounty != null &&
+      countyName !== hoveredCounty
+    ) {
+      return;
+    }
     if (hideTimeoutRef.current) {
       clearTimeout(hideTimeoutRef.current);
       hideTimeoutRef.current = null;
@@ -187,6 +213,19 @@ export default function InteractiveKenyaMap({
     }
     if (isProcessingLeaveRef.current) return;
     isProcessingLeaveRef.current = true;
+    // Open the hover-intent window: any neighbour county path the
+    // cursor crosses on its way to the tooltip will be ignored for
+    // the next 150ms. That's enough to bridge the 6px TIP_GAP + 32px
+    // inset hit-zone without feeling laggy if the user is actually
+    // moving to a different county.
+    if (transitLockoutTimerRef.current) {
+      clearTimeout(transitLockoutTimerRef.current);
+    }
+    transitLockoutRef.current = true;
+    transitLockoutTimerRef.current = setTimeout(() => {
+      transitLockoutRef.current = false;
+      transitLockoutTimerRef.current = null;
+    }, 150);
     if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
     const hoveredAtLeave = hoveredCounty;
     hideTimeoutRef.current = setTimeout(() => {
@@ -207,6 +246,15 @@ export default function InteractiveKenyaMap({
       clearTimeout(hideTimeoutRef.current);
       hideTimeoutRef.current = null;
     }
+    // Cursor reached the tooltip — mission accomplished. Release the
+    // hover-intent lockout immediately so a subsequent mouseleave
+    // from the overlay back to a (possibly different) county works
+    // without a lingering 150ms window.
+    if (transitLockoutTimerRef.current) {
+      clearTimeout(transitLockoutTimerRef.current);
+      transitLockoutTimerRef.current = null;
+    }
+    transitLockoutRef.current = false;
   };
   const handleOverlayMouseLeave = () => {
     // See handleCountyMouseLeave — on touch the tooltip stays open until
@@ -263,6 +311,8 @@ export default function InteractiveKenyaMap({
   useEffect(
     () => () => {
       if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
+      if (transitLockoutTimerRef.current)
+        clearTimeout(transitLockoutTimerRef.current);
     },
     []
   );

--- a/frontend/components/InteractiveKenyaMap.tsx
+++ b/frontend/components/InteractiveKenyaMap.tsx
@@ -72,18 +72,6 @@ export default function InteractiveKenyaMap({
   }, []);
   const isOverlayHoveredRef = useRef(false);
   const isProcessingLeaveRef = useRef(false);
-  // Short "hover intent" window after the cursor leaves a county path.
-  // While this is true, a neighbouring county's onMouseEnter is ignored
-  // so the user can travel across the SVG gap to the tooltip without
-  // the hover state flipping to a neighbor mid-transit. Released either
-  // when the cursor reaches the tooltip's hit zone (see
-  // handleOverlayMouseEnter) or when the timer below expires naturally.
-  // This targets the Meru-style case where the tooltip straddles
-  // dense-neighbour territory — large isolated counties are unaffected.
-  const transitLockoutRef = useRef(false);
-  const transitLockoutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
   // Must be a ref, not useState. State reads close over the render that
   // created the handler — if a mouseenter runs BEFORE React commits the
   // render after a mouseleave's `setHideTimeoutId(tid)`, the closure
@@ -168,20 +156,6 @@ export default function InteractiveKenyaMap({
 
   /* ── hover handlers ── */
   const handleCountyMouseEnter = (countyName: string, county: any, e?: React.MouseEvent) => {
-    // Hover-intent lockout: if the cursor just left another county,
-    // ignore neighbouring paths for a brief window so the user has
-    // time to reach the tooltip. Same-county re-entries (cursor
-    // wobbling inside Meru's bounds) aren't blocked — only swaps to a
-    // *different* county. If the cursor never reaches the tooltip,
-    // the timer releases the lockout and the neighbour takes over
-    // naturally. See transitLockoutRef declaration for full rationale.
-    if (
-      transitLockoutRef.current &&
-      hoveredCounty != null &&
-      countyName !== hoveredCounty
-    ) {
-      return;
-    }
     if (hideTimeoutRef.current) {
       clearTimeout(hideTimeoutRef.current);
       hideTimeoutRef.current = null;
@@ -213,19 +187,6 @@ export default function InteractiveKenyaMap({
     }
     if (isProcessingLeaveRef.current) return;
     isProcessingLeaveRef.current = true;
-    // Open the hover-intent window: any neighbour county path the
-    // cursor crosses on its way to the tooltip will be ignored for
-    // the next 150ms. That's enough to bridge the 6px TIP_GAP + 32px
-    // inset hit-zone without feeling laggy if the user is actually
-    // moving to a different county.
-    if (transitLockoutTimerRef.current) {
-      clearTimeout(transitLockoutTimerRef.current);
-    }
-    transitLockoutRef.current = true;
-    transitLockoutTimerRef.current = setTimeout(() => {
-      transitLockoutRef.current = false;
-      transitLockoutTimerRef.current = null;
-    }, 150);
     if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
     const hoveredAtLeave = hoveredCounty;
     hideTimeoutRef.current = setTimeout(() => {
@@ -246,15 +207,6 @@ export default function InteractiveKenyaMap({
       clearTimeout(hideTimeoutRef.current);
       hideTimeoutRef.current = null;
     }
-    // Cursor reached the tooltip — mission accomplished. Release the
-    // hover-intent lockout immediately so a subsequent mouseleave
-    // from the overlay back to a (possibly different) county works
-    // without a lingering 150ms window.
-    if (transitLockoutTimerRef.current) {
-      clearTimeout(transitLockoutTimerRef.current);
-      transitLockoutTimerRef.current = null;
-    }
-    transitLockoutRef.current = false;
   };
   const handleOverlayMouseLeave = () => {
     // See handleCountyMouseLeave — on touch the tooltip stays open until
@@ -311,8 +263,6 @@ export default function InteractiveKenyaMap({
   useEffect(
     () => () => {
       if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
-      if (transitLockoutTimerRef.current)
-        clearTimeout(transitLockoutTimerRef.current);
     },
     []
   );

--- a/frontend/components/dashboard/MapWithDetailPanel.tsx
+++ b/frontend/components/dashboard/MapWithDetailPanel.tsx
@@ -55,11 +55,12 @@ export default function MapWithDetailPanel({
 
   return (
     <motion.div
+      id='home-map'
       initial={{ opacity: 0 }}
       whileInView={{ opacity: 1 }}
       viewport={{ once: true, margin: '-80px' }}
       transition={{ duration: 0.8, delay: 0.2 }}
-      className='grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-0 items-stretch rounded-xl bg-gray-50/60 border border-gray-200/40 overflow-hidden'>
+      className='grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-0 items-stretch rounded-xl bg-gray-50/60 border border-gray-200/40 overflow-hidden scroll-mt-24'>
       <InteractiveKenyaMap
         counties={counties}
         onCountySelect={setSelectedCounty}

--- a/frontend/components/map/MapTooltip.tsx
+++ b/frontend/components/map/MapTooltip.tsx
@@ -261,8 +261,13 @@ export default function MapTooltip({
             CTA is a distinct target for "take me to the full page". We
             stopPropagation so the card's onClick doesn't also fire the
             selection — the page transition makes that stale anyway. */}
+        {/* ?from=home-map is the signal the detail page uses to render
+            "Back to map" + "All counties" shortcuts. InteractiveKenyaMap
+            is only mounted on the home dashboard today, so the param is
+            always accurate here; if that changes, hoist this into a
+            prop. */}
         <Link
-          href={`/counties/${county.id}`}
+          href={`/counties/${county.id}?from=home-map`}
           onClick={(e) => e.stopPropagation()}
           className='mt-3 pt-2 border-t border-gray-200/60 flex items-center justify-center gap-1 text-[11px] font-medium text-gov-forest hover:text-gov-dark transition-colors'>
           View detailed analysis

--- a/frontend/components/map/MapTooltip.tsx
+++ b/frontend/components/map/MapTooltip.tsx
@@ -7,6 +7,7 @@
 import { County } from '@/types';
 import { motion } from 'framer-motion';
 import { AlertTriangle, ArrowRight, Receipt, Scale, X } from 'lucide-react';
+import Link from 'next/link';
 
 interface MapTooltipProps {
   county: County;
@@ -254,11 +255,19 @@ export default function MapTooltip({
           )}
         </div>
 
-        {/* ── CTA ── */}
-        <div className='mt-3 pt-2 border-t border-gray-200/60 flex items-center justify-center gap-1 text-[11px] font-medium text-gov-forest'>
+        {/* ── CTA ──
+            Real Link, not just text. The card's wrapping onClick selects
+            the county (drives the home-dashboard side panel), but this
+            CTA is a distinct target for "take me to the full page". We
+            stopPropagation so the card's onClick doesn't also fire the
+            selection — the page transition makes that stale anyway. */}
+        <Link
+          href={`/counties/${county.id}`}
+          onClick={(e) => e.stopPropagation()}
+          className='mt-3 pt-2 border-t border-gray-200/60 flex items-center justify-center gap-1 text-[11px] font-medium text-gov-forest hover:text-gov-dark transition-colors'>
           View detailed analysis
           <ArrowRight className='w-3 h-3' />
-        </div>
+        </Link>
       </div>
     </motion.div>
   );

--- a/frontend/components/map/MapTooltip.tsx
+++ b/frontend/components/map/MapTooltip.tsx
@@ -30,9 +30,13 @@ interface MapTooltipProps {
  * the default content; a bit of padding in the math is safe. */
 const TIP_W = 288;
 const TIP_H = 260;
-/** Gap between the cursor and the tooltip. Kept small so the tooltip's
- * -inset-5 hit area (20px) fully bridges the gap. */
-const TIP_GAP = 12;
+/** Gap between the cursor and the tooltip. The smaller this is, the
+ * less neighboring-county territory the cursor must cross to reach the
+ * tooltip — in dense central-Kenya clusters (Meru, Nairobi, Kiambu)
+ * even a 12px gap was enough for SVG hit-testing to fire a neighbor's
+ * onMouseEnter mid-transit. The inset-8 hit zone (32px) on the card
+ * more than bridges this. */
+const TIP_GAP = 6;
 
 /** Place the tooltip relative to a cursor/centroid anchor with edge
  * collision. Prefers ABOVE the cursor (so the user can move up into
@@ -144,9 +148,13 @@ export default function MapTooltip({
           ? 'absolute z-50'
           : 'absolute z-50 top-[18%] left-1/2'
       }>
-      {/* Invisible hit-area so mouse doesn't lose hover in the gap */}
+      {/* Invisible hit-area so mouse doesn't lose hover in the gap.
+          Wider than TIP_GAP by design: the card is "easy to catch"
+          even if the cursor overshoots slightly while transiting from
+          the county — the 32px pad + 6px TIP_GAP means the hit zone
+          starts overlapping the county before the visual card does. */}
       <div
-        className='absolute -inset-5 z-0'
+        className='absolute -inset-8 z-0'
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       />

--- a/frontend/components/map/MapTooltip.tsx
+++ b/frontend/components/map/MapTooltip.tsx
@@ -6,7 +6,15 @@
 
 import { County } from '@/types';
 import { motion } from 'framer-motion';
-import { AlertTriangle, ArrowRight, Receipt, Scale, X } from 'lucide-react';
+import {
+  AlertTriangle,
+  ArrowRight,
+  Coins,
+  Receipt,
+  Scale,
+  TrendingUp,
+  X,
+} from 'lucide-react';
 import Link from 'next/link';
 
 interface MapTooltipProps {
@@ -30,7 +38,11 @@ interface MapTooltipProps {
  * `w-[min(18rem, ...)]` class below. 18rem = 288px. ~260px tall with
  * the default content; a bit of padding in the math is safe. */
 const TIP_W = 288;
-const TIP_H = 260;
+// Slightly taller than before to accommodate the status stripe, larger
+// metric values, and button-styled CTA. Only used for anchor-placement
+// math — the card itself is content-sized, so being ~10px off here just
+// shifts the tooltip marginally from its ideal position.
+const TIP_H = 290;
 /** Gap between the cursor and the tooltip. The smaller this is, the
  * less neighboring-county territory the cursor must cross to reach the
  * tooltip — in dense central-Kenya clusters (Meru, Nairobi, Kiambu)
@@ -66,27 +78,52 @@ const fmtKES = (n: number | undefined): string => {
   return `KES ${n}`;
 };
 
-const STATUS_CONFIG: Record<string, { bg: string; text: string; ring: string; dot: string }> = {
+const STATUS_CONFIG: Record<
+  string,
+  { bg: string; text: string; ring: string; dot: string; stripe: string }
+> = {
   clean: {
     bg: 'bg-emerald-50',
     text: 'text-emerald-700',
     ring: 'ring-emerald-200',
     dot: 'bg-emerald-500',
+    stripe: 'bg-emerald-500',
   },
   qualified: {
     bg: 'bg-amber-50',
     text: 'text-amber-700',
     ring: 'ring-amber-200',
     dot: 'bg-amber-500',
+    stripe: 'bg-amber-500',
   },
-  adverse: { bg: 'bg-red-50', text: 'text-red-700', ring: 'ring-red-200', dot: 'bg-red-500' },
+  adverse: {
+    bg: 'bg-red-50',
+    text: 'text-red-700',
+    ring: 'ring-red-200',
+    dot: 'bg-red-500',
+    stripe: 'bg-red-500',
+  },
   disclaimer: {
     bg: 'bg-violet-50',
     text: 'text-violet-700',
     ring: 'ring-violet-200',
     dot: 'bg-violet-500',
+    stripe: 'bg-violet-500',
   },
-  pending: { bg: 'bg-gray-50', text: 'text-gray-600', ring: 'ring-gray-200', dot: 'bg-gray-400' },
+  pending: {
+    bg: 'bg-gray-50',
+    text: 'text-gray-600',
+    ring: 'ring-gray-200',
+    dot: 'bg-gray-400',
+    stripe: 'bg-gray-300',
+  },
+};
+
+const fmtPopulation = (n?: number) => {
+  if (!n) return null;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M residents`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K residents`;
+  return `${n} residents`;
 };
 
 const utilizationClass = (u: number) =>
@@ -168,125 +205,179 @@ export default function MapTooltip({
         // of viewport margin on either side so the tooltip never clips
         // off the right edge on mobile. Content inside uses truncate /
         // min-w-0 so labels reflow instead of overflowing the card.
-        className='relative w-[min(18rem,calc(100vw-2rem))] rounded-xl bg-white/80 backdrop-blur-xl border border-white/40 shadow-[0_8px_32px_rgba(0,0,0,0.12)] p-4 cursor-pointer transition-shadow hover:shadow-[0_12px_40px_rgba(0,0,0,0.18)]'>
-        {/* ── Header ── */}
-        <div className='flex items-start justify-between gap-2 mb-3'>
-          <div className='min-w-0'>
-            <h3 className='text-[15px] font-bold text-gov-dark truncate'>{county.name}</h3>
-            <p className='text-[11px] text-gray-400 mt-0.5'>
-              {county.lastAuditDate
-                ? `Audited ${new Date(county.lastAuditDate).getFullYear()}`
-                : 'County overview'}
-            </p>
+        // `overflow-hidden` clips the status-stripe to the rounded-xl
+        // corners so the accent doesn't square off the top edge.
+        className='relative w-[min(18rem,calc(100vw-2rem))] rounded-xl bg-gradient-to-br from-white via-white to-gov-sand/30 backdrop-blur-xl border border-white/60 shadow-[0_10px_40px_rgba(15,23,42,0.14)] overflow-hidden cursor-pointer transition-all duration-200 hover:shadow-[0_14px_48px_rgba(15,23,42,0.20)] hover:-translate-y-0.5'>
+        {/* ── Status-colour stripe — visual cue for audit state before
+            the reader parses the chip. Pending = gray (neutral). */}
+        <div className={`h-1 w-full ${cfg.stripe}`} />
+
+        <div className='p-4'>
+          {/* ── Header ── */}
+          <div className='flex items-start justify-between gap-2 mb-3'>
+            <div className='min-w-0'>
+              <h3 className='text-[16px] font-bold text-gov-dark truncate leading-tight'>
+                {county.name}
+              </h3>
+              <p className='text-[11px] text-neutral-muted mt-0.5 truncate'>
+                {[
+                  fmtPopulation(county.population),
+                  county.governor ? `Gov. ${county.governor.split(' ').slice(-1)[0]}` : null,
+                  county.lastAuditDate
+                    ? `Audited ${new Date(county.lastAuditDate).getFullYear()}`
+                    : null,
+                ]
+                  .filter(Boolean)
+                  .join(' · ') || 'County overview'}
+              </p>
+            </div>
+            <div className='flex items-center gap-1.5 shrink-0'>
+              <span
+                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wider ring-1 ${cfg.bg} ${cfg.text} ${cfg.ring}`}>
+                <span className={`w-1.5 h-1.5 rounded-full ${cfg.dot}`} />
+                {status}
+              </span>
+              {onClose && (
+                // Explicit close button — needed on touch devices where the
+                // tooltip no longer auto-dismisses after a hover-leave timer.
+                // Rendered as a real <button> (not a div) for screen readers
+                // and to avoid the card's onClick swallowing the tap.
+                <button
+                  type='button'
+                  aria-label={`Close ${county.name} tooltip`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onClose();
+                  }}
+                  className='inline-flex h-6 w-6 items-center justify-center rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-800 active:bg-gray-300 transition-colors'>
+                  <X className='w-3.5 h-3.5' />
+                </button>
+              )}
+            </div>
           </div>
-          <div className='flex items-center gap-1.5 shrink-0'>
-            <span
-              className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wider ring-1 ${cfg.bg} ${cfg.text} ${cfg.ring}`}>
-              <span className={`w-1.5 h-1.5 rounded-full ${cfg.dot}`} />
-              {status}
-            </span>
-            {onClose && (
-              // Explicit close button — needed on touch devices where the
-              // tooltip no longer auto-dismisses after a hover-leave timer.
-              // Rendered as a real <button> (not a div) for screen readers
-              // and to avoid the card's onClick swallowing the tap.
-              <button
-                type='button'
-                aria-label={`Close ${county.name} tooltip`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onClose();
-                }}
-                className='inline-flex h-6 w-6 items-center justify-center rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-800 active:bg-gray-300 transition-colors'>
-                <X className='w-3.5 h-3.5' />
-              </button>
+
+          {/* ── Metrics row ── */}
+          <div className='grid grid-cols-2 gap-2 mb-3'>
+            {/* Budget utilisation */}
+            <div className='rounded-lg border border-neutral-border/40 bg-white/70 p-2.5'>
+              <div className='flex items-center gap-1 mb-1.5'>
+                <Coins className='w-3 h-3 text-gov-forest/70' />
+                <span className='text-[10px] font-medium text-neutral-muted'>Utilisation</span>
+              </div>
+              <div className='flex items-baseline gap-1 mb-1.5'>
+                <span className='text-[15px] font-bold text-gov-dark tabular-nums leading-none'>
+                  {utilization.toFixed(0)}
+                </span>
+                <span className='text-[10px] font-medium text-neutral-muted'>%</span>
+              </div>
+              <div className='w-full h-1 rounded-full bg-gray-200/70'>
+                <div
+                  className={`h-1 rounded-full ${utilizationClass(utilization)} transition-all`}
+                  style={{ width: `${Math.min(utilization, 100)}%` }}
+                />
+              </div>
+            </div>
+
+            {/* Debt ratio */}
+            <div className='rounded-lg border border-neutral-border/40 bg-white/70 p-2.5'>
+              <div className='flex items-center gap-1 mb-1.5'>
+                <TrendingUp className='w-3 h-3 text-gov-gold/80' />
+                <span className='text-[10px] font-medium text-neutral-muted'>Debt Ratio</span>
+              </div>
+              <div className='flex items-baseline gap-1 mb-0.5'>
+                <span className='text-[15px] font-bold text-gov-dark tabular-nums leading-none'>
+                  {debtRatio.toFixed(1)}
+                </span>
+                <span className='text-[10px] font-medium text-neutral-muted'>%</span>
+              </div>
+              <div className='text-[10px] text-neutral-muted truncate'>{fmtKES(county.debt)}</div>
+            </div>
+          </div>
+
+          {/* ── Alerts (compact) ── */}
+          <div className='space-y-1'>
+            {fundingGap > 0 && (
+              <AlertRow
+                icon={<Scale className='w-3 h-3 text-amber-600' />}
+                label='Funding gap'
+                value={fmtKES(fundingGap)}
+                tint='amber'
+              />
+            )}
+            {auditIssuesCount > 0 && (
+              <AlertRow
+                icon={<AlertTriangle className='w-3 h-3 text-red-500' />}
+                label='Audit issues'
+                value={`${auditIssuesCount} found`}
+                tint='red'
+              />
+            )}
+            {(county.pendingBills ?? 0) > 0 && (
+              <AlertRow
+                icon={<Receipt className='w-3 h-3 text-violet-500' />}
+                label='Pending bills'
+                value={fmtKES(county.pendingBills)}
+                tint='violet'
+              />
             )}
           </div>
+
+          {/* ── CTA ──
+              Real Link, not just text. The card's wrapping onClick selects
+              the county (drives the home-dashboard side panel), but this
+              CTA is a distinct target for "take me to the full page". We
+              stopPropagation so the card's onClick doesn't also fire the
+              selection — the page transition makes that stale anyway.
+
+              ?from=home-map is the signal the detail page uses to render
+              "Back to map" + "All counties" shortcuts. InteractiveKenyaMap
+              is only mounted on the home dashboard today, so the param is
+              always accurate here; if that changes, hoist this into a
+              prop. */}
+          <Link
+            href={`/counties/${county.id}?from=home-map`}
+            onClick={(e) => e.stopPropagation()}
+            className='mt-3 flex items-center justify-center gap-1.5 rounded-lg bg-gov-forest/[0.06] hover:bg-gov-forest hover:text-white px-3 py-2 text-[11px] font-semibold text-gov-forest transition-colors group/cta'>
+            View detailed analysis
+            <ArrowRight className='w-3 h-3 transition-transform group-hover/cta:translate-x-0.5' />
+          </Link>
         </div>
-
-        {/* ── Metrics row ── */}
-        <div className='grid grid-cols-2 gap-2 mb-3'>
-          {/* Budget utilisation */}
-          <div className='bg-gray-50/80 rounded-lg p-2'>
-            <div className='flex items-center justify-between mb-1'>
-              <span className='text-[10px] font-medium text-gray-500'>Utilisation</span>
-              <span className='text-xs font-bold text-gov-dark'>{utilization.toFixed(0)}%</span>
-            </div>
-            <div className='w-full h-1.5 rounded-full bg-gray-200'>
-              <div
-                className={`h-1.5 rounded-full ${utilizationClass(utilization)} transition-all`}
-                style={{ width: `${Math.min(utilization, 100)}%` }}
-              />
-            </div>
-          </div>
-
-          {/* Debt ratio */}
-          <div className='bg-gray-50/80 rounded-lg p-2'>
-            <div className='flex items-center justify-between mb-1'>
-              <span className='text-[10px] font-medium text-gray-500'>Debt Ratio</span>
-              <span className='text-xs font-bold text-gov-dark'>{debtRatio.toFixed(1)}%</span>
-            </div>
-            <div className='text-[10px] text-gray-400 truncate'>{fmtKES(county.debt)}</div>
-          </div>
-        </div>
-
-        {/* ── Alerts (compact) ── */}
-        <div className='space-y-1'>
-          {fundingGap > 0 && (
-            <AlertRow
-              icon={<Scale className='w-3 h-3 text-amber-600' />}
-              label='Funding gap'
-              value={fmtKES(fundingGap)}
-            />
-          )}
-          {auditIssuesCount > 0 && (
-            <AlertRow
-              icon={<AlertTriangle className='w-3 h-3 text-red-500' />}
-              label='Audit issues'
-              value={`${auditIssuesCount} found`}
-            />
-          )}
-          {(county.pendingBills ?? 0) > 0 && (
-            <AlertRow
-              icon={<Receipt className='w-3 h-3 text-violet-500' />}
-              label='Pending bills'
-              value={fmtKES(county.pendingBills)}
-            />
-          )}
-        </div>
-
-        {/* ── CTA ──
-            Real Link, not just text. The card's wrapping onClick selects
-            the county (drives the home-dashboard side panel), but this
-            CTA is a distinct target for "take me to the full page". We
-            stopPropagation so the card's onClick doesn't also fire the
-            selection — the page transition makes that stale anyway. */}
-        {/* ?from=home-map is the signal the detail page uses to render
-            "Back to map" + "All counties" shortcuts. InteractiveKenyaMap
-            is only mounted on the home dashboard today, so the param is
-            always accurate here; if that changes, hoist this into a
-            prop. */}
-        <Link
-          href={`/counties/${county.id}?from=home-map`}
-          onClick={(e) => e.stopPropagation()}
-          className='mt-3 pt-2 border-t border-gray-200/60 flex items-center justify-center gap-1 text-[11px] font-medium text-gov-forest hover:text-gov-dark transition-colors'>
-          View detailed analysis
-          <ArrowRight className='w-3 h-3' />
-        </Link>
       </div>
     </motion.div>
   );
 }
 
-/* tiny helper row */
-function AlertRow({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+/* tiny helper row — severity-tinted background so red/amber/violet
+ * alerts carry weight at a glance rather than blending into the card. */
+const ALERT_TINT: Record<
+  'amber' | 'red' | 'violet',
+  { bg: string; border: string; value: string }
+> = {
+  amber: { bg: 'bg-amber-50/70', border: 'border-amber-100', value: 'text-amber-800' },
+  red: { bg: 'bg-red-50/70', border: 'border-red-100', value: 'text-red-800' },
+  violet: { bg: 'bg-violet-50/70', border: 'border-violet-100', value: 'text-violet-800' },
+};
+
+function AlertRow({
+  icon,
+  label,
+  value,
+  tint,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  tint: 'amber' | 'red' | 'violet';
+}) {
+  const t = ALERT_TINT[tint];
   return (
-    <div className='flex items-center justify-between bg-white/60 rounded-md px-2 py-1.5 border border-gray-100'>
+    <div
+      className={`flex items-center justify-between rounded-md px-2 py-1.5 border ${t.bg} ${t.border}`}>
       <div className='flex items-center gap-1.5'>
         {icon}
-        <span className='text-[10px] font-medium text-gray-600'>{label}</span>
+        <span className='text-[10px] font-medium text-gray-700'>{label}</span>
       </div>
-      <span className='text-[10px] font-bold text-gray-700'>{value}</span>
+      <span className={`text-[10px] font-bold tabular-nums ${t.value}`}>{value}</span>
     </div>
   );
 }

--- a/frontend/lib/i18n/messages.ts
+++ b/frontend/lib/i18n/messages.ts
@@ -762,6 +762,7 @@ export const MESSAGES = {
   'county.page.back_county_explorer': { en: 'Back to County Explorer', sw: 'Rudi kwa Kivinjari cha Kaunti', plain: 'Back to Counties' },
   'county.page.follow_money_short': { en: 'Follow the Money', sw: 'Fuatilia Pesa', plain: 'Follow the Money' },
   'county.page.all_counties_short': { en: 'All Counties', sw: 'Kaunti Zote', plain: 'All Counties' },
+  'county.page.back_to_home_map': { en: 'Back to map', sw: 'Rudi kwa ramani', plain: 'Back to map' },
 
   // Hero
   'county.hero.eyebrow': { en: 'County Government · Kenya', sw: 'Serikali ya Kaunti · Kenya', plain: 'County Government · Kenya' },


### PR DESCRIPTION
## Summary
Cluster of UX fixes and a small copy correction, all on top of main after PR #65 merged.

### Map — county hover tooltip
- **Hover-intent dance**: first attempt at a 150ms "transit lockout" ([d657ce7](https://github.com/Rodgers31/audit_app/commit/d657ce7)) blocked legitimate county switches and left the tooltip hanging on a default auto-rotate county — reverted in [e5a4d20](https://github.com/Rodgers31/audit_app/commit/e5a4d20). The geometric tuning from the same effort stayed (6px gap + 32px invisible hit-zone), which is what actually solves the Meru-style "cursor crossed a neighbour" race in practice.
- **CTA now navigates** ([9e2167a](https://github.com/Rodgers31/audit_app/commit/9e2167a)) — "View detailed analysis" was a plain div. Now a real `next/link` to `/counties/[id]?from=home-map` with stopPropagation.
- **Tooltip redesign** ([248574e](https://github.com/Rodgers31/audit_app/commit/248574e)) — status-colour top stripe, warm gradient + subtle lift, richer header subtitle (population · governor · audit year), icons on metric cards, severity-tinted alert chips, pill-button CTA with hover translate. Same footprint — positioning math still holds.

### County detail page — map round-trip
- **Conditional nav buttons** ([fc7d642](https://github.com/Rodgers31/audit_app/commit/fc7d642)) — when the URL carries `?from=home-map`, replace the single SmartBackLink with two shortcuts: *Back to map* (→ `/#home-map`, restoring scroll via `scroll-mt-24`) and *All counties*. Every other entry path keeps its existing flow.
- **Primary-action restyle** ([63db03b](https://github.com/Rodgers31/audit_app/commit/63db03b)) — solid gov-forest fill + ArrowLeft so "Back to map" reads as the primary return action; outlined secondary pill for "All Counties".

### Learn page
- **Real counts** ([8e340c9](https://github.com/Rodgers31/audit_app/commit/8e340c9)) — constitution intro said "Six chapters, dozens of articles". Actual: **18 chapters, 264 articles**. Now pulled from `CONSTITUTION_META.length` + `TOTAL_ARTICLES` so the copy can't drift again.

## Verification
- End-to-end navigation round-trip confirmed: map tooltip → detail page shows both buttons → "Back to map" lands at `/#home-map` scrolled to the map section.
- Default detail-page entry (no `?from=home-map`) still shows the original single SmartBackLink — no regression on transparency/direct/list-page flows.
- Tooltip redesign rendered on Lamu County in the home dashboard; all six refinements visible in screenshot.
- Learn page now shows "18 chapters, 264 articles".

## Test plan
- [ ] Vercel preview: hover Meru, Nairobi, Kiambu on home map — tooltip tracks cursor, clicking "View detailed analysis" navigates.
- [ ] On county detail from home-map arrival, both pill buttons present; "Back to map" is solid forest.
- [ ] Learn page shows `18 chapters, 264 articles`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)