### PR TITLE
feat(learn): clickable constitution cross-references with clause-scoped highlight

### DIFF
--- a/frontend/components/learn/constitution/ArticleViewer.tsx
+++ b/frontend/components/learn/constitution/ArticleViewer.tsx
@@ -57,6 +57,11 @@ interface ArticleViewerProps {
    * reference into this article. `null` / `undefined` hides it. */
   backTarget?: { articleNumber: number } | null;
   onBack?: () => void;
+  /** When true, the header briefly flashes a soft yellow on mount —
+   * the visual "you landed on the right thing" cue for reference
+   * arrivals. Pass false for prev/next/sidebar/back navigations where
+   * the reader already knows where they are. */
+  flashOnMount?: boolean;
 }
 
 /** Cheap, allocation-light highlight: splits on case-insensitive query. */
@@ -105,6 +110,7 @@ export default function ArticleViewer({
   onReferenceClick,
   backTarget,
   onBack,
+  flashOnMount = false,
 }: ArticleViewerProps) {
   const pageKey = useMemo(
     () => `${chapter.number}-${article.number}`,
@@ -126,8 +132,22 @@ export default function ArticleViewer({
           transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
           className='flex h-full flex-col'
           style={{ transformStyle: 'preserve-3d', transformOrigin: 'center' }}>
-          {/* ── Header ── */}
-          <header className='border-b border-neutral-border/70 px-5 pb-4 pt-5 sm:px-7 sm:pt-6'>
+          {/* ── Header ──
+              When flashOnMount is set we briefly bathe the header in a
+              soft yellow and fade it out over ~1.6s. The colour sits
+              between amber-100 (too cream) and amber-200 (too bright);
+              35% opacity keeps it readable-over. */}
+          <motion.header
+            initial={
+              flashOnMount
+                ? { backgroundColor: 'rgba(253, 230, 138, 0.35)' }
+                : undefined
+            }
+            animate={
+              flashOnMount ? { backgroundColor: 'rgba(253, 230, 138, 0)' } : undefined
+            }
+            transition={flashOnMount ? { duration: 1.6, ease: 'easeOut' } : undefined}
+            className='border-b border-neutral-border/70 px-5 pb-4 pt-5 sm:px-7 sm:pt-6'>
             {/* Back pill — only shown when the reader arrived here via an
                 in-prose reference click. Sits above the chapter chip so it
                 reads as "you followed a thread; here's how to unwind it"
@@ -164,7 +184,7 @@ export default function ArticleViewer({
                 {renderProse(article.summary, { query, onRefClick: onReferenceClick })}
               </p>
             )}
-          </header>
+          </motion.header>
 
           {/* ── Paragraphs ── */}
           <div className='flex-1 space-y-3 overflow-y-auto px-5 py-5 text-[14.5px] leading-relaxed text-neutral-text sm:px-7 sm:py-6'>

--- a/frontend/components/learn/constitution/ArticleViewer.tsx
+++ b/frontend/components/learn/constitution/ArticleViewer.tsx
@@ -132,22 +132,8 @@ export default function ArticleViewer({
           transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
           className='flex h-full flex-col'
           style={{ transformStyle: 'preserve-3d', transformOrigin: 'center' }}>
-          {/* ── Header ──
-              When flashOnMount is set we briefly bathe the header in a
-              soft yellow and fade it out over ~1.6s. The colour sits
-              between amber-100 (too cream) and amber-200 (too bright);
-              35% opacity keeps it readable-over. */}
-          <motion.header
-            initial={
-              flashOnMount
-                ? { backgroundColor: 'rgba(253, 230, 138, 0.35)' }
-                : undefined
-            }
-            animate={
-              flashOnMount ? { backgroundColor: 'rgba(253, 230, 138, 0)' } : undefined
-            }
-            transition={flashOnMount ? { duration: 1.6, ease: 'easeOut' } : undefined}
-            className='border-b border-neutral-border/70 px-5 pb-4 pt-5 sm:px-7 sm:pt-6'>
+          {/* ── Header ── */}
+          <header className='border-b border-neutral-border/70 px-5 pb-4 pt-5 sm:px-7 sm:pt-6'>
             {/* Back pill — only shown when the reader arrived here via an
                 in-prose reference click. Sits above the chapter chip so it
                 reads as "you followed a thread; here's how to unwind it"
@@ -184,10 +170,35 @@ export default function ArticleViewer({
                 {renderProse(article.summary, { query, onRefClick: onReferenceClick })}
               </p>
             )}
-          </motion.header>
+          </header>
 
-          {/* ── Paragraphs ── */}
-          <div className='flex-1 space-y-3 overflow-y-auto px-5 py-5 text-[14.5px] leading-relaxed text-neutral-text sm:px-7 sm:py-6'>
+          {/* ── Paragraphs ──
+              Arrival flash: when the reader clicks a cross-reference,
+              flashOnMount=true and this container holds a fully opaque
+              pale yellow (Tailwind yellow-100 ≈ #fef9c3) for ~0.6s,
+              then eases to transparent over ~1.8s. We use a solid
+              colour, not a translucent amber, because a parent
+              bg-white/70 backdrop was washing the previous rgba-based
+              tint below the perception threshold. */}
+          <motion.div
+            initial={
+              flashOnMount ? { backgroundColor: 'rgb(254, 249, 195)' } : undefined
+            }
+            animate={
+              flashOnMount
+                ? {
+                    backgroundColor: [
+                      'rgba(254, 249, 195, 1)',
+                      'rgba(254, 249, 195, 1)',
+                      'rgba(254, 249, 195, 0)',
+                    ],
+                  }
+                : undefined
+            }
+            transition={
+              flashOnMount ? { duration: 2.4, times: [0, 0.25, 1], ease: 'easeOut' } : undefined
+            }
+            className='flex-1 space-y-3 overflow-y-auto px-5 py-5 text-[14.5px] leading-relaxed text-neutral-text sm:px-7 sm:py-6'>
             {article.paragraphs.map((p, i) => (
               <p key={i} className='font-serif first-letter:text-[1.15em] first-letter:font-semibold'>
                 {renderProse(p, { query, onRefClick: onReferenceClick })}
@@ -243,7 +254,7 @@ export default function ArticleViewer({
                 </div>
               </div>
             )}
-          </div>
+          </motion.div>
 
           {/* ── Footer nav ── */}
           <footer className='flex items-center justify-between gap-3 border-t border-neutral-border/70 bg-gov-cream/60 px-5 py-3 sm:px-7'>

--- a/frontend/components/learn/constitution/ArticleViewer.tsx
+++ b/frontend/components/learn/constitution/ArticleViewer.tsx
@@ -21,7 +21,7 @@ import {
   Lightbulb,
   ScrollText,
 } from 'lucide-react';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import { renderProse, type ReferenceTarget } from './prose';
 
@@ -57,11 +57,12 @@ interface ArticleViewerProps {
    * reference into this article. `null` / `undefined` hides it. */
   backTarget?: { articleNumber: number } | null;
   onBack?: () => void;
-  /** When true, the header briefly flashes a soft yellow on mount —
-   * the visual "you landed on the right thing" cue for reference
-   * arrivals. Pass false for prev/next/sidebar/back navigations where
-   * the reader already knows where they are. */
-  flashOnMount?: boolean;
+  /** Top-level clause the reader was pointed at — e.g. "3" when the
+   * reference was "Article 144(3)(c)". On arrival we flash + scroll
+   * to the paragraph whose leading "(X)" marker matches. `null` /
+   * absent means "no clause highlight" (plain-article or non-
+   * reference navigation: the page switch is itself the feedback). */
+  highlightClause?: string | null;
 }
 
 /** Cheap, allocation-light highlight: splits on case-insensitive query. */
@@ -110,8 +111,18 @@ export default function ArticleViewer({
   onReferenceClick,
   backTarget,
   onBack,
-  flashOnMount = false,
+  highlightClause,
 }: ArticleViewerProps) {
+  const clauseRef = useRef<HTMLParagraphElement | null>(null);
+
+  // When the viewer mounts with a clause to highlight, scroll that
+  // paragraph into view inside the overflow-y-auto body. We run this
+  // after paint so the ref is populated, and key on article.number so
+  // a second ref-click to the same article re-triggers scrolling.
+  useEffect(() => {
+    if (!highlightClause || !clauseRef.current) return;
+    clauseRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, [article.number, highlightClause]);
   const pageKey = useMemo(
     () => `${chapter.number}-${article.number}`,
     [chapter.number, article.number]
@@ -173,37 +184,45 @@ export default function ArticleViewer({
           </header>
 
           {/* ── Paragraphs ──
-              Arrival flash: when the reader clicks a cross-reference,
-              flashOnMount=true and this container holds a fully opaque
-              pale yellow (Tailwind yellow-100 ≈ #fef9c3) for ~0.6s,
-              then eases to transparent over ~1.8s. We use a solid
-              colour, not a translucent amber, because a parent
-              bg-white/70 backdrop was washing the previous rgba-based
-              tint below the perception threshold. */}
-          <motion.div
-            initial={
-              flashOnMount ? { backgroundColor: 'rgb(254, 249, 195)' } : undefined
-            }
-            animate={
-              flashOnMount
-                ? {
-                    backgroundColor: [
-                      'rgba(254, 249, 195, 1)',
-                      'rgba(254, 249, 195, 1)',
-                      'rgba(254, 249, 195, 0)',
-                    ],
+              No container-level flash anymore — only the paragraph
+              whose leading "(X)" marker matches highlightClause
+              flashes. That keeps the scope of the highlight aligned
+              with the scope of the reference: "Article 144(3)" lights
+              up clause (3), not the whole article. Paragraphs without
+              a leading clause marker, or when highlightClause is
+              absent, render unchanged. */}
+          <div className='flex-1 space-y-3 overflow-y-auto px-5 py-5 text-[14.5px] leading-relaxed text-neutral-text sm:px-7 sm:py-6'>
+            {article.paragraphs.map((p, i) => {
+              const leading = /^\s*\((\w+)\)/.exec(p)?.[1];
+              const isTarget = !!highlightClause && leading === highlightClause;
+              return (
+                <motion.p
+                  key={i}
+                  ref={isTarget ? clauseRef : undefined}
+                  initial={isTarget ? { backgroundColor: 'rgb(254, 249, 195)' } : undefined}
+                  animate={
+                    isTarget
+                      ? {
+                          backgroundColor: [
+                            'rgba(254, 249, 195, 1)',
+                            'rgba(254, 249, 195, 1)',
+                            'rgba(254, 249, 195, 0)',
+                          ],
+                        }
+                      : undefined
                   }
-                : undefined
-            }
-            transition={
-              flashOnMount ? { duration: 2.4, times: [0, 0.25, 1], ease: 'easeOut' } : undefined
-            }
-            className='flex-1 space-y-3 overflow-y-auto px-5 py-5 text-[14.5px] leading-relaxed text-neutral-text sm:px-7 sm:py-6'>
-            {article.paragraphs.map((p, i) => (
-              <p key={i} className='font-serif first-letter:text-[1.15em] first-letter:font-semibold'>
-                {renderProse(p, { query, onRefClick: onReferenceClick })}
-              </p>
-            ))}
+                  transition={
+                    isTarget
+                      ? { duration: 2.4, times: [0, 0.25, 1], ease: 'easeOut' }
+                      : undefined
+                  }
+                  className={`font-serif first-letter:text-[1.15em] first-letter:font-semibold ${
+                    isTarget ? 'rounded-md px-2 -mx-2 py-1 -my-1' : ''
+                  }`}>
+                  {renderProse(p, { query, onRefClick: onReferenceClick })}
+                </motion.p>
+              );
+            })}
 
             {article.explanation && (
               <div className='mt-4 rounded-xl bg-gradient-to-br from-gov-gold/15 via-gov-sand to-gov-cream/80 p-4 ring-1 ring-gov-gold/30'>
@@ -254,7 +273,7 @@ export default function ArticleViewer({
                 </div>
               </div>
             )}
-          </motion.div>
+          </div>
 
           {/* ── Footer nav ── */}
           <footer className='flex items-center justify-between gap-3 border-t border-neutral-border/70 bg-gov-cream/60 px-5 py-3 sm:px-7'>

--- a/frontend/components/learn/constitution/ArticleViewer.tsx
+++ b/frontend/components/learn/constitution/ArticleViewer.tsx
@@ -116,12 +116,16 @@ export default function ArticleViewer({
   const clauseRef = useRef<HTMLParagraphElement | null>(null);
 
   // When the viewer mounts with a clause to highlight, scroll that
-  // paragraph into view inside the overflow-y-auto body. We run this
-  // after paint so the ref is populated, and key on article.number so
-  // a second ref-click to the same article re-triggers scrolling.
+  // paragraph into view inside the overflow-y-auto body. `block:
+  // 'nearest'` (not 'start'): short articles where the whole body
+  // already fits need no scroll, and 'start' would try to align the
+  // paragraph with the viewport top — if the inner container can't
+  // scroll the browser walks up ancestors and ends up scrolling the
+  // outer page, visually pushing the article down. 'nearest' is a
+  // no-op whenever the paragraph is already visible.
   useEffect(() => {
     if (!highlightClause || !clauseRef.current) return;
-    clauseRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    clauseRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   }, [article.number, highlightClause]);
   const pageKey = useMemo(
     () => `${chapter.number}-${article.number}`,

--- a/frontend/components/learn/constitution/ArticleViewer.tsx
+++ b/frontend/components/learn/constitution/ArticleViewer.tsx
@@ -16,11 +16,14 @@ import {
   ArrowRight,
   Bookmark,
   CheckCircle2,
+  CornerDownLeft,
   Hash,
   Lightbulb,
   ScrollText,
 } from 'lucide-react';
 import { useMemo } from 'react';
+
+import { renderProse, type ReferenceTarget } from './prose';
 
 /** Page-turn variants. `direction` is passed via AnimatePresence's custom prop. */
 const PAGE_VARIANTS: Variants = {
@@ -46,6 +49,14 @@ interface ArticleViewerProps {
   nextChapterNumber?: number;
   nextChapterTitle?: string;
   onGoNextChapter?: () => void;
+  /** Called when the reader clicks an "Article N" / "Chapter N"
+   * reference embedded in the prose. The parent decides whether the
+   * jump pushes history, opens in place, etc. */
+  onReferenceClick?: (target: ReferenceTarget) => void;
+  /** Label for the back-pill shown when the reader followed a
+   * reference into this article. `null` / `undefined` hides it. */
+  backTarget?: { articleNumber: number } | null;
+  onBack?: () => void;
 }
 
 /** Cheap, allocation-light highlight: splits on case-insensitive query. */
@@ -91,6 +102,9 @@ export default function ArticleViewer({
   nextChapterNumber,
   nextChapterTitle,
   onGoNextChapter,
+  onReferenceClick,
+  backTarget,
+  onBack,
 }: ArticleViewerProps) {
   const pageKey = useMemo(
     () => `${chapter.number}-${article.number}`,
@@ -114,6 +128,19 @@ export default function ArticleViewer({
           style={{ transformStyle: 'preserve-3d', transformOrigin: 'center' }}>
           {/* ── Header ── */}
           <header className='border-b border-neutral-border/70 px-5 pb-4 pt-5 sm:px-7 sm:pt-6'>
+            {/* Back pill — only shown when the reader arrived here via an
+                in-prose reference click. Sits above the chapter chip so it
+                reads as "you followed a thread; here's how to unwind it"
+                rather than general navigation (left/right arrows do that). */}
+            {backTarget && onBack && (
+              <button
+                type='button'
+                onClick={onBack}
+                className='mb-3 inline-flex items-center gap-1.5 rounded-full border border-gov-forest/20 bg-gov-forest/5 px-3 py-1 text-[11px] font-semibold text-gov-forest hover:bg-gov-forest/10 hover:border-gov-forest/40 transition-colors'>
+                <CornerDownLeft size={12} />
+                Back to Article {backTarget.articleNumber}
+              </button>
+            )}
             <div className='mb-2 flex flex-wrap items-center gap-2 text-[11px] uppercase tracking-wider text-gov-forest/70'>
               <span className='inline-flex items-center gap-1 rounded-full bg-gov-forest/10 px-2 py-0.5 font-semibold'>
                 <ScrollText size={11} />
@@ -134,7 +161,7 @@ export default function ArticleViewer({
             {article.summary && (
               <p className='mt-3 rounded-xl border border-gov-sage/30 bg-gov-sage/10 px-3.5 py-2.5 text-[13.5px] leading-relaxed text-gov-forest'>
                 <Bookmark size={13} className='-mt-0.5 mr-1 inline text-gov-sage' />
-                {highlight(article.summary, query)}
+                {renderProse(article.summary, { query, onRefClick: onReferenceClick })}
               </p>
             )}
           </header>
@@ -143,7 +170,7 @@ export default function ArticleViewer({
           <div className='flex-1 space-y-3 overflow-y-auto px-5 py-5 text-[14.5px] leading-relaxed text-neutral-text sm:px-7 sm:py-6'>
             {article.paragraphs.map((p, i) => (
               <p key={i} className='font-serif first-letter:text-[1.15em] first-letter:font-semibold'>
-                {highlight(p, query)}
+                {renderProse(p, { query, onRefClick: onReferenceClick })}
               </p>
             ))}
 
@@ -154,7 +181,7 @@ export default function ArticleViewer({
                   Why it matters
                 </div>
                 <p className='text-[13.5px] leading-relaxed text-gov-dark'>
-                  {highlight(article.explanation, query)}
+                  {renderProse(article.explanation, { query, onRefClick: onReferenceClick })}
                 </p>
               </div>
             )}

--- a/frontend/components/learn/constitution/ConstitutionBook.tsx
+++ b/frontend/components/learn/constitution/ConstitutionBook.tsx
@@ -23,6 +23,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import ArticleViewer from './ArticleViewer';
 import ChapterSidebar from './ChapterSidebar';
+import type { ReferenceTarget } from './prose';
 
 interface ConstitutionBookProps {
   /** Initial chapter to open. Defaults to Chapter 12 (Public Finance). */
@@ -48,6 +49,14 @@ export default function ConstitutionBook({
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [direction, setDirection] = useState<number>(1);
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
+  // Breadcrumb of positions the reader left when they clicked a
+  // reference inside the prose. Pushed in navigateToReference(),
+  // popped in goBack(), cleared when the reader jumps via the sidebar
+  // (that's general navigation — the back-pill only makes sense when
+  // the user is following a chain of cross-references).
+  const [refHistory, setRefHistory] = useState<
+    Array<{ chapter: number; article: number }>
+  >([]);
 
   /* Use a ref for direction too so keyboard/swipe handlers always read the
      latest value regardless of render timing. */
@@ -112,6 +121,9 @@ export default function ConstitutionBook({
       setActiveChapter(n);
       // Drop the preselected article so the new chapter opens at #1.
       setActiveArticle(null);
+      // Sidebar / keyboard jumps aren't "following a reference", so the
+      // back-pill would be misleading here — start fresh.
+      setRefHistory([]);
     },
     [activeChapter]
   );
@@ -143,6 +155,61 @@ export default function ConstitutionBook({
     },
     [activeChapter, activeArticle]
   );
+
+  /** Follow a cross-reference from inside the prose. Pushes the
+   * current location onto refHistory so the viewer's Back pill can
+   * rewind — possibly across several hops. Chapter refs land on the
+   * chapter's first article. No-ops when the reference points at
+   * wherever the reader already is (self-references appear in summary
+   * text often enough to matter). */
+  const navigateToReference = useCallback(
+    (target: ReferenceTarget) => {
+      const sameChapter = target.chapterNumber === activeChapter;
+      const sameArticle =
+        target.kind === 'article' && sameChapter && target.articleNumber === activeArticle;
+      const sameChapterStart = target.kind === 'chapter' && sameChapter;
+      if (sameArticle || sameChapterStart) return;
+
+      if (activeArticle !== null) {
+        setRefHistory((h) => [...h, { chapter: activeChapter, article: activeArticle }]);
+      }
+      if (target.kind === 'chapter') {
+        setDirection(target.chapterNumber > activeChapter ? 1 : -1);
+        setActiveChapter(target.chapterNumber);
+        setActiveArticle(null); // fall through to first article
+        return;
+      }
+      // Article ref — same logic as selectArticle but we already
+      // managed direction / state above.
+      if (!sameChapter) {
+        setDirection(target.chapterNumber > activeChapter ? 1 : -1);
+        setActiveChapter(target.chapterNumber);
+        setActiveArticle(target.articleNumber);
+      } else {
+        setDirection(target.articleNumber > (activeArticle ?? 0) ? 1 : -1);
+        setActiveArticle(target.articleNumber);
+      }
+    },
+    [activeChapter, activeArticle]
+  );
+
+  const goBack = useCallback(() => {
+    setRefHistory((h) => {
+      if (h.length === 0) return h;
+      const prev = h[h.length - 1]!;
+      // Apply navigation as a side effect — React batches the history
+      // slice + the chapter/article sets into one render.
+      if (prev.chapter !== activeChapter) {
+        setDirection(prev.chapter > activeChapter ? 1 : -1);
+        setActiveChapter(prev.chapter);
+        setActiveArticle(prev.article);
+      } else {
+        setDirection(prev.article > (activeArticle ?? 0) ? 1 : -1);
+        setActiveArticle(prev.article);
+      }
+      return h.slice(0, -1);
+    });
+  }, [activeChapter, activeArticle]);
 
   /* ── Keyboard navigation (arrow keys) ── */
   useEffect(() => {
@@ -271,6 +338,13 @@ export default function ConstitutionBook({
               nextChapterNumber={nextChapterMeta?.number}
               nextChapterTitle={nextChapterMeta?.title}
               onGoNextChapter={goNextChapter}
+              onReferenceClick={navigateToReference}
+              backTarget={
+                refHistory.length > 0
+                  ? { articleNumber: refHistory[refHistory.length - 1]!.article }
+                  : null
+              }
+              onBack={goBack}
             />
           ) : null}
         </motion.div>

--- a/frontend/components/learn/constitution/ConstitutionBook.tsx
+++ b/frontend/components/learn/constitution/ConstitutionBook.tsx
@@ -57,6 +57,11 @@ export default function ConstitutionBook({
   const [refHistory, setRefHistory] = useState<
     Array<{ chapter: number; article: number }>
   >([]);
+  // True for exactly one render after navigateToReference(): lets the
+  // viewer flash a soft yellow on mount so the reader can see which
+  // article answered their click. Reset by every other navigation
+  // path (prev/next/sidebar/back) so routine scrolling doesn't flash.
+  const [flashOnArrival, setFlashOnArrival] = useState<boolean>(false);
 
   /* Use a ref for direction too so keyboard/swipe handlers always read the
      latest value regardless of render timing. */
@@ -104,6 +109,7 @@ export default function ConstitutionBook({
     if (prevArticle) {
       setDirection(-1);
       setActiveArticle(prevArticle.number);
+      setFlashOnArrival(false);
     }
   }, [prevArticle]);
 
@@ -111,6 +117,7 @@ export default function ConstitutionBook({
     if (nextArticle) {
       setDirection(1);
       setActiveArticle(nextArticle.number);
+      setFlashOnArrival(false);
     }
   }, [nextArticle]);
 
@@ -124,6 +131,7 @@ export default function ConstitutionBook({
       // Sidebar / keyboard jumps aren't "following a reference", so the
       // back-pill would be misleading here — start fresh.
       setRefHistory([]);
+      setFlashOnArrival(false);
     },
     [activeChapter]
   );
@@ -140,6 +148,7 @@ export default function ConstitutionBook({
     setDirection(1);
     setActiveChapter(nextChapterMeta.number);
     setActiveArticle(null);
+    setFlashOnArrival(false);
   }, [nextChapterMeta]);
 
   const selectArticle = useCallback(
@@ -152,6 +161,7 @@ export default function ConstitutionBook({
         setDirection(articleNumber > (activeArticle ?? 0) ? 1 : -1);
         setActiveArticle(articleNumber);
       }
+      setFlashOnArrival(false);
     },
     [activeChapter, activeArticle]
   );
@@ -173,6 +183,7 @@ export default function ConstitutionBook({
       if (activeArticle !== null) {
         setRefHistory((h) => [...h, { chapter: activeChapter, article: activeArticle }]);
       }
+      setFlashOnArrival(true);
       if (target.kind === 'chapter') {
         setDirection(target.chapterNumber > activeChapter ? 1 : -1);
         setActiveChapter(target.chapterNumber);
@@ -209,6 +220,10 @@ export default function ConstitutionBook({
       }
       return h.slice(0, -1);
     });
+    // Returning somewhere the reader has already read shouldn't flash
+    // — they know the content. Flashing would read as "new answer" and
+    // be misleading.
+    setFlashOnArrival(false);
   }, [activeChapter, activeArticle]);
 
   /* ── Keyboard navigation (arrow keys) ── */
@@ -345,6 +360,7 @@ export default function ConstitutionBook({
                   : null
               }
               onBack={goBack}
+              flashOnMount={flashOnArrival}
             />
           ) : null}
         </motion.div>

--- a/frontend/components/learn/constitution/ConstitutionBook.tsx
+++ b/frontend/components/learn/constitution/ConstitutionBook.tsx
@@ -57,11 +57,13 @@ export default function ConstitutionBook({
   const [refHistory, setRefHistory] = useState<
     Array<{ chapter: number; article: number }>
   >([]);
-  // True for exactly one render after navigateToReference(): lets the
-  // viewer flash a soft yellow on mount so the reader can see which
-  // article answered their click. Reset by every other navigation
-  // path (prev/next/sidebar/back) so routine scrolling doesn't flash.
-  const [flashOnArrival, setFlashOnArrival] = useState<boolean>(false);
+  // Top-level clause to flash + scroll into view after a reference
+  // click. Set in navigateToReference when the reference named a
+  // subparagraph (e.g. "Article 144(3)(c)" → "3"); cleared on every
+  // other navigation path. Plain "Article 144" refs don't set a
+  // clause, so the viewer mounts with no flash — the page switch
+  // itself is the feedback.
+  const [highlightClause, setHighlightClause] = useState<string | null>(null);
 
   /* Use a ref for direction too so keyboard/swipe handlers always read the
      latest value regardless of render timing. */
@@ -109,7 +111,7 @@ export default function ConstitutionBook({
     if (prevArticle) {
       setDirection(-1);
       setActiveArticle(prevArticle.number);
-      setFlashOnArrival(false);
+      setHighlightClause(null);
     }
   }, [prevArticle]);
 
@@ -117,7 +119,7 @@ export default function ConstitutionBook({
     if (nextArticle) {
       setDirection(1);
       setActiveArticle(nextArticle.number);
-      setFlashOnArrival(false);
+      setHighlightClause(null);
     }
   }, [nextArticle]);
 
@@ -131,7 +133,7 @@ export default function ConstitutionBook({
       // Sidebar / keyboard jumps aren't "following a reference", so the
       // back-pill would be misleading here — start fresh.
       setRefHistory([]);
-      setFlashOnArrival(false);
+      setHighlightClause(null);
     },
     [activeChapter]
   );
@@ -148,7 +150,7 @@ export default function ConstitutionBook({
     setDirection(1);
     setActiveChapter(nextChapterMeta.number);
     setActiveArticle(null);
-    setFlashOnArrival(false);
+    setHighlightClause(null);
   }, [nextChapterMeta]);
 
   const selectArticle = useCallback(
@@ -161,7 +163,7 @@ export default function ConstitutionBook({
         setDirection(articleNumber > (activeArticle ?? 0) ? 1 : -1);
         setActiveArticle(articleNumber);
       }
-      setFlashOnArrival(false);
+      setHighlightClause(null);
     },
     [activeChapter, activeArticle]
   );
@@ -183,7 +185,13 @@ export default function ConstitutionBook({
       if (activeArticle !== null) {
         setRefHistory((h) => [...h, { chapter: activeChapter, article: activeArticle }]);
       }
-      setFlashOnArrival(true);
+      // Only flash when the reference explicitly named a clause. A
+      // bare "Article 144" lands on the article with no highlight —
+      // the page switch is the feedback, the whole-article flash we
+      // had before was over-reaching.
+      setHighlightClause(
+        target.kind === 'article' && target.clauses.length > 0 ? target.clauses[0]! : null,
+      );
       if (target.kind === 'chapter') {
         setDirection(target.chapterNumber > activeChapter ? 1 : -1);
         setActiveChapter(target.chapterNumber);
@@ -223,7 +231,7 @@ export default function ConstitutionBook({
     // Returning somewhere the reader has already read shouldn't flash
     // — they know the content. Flashing would read as "new answer" and
     // be misleading.
-    setFlashOnArrival(false);
+    setHighlightClause(null);
   }, [activeChapter, activeArticle]);
 
   /* ── Keyboard navigation (arrow keys) ── */
@@ -360,7 +368,7 @@ export default function ConstitutionBook({
                   : null
               }
               onBack={goBack}
-              flashOnMount={flashOnArrival}
+              highlightClause={highlightClause}
             />
           ) : null}
         </motion.div>

--- a/frontend/components/learn/constitution/prose.tsx
+++ b/frontend/components/learn/constitution/prose.tsx
@@ -17,18 +17,24 @@ import { CONSTITUTION_META, findChapterForArticle } from '@/data/constitution';
 
 /**
  * Primary match — anchors the chain on an explicit keyword:
- *   - "Article 152"      → article 152
- *   - "Articles 156"     → article 156 (plural form)
- *   - "Article 152(2)"   → article 152; the "(2)" marker is cosmetic,
- *                          we don't jump to subparagraphs.
- *   - "Chapter 12"       → chapter 12
+ *   - "Article 152"       → article 152, no clauses
+ *   - "Articles 156"      → article 156 (plural form), no clauses
+ *   - "Article 142(2)"    → article 142, clauses = ['2']
+ *   - "Article 136(2)(a)" → article 136, clauses = ['2', 'a']
+ *   - "Chapter 12"        → chapter 12
+ *
+ * The third capture group greedily collects zero-or-more parenthesised
+ * clause markers so we can jump to a specific subparagraph when the
+ * reference names one. Extracted via extractClauses() since the group
+ * captures the whole "(2)(a)" blob.
  *
  * Skipped by design:
  *   - clause markers like "(1)", "(a)", "sub-paragraph (i)" — these
  *     are intra-article and have no useful navigation target.
  *   - phrases like "this Constitution" — self-referential.
  */
-const REF_RE = /\b(Article|Articles|Chapter|Chapters)\s+(\d+)(\([A-Za-z0-9]+\))?/g;
+const REF_RE =
+  /\b(Article|Articles|Chapter|Chapters)\s+(\d+)((?:\([A-Za-z0-9]+\))*)/g;
 
 /**
  * After a primary match, prose often continues with more bare numbers
@@ -36,13 +42,29 @@ const REF_RE = /\b(Article|Articles|Chapter|Chapters)\s+(\d+)(\([A-Za-z0-9]+\))?
  * 154, 155 and 156"). CONTINUATION_RE eats ONE of those separators
  * plus the next number; we apply it repeatedly until the chain breaks
  * so every number in a list becomes clickable under the same kind as
- * the anchor.
+ * the anchor. Continuation numbers can carry their own subparagraph
+ * markers too (rarely: "Article 136(2)(a) or 137(1)").
  */
 const CONTINUATION_RE =
-  /^(?:,\s+and\s+|,\s*|\s+and\s+|\s+or\s+)(\d+)(?:\([A-Za-z0-9]+\))?/i;
+  /^(?:,\s+and\s+|,\s*|\s+and\s+|\s+or\s+)(\d+)((?:\([A-Za-z0-9]+\))*)/i;
+
+/** Turn a captured "(2)(a)" blob into ['2', 'a']. Empty string → []. */
+function extractClauses(parenBlob: string | undefined): string[] {
+  if (!parenBlob) return [];
+  return [...parenBlob.matchAll(/\(([A-Za-z0-9]+)\)/g)].map((m) => m[1]!);
+}
 
 export type ReferenceTarget =
-  | { kind: 'article'; articleNumber: number; chapterNumber: number }
+  | {
+      kind: 'article';
+      articleNumber: number;
+      chapterNumber: number;
+      /** Parsed clause path — e.g. ["3"] for "Article 144(3)" or
+       * ["3", "c"] for "Article 144(3)(c)". Top-level entry is the
+       * paragraph to scroll to / flash on arrival. Empty when the
+       * reference didn't name a clause. */
+      clauses: string[];
+    }
   | { kind: 'chapter'; chapterNumber: number };
 
 interface RenderProseOptions {
@@ -110,12 +132,13 @@ interface FoundRef {
 function findReferences(text: string): FoundRef[] {
   const out: FoundRef[] = [];
   for (const match of text.matchAll(REF_RE)) {
-    const [whole, kindWord, numStr] = match;
+    const [whole, kindWord, numStr, parenBlob] = match;
     const n = Number.parseInt(numStr!, 10);
+    const clauses = extractClauses(parenBlob);
     const start = match.index!;
     const end = start + whole.length;
     const isChapter = kindWord!.toLowerCase().startsWith('chapter');
-    out.push({ start, end, target: buildTarget(n, isChapter) });
+    out.push({ start, end, target: buildTarget(n, isChapter, clauses) });
 
     // Chain continuation: "Article 144 or 145 and 146" — each extra
     // number becomes its own clickable ref under the same kind as the
@@ -128,26 +151,37 @@ function findReferences(text: string): FoundRef[] {
       if (!cont) break;
       const sep = cont[0]!;
       const numInChain = Number.parseInt(cont[1]!, 10);
-      // The link's clickable range is just the number (and any
-      // subparagraph paren) — the " or ", ", ", " and " glue stays as
-      // plain text so the sentence still reads naturally.
+      const contClauses = extractClauses(cont[2]);
+      // The link's clickable range is just the number (+ any clause
+      // parens) — the " or ", ", ", " and " glue stays as plain text
+      // so the sentence still reads naturally.
       const numStart = cursor + sep.indexOf(cont[1]!);
       const numEnd = cursor + sep.length;
-      out.push({ start: numStart, end: numEnd, target: buildTarget(numInChain, isChapter) });
+      out.push({
+        start: numStart,
+        end: numEnd,
+        target: buildTarget(numInChain, isChapter, contClauses),
+      });
       cursor += sep.length;
     }
   }
   return out;
 }
 
-function buildTarget(n: number, isChapter: boolean): ReferenceTarget | null {
+function buildTarget(
+  n: number,
+  isChapter: boolean,
+  clauses: string[],
+): ReferenceTarget | null {
   if (isChapter) {
     return CONSTITUTION_META.some((m) => m.number === n)
       ? { kind: 'chapter', chapterNumber: n }
       : null;
   }
   const meta = findChapterForArticle(n);
-  return meta ? { kind: 'article', articleNumber: n, chapterNumber: meta.number } : null;
+  return meta
+    ? { kind: 'article', articleNumber: n, chapterNumber: meta.number, clauses }
+    : null;
 }
 
 /** Cheap case-insensitive token highlight — mirror of the old helper

--- a/frontend/components/learn/constitution/prose.tsx
+++ b/frontend/components/learn/constitution/prose.tsx
@@ -16,19 +16,30 @@ import type React from 'react';
 import { CONSTITUTION_META, findChapterForArticle } from '@/data/constitution';
 
 /**
- * Matches:
- *   - "Article 152"      → { kind: 'article', n: 152 }
- *   - "Articles 156"     → { kind: 'article', n: 156 }
- *   - "Article 152(2)"   → navigate to Art. 152; the "(2)" marker is
- *                          cosmetic — we don't jump to subparagraphs.
- *   - "Chapter 12"       → { kind: 'chapter', n: 12 }
+ * Primary match — anchors the chain on an explicit keyword:
+ *   - "Article 152"      → article 152
+ *   - "Articles 156"     → article 156 (plural form)
+ *   - "Article 152(2)"   → article 152; the "(2)" marker is cosmetic,
+ *                          we don't jump to subparagraphs.
+ *   - "Chapter 12"       → chapter 12
  *
  * Skipped by design:
  *   - clause markers like "(1)", "(a)", "sub-paragraph (i)" — these
  *     are intra-article and have no useful navigation target.
  *   - phrases like "this Constitution" — self-referential.
  */
-const REF_RE = /\b(Article|Articles|Chapter)\s+(\d+)(\([A-Za-z0-9]+\))?/g;
+const REF_RE = /\b(Article|Articles|Chapter|Chapters)\s+(\d+)(\([A-Za-z0-9]+\))?/g;
+
+/**
+ * After a primary match, prose often continues with more bare numbers
+ * joined by ", ", " or ", " and ", or some combination ("Articles 152,
+ * 154, 155 and 156"). CONTINUATION_RE eats ONE of those separators
+ * plus the next number; we apply it repeatedly until the chain breaks
+ * so every number in a list becomes clickable under the same kind as
+ * the anchor.
+ */
+const CONTINUATION_RE =
+  /^(?:,\s+and\s+|,\s*|\s+and\s+|\s+or\s+)(\d+)(?:\([A-Za-z0-9]+\))?/i;
 
 export type ReferenceTarget =
   | { kind: 'article'; articleNumber: number; chapterNumber: number }
@@ -103,21 +114,40 @@ function findReferences(text: string): FoundRef[] {
     const n = Number.parseInt(numStr!, 10);
     const start = match.index!;
     const end = start + whole.length;
-    const isChapter = kindWord!.toLowerCase() === 'chapter';
-    let target: ReferenceTarget | null = null;
-    if (isChapter) {
-      if (CONSTITUTION_META.some((m) => m.number === n)) {
-        target = { kind: 'chapter', chapterNumber: n };
-      }
-    } else {
-      const meta = findChapterForArticle(n);
-      if (meta) {
-        target = { kind: 'article', articleNumber: n, chapterNumber: meta.number };
-      }
+    const isChapter = kindWord!.toLowerCase().startsWith('chapter');
+    out.push({ start, end, target: buildTarget(n, isChapter) });
+
+    // Chain continuation: "Article 144 or 145 and 146" — each extra
+    // number becomes its own clickable ref under the same kind as the
+    // anchor. We walk the text after the primary match one continuation
+    // at a time until the chain breaks on arbitrary prose.
+    let cursor = end;
+    while (cursor < text.length) {
+      const rest = text.slice(cursor);
+      const cont = CONTINUATION_RE.exec(rest);
+      if (!cont) break;
+      const sep = cont[0]!;
+      const numInChain = Number.parseInt(cont[1]!, 10);
+      // The link's clickable range is just the number (and any
+      // subparagraph paren) — the " or ", ", ", " and " glue stays as
+      // plain text so the sentence still reads naturally.
+      const numStart = cursor + sep.indexOf(cont[1]!);
+      const numEnd = cursor + sep.length;
+      out.push({ start: numStart, end: numEnd, target: buildTarget(numInChain, isChapter) });
+      cursor += sep.length;
     }
-    out.push({ start, end, target });
   }
   return out;
+}
+
+function buildTarget(n: number, isChapter: boolean): ReferenceTarget | null {
+  if (isChapter) {
+    return CONSTITUTION_META.some((m) => m.number === n)
+      ? { kind: 'chapter', chapterNumber: n }
+      : null;
+  }
+  const meta = findChapterForArticle(n);
+  return meta ? { kind: 'article', articleNumber: n, chapterNumber: meta.number } : null;
 }
 
 /** Cheap case-insensitive token highlight — mirror of the old helper

--- a/frontend/components/learn/constitution/prose.tsx
+++ b/frontend/components/learn/constitution/prose.tsx
@@ -1,0 +1,151 @@
+/**
+ * prose.tsx — turn a Constitution paragraph into clickable JSX.
+ *
+ * Two transforms compose in a single pass so they don't fight each
+ * other and produce double-wrapped markup:
+ *   1. Cross-references — "Article 152", "Articles 154", "Chapter 12" —
+ *      become buttons that invoke the caller's navigate handler.
+ *   2. Search highlight — a case-insensitive literal match for `query`
+ *      gets wrapped in <mark>.
+ *
+ * Unknown article/chapter numbers (e.g. a typo in the JSON) are left
+ * as plain text, so we never ship a dead link.
+ */
+import type React from 'react';
+
+import { CONSTITUTION_META, findChapterForArticle } from '@/data/constitution';
+
+/**
+ * Matches:
+ *   - "Article 152"      → { kind: 'article', n: 152 }
+ *   - "Articles 156"     → { kind: 'article', n: 156 }
+ *   - "Article 152(2)"   → navigate to Art. 152; the "(2)" marker is
+ *                          cosmetic — we don't jump to subparagraphs.
+ *   - "Chapter 12"       → { kind: 'chapter', n: 12 }
+ *
+ * Skipped by design:
+ *   - clause markers like "(1)", "(a)", "sub-paragraph (i)" — these
+ *     are intra-article and have no useful navigation target.
+ *   - phrases like "this Constitution" — self-referential.
+ */
+const REF_RE = /\b(Article|Articles|Chapter)\s+(\d+)(\([A-Za-z0-9]+\))?/g;
+
+export type ReferenceTarget =
+  | { kind: 'article'; articleNumber: number; chapterNumber: number }
+  | { kind: 'chapter'; chapterNumber: number };
+
+interface RenderProseOptions {
+  query?: string;
+  onRefClick?: (target: ReferenceTarget) => void;
+}
+
+/** Single entry point — returns JSX ready to splat into a <p>. */
+export function renderProse(
+  text: string,
+  { query, onRefClick }: RenderProseOptions = {},
+): React.ReactNode {
+  const refs = findReferences(text);
+  const out: React.ReactNode[] = [];
+  let cursor = 0;
+  let key = 0;
+
+  for (const ref of refs) {
+    // Plain text before this reference — still needs search-highlight.
+    if (ref.start > cursor) {
+      out.push(
+        <span key={`t-${key++}`}>
+          {highlightSearch(text.slice(cursor, ref.start), query)}
+        </span>,
+      );
+    }
+    const label = text.slice(ref.start, ref.end);
+    if (ref.target && onRefClick) {
+      out.push(
+        <button
+          key={`r-${key++}`}
+          type='button'
+          onClick={() => onRefClick(ref.target!)}
+          className='inline rounded px-0.5 font-semibold text-gov-forest decoration-gov-forest/40 decoration-dotted underline-offset-2 hover:bg-gov-forest/5 hover:underline focus:outline-none focus:ring-2 focus:ring-gov-forest/30'>
+          {highlightSearch(label, query)}
+        </button>,
+      );
+    } else {
+      // Unknown article/chapter number — render as plain text so we
+      // never ship a button that goes nowhere.
+      out.push(
+        <span key={`u-${key++}`}>{highlightSearch(label, query)}</span>,
+      );
+    }
+    cursor = ref.end;
+  }
+  if (cursor < text.length) {
+    out.push(
+      <span key={`tail-${key++}`}>
+        {highlightSearch(text.slice(cursor), query)}
+      </span>,
+    );
+  }
+  return <>{out}</>;
+}
+
+/* ── internals ── */
+
+interface FoundRef {
+  start: number;
+  end: number;
+  target: ReferenceTarget | null;
+}
+
+function findReferences(text: string): FoundRef[] {
+  const out: FoundRef[] = [];
+  for (const match of text.matchAll(REF_RE)) {
+    const [whole, kindWord, numStr] = match;
+    const n = Number.parseInt(numStr!, 10);
+    const start = match.index!;
+    const end = start + whole.length;
+    const isChapter = kindWord!.toLowerCase() === 'chapter';
+    let target: ReferenceTarget | null = null;
+    if (isChapter) {
+      if (CONSTITUTION_META.some((m) => m.number === n)) {
+        target = { kind: 'chapter', chapterNumber: n };
+      }
+    } else {
+      const meta = findChapterForArticle(n);
+      if (meta) {
+        target = { kind: 'article', articleNumber: n, chapterNumber: meta.number };
+      }
+    }
+    out.push({ start, end, target });
+  }
+  return out;
+}
+
+/** Cheap case-insensitive token highlight — mirror of the old helper
+ * inside ArticleViewer. Kept here so prose rendering is a single pass. */
+function highlightSearch(text: string, query?: string): React.ReactNode {
+  if (!query || query.length < 2) return text;
+  const q = query.trim();
+  if (!q) return text;
+  const lower = text.toLowerCase();
+  const needle = q.toLowerCase();
+  const out: React.ReactNode[] = [];
+  let i = 0;
+  let n = 0;
+  while (i < text.length) {
+    const j = lower.indexOf(needle, i);
+    if (j === -1) {
+      out.push(text.slice(i));
+      break;
+    }
+    if (j > i) out.push(text.slice(i, j));
+    out.push(
+      <mark
+        key={`h-${n++}`}
+        className='rounded bg-gov-gold/30 px-0.5 text-gov-dark'>
+        {text.slice(j, j + q.length)}
+      </mark>,
+    );
+    i = j + q.length;
+  }
+  return <>{out}</>;
+}

--- a/frontend/components/learn/constitution/prose.tsx
+++ b/frontend/components/learn/constitution/prose.tsx
@@ -48,10 +48,19 @@ const REF_RE =
 const CONTINUATION_RE =
   /^(?:,\s+and\s+|,\s*|\s+and\s+|\s+or\s+)(\d+)((?:\([A-Za-z0-9]+\))*)/i;
 
-/** Turn a captured "(2)(a)" blob into ['2', 'a']. Empty string → []. */
+/** Turn a captured "(2)(a)" blob into ['2', 'a']. Empty string → [].
+ * Uses an exec loop rather than [...matchAll(...)] because this repo's
+ * tsconfig target doesn't include downlevelIteration support for the
+ * RegExpStringIterator return type. */
 function extractClauses(parenBlob: string | undefined): string[] {
   if (!parenBlob) return [];
-  return [...parenBlob.matchAll(/\(([A-Za-z0-9]+)\)/g)].map((m) => m[1]!);
+  const out: string[] = [];
+  const re = /\(([A-Za-z0-9]+)\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(parenBlob)) !== null) {
+    out.push(m[1]!);
+  }
+  return out;
 }
 
 export type ReferenceTarget =
@@ -131,11 +140,16 @@ interface FoundRef {
 
 function findReferences(text: string): FoundRef[] {
   const out: FoundRef[] = [];
-  for (const match of text.matchAll(REF_RE)) {
+  // exec-loop rather than for...of on matchAll — see extractClauses
+  // for the tsconfig rationale. Clone the regex so the shared /g
+  // state at module level doesn't carry lastIndex across calls.
+  const re = new RegExp(REF_RE.source, REF_RE.flags);
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
     const [whole, kindWord, numStr, parenBlob] = match;
     const n = Number.parseInt(numStr!, 10);
     const clauses = extractClauses(parenBlob);
-    const start = match.index!;
+    const start = match.index;
     const end = start + whole.length;
     const isChapter = kindWord!.toLowerCase().startsWith('chapter');
     out.push({ start, end, target: buildTarget(n, isChapter, clauses) });


### PR DESCRIPTION
## Summary
Turns the plain-text "Article N" / "Chapter N" mentions inside the Constitution reader into a navigable, scope-aware cross-reference system. Five commits, all on top of main after PR #66 merged.

### What changed

1. **Clickable refs in prose** ([05faa6c](https://github.com/Rodgers31/audit_app/commit/05faa6c)) — A new `renderProse()` helper detects \`Article N\`, \`Articles N\`, \`Chapter N\` patterns (with optional \`(subparagraph)\` markers) and renders each as an in-text button that navigates. Unknown article/chapter numbers stay as plain text so JSON typos never ship a dead link. A "Back to Article X" pill appears in the viewer header whenever the reader is mid-chain, with a small history stack so backtracking across 3–4 hops works cleanly. Self-references and sidebar/keyboard nav don't push history.

2. **Multi-number lists + initial arrival flash** ([3b73cb1](https://github.com/Rodgers31/audit_app/commit/3b73cb1)) — Text like "Article 144 or 145" or "Articles 152, 154, 155 and 156" now makes *every* number clickable, not just the first. After the primary match, a continuation regex walks forward eating \`", N"\`, \`" or N"\`, \`" and N"\` separators under the same kind as the anchor. Plus a soft-yellow flash on the arrival article so the reader gets visual confirmation they landed on the right thing.

3. **Flash fix: body, not header** ([45ff204](https://github.com/Rodgers31/audit_app/commit/45ff204)) — Initial flash landed on the chapter chip/title header; misread the ask. Moved to the paragraphs container so the highlight sits on the text the reader came to read. Switched to solid \`rgb(254, 249, 195)\` (yellow-100) because the previous translucent amber was getting washed out by a \`bg-white/70\` parent backdrop.

4. **Clause-scoped flash** ([54ef647](https://github.com/Rodgers31/audit_app/commit/54ef647)) — Whole-article flash was too broad. When a reference carries a clause path like "Article 142(2)" or "Article 136(2)(a)", only the paragraph whose leading "(X)" marker matches flashes. Plain "Article 144" refs now produce **no** body flash — the page switch is itself the feedback. Requires parser to capture clause arrays \`["2"]\` or \`["2","a"]\` and thread them through to the viewer.

5. **Short-article scroll bug** ([f1ae46b](https://github.com/Rodgers31/audit_app/commit/f1ae46b)) — \`scrollIntoView({ block: 'start' })\` was scrolling the outer page when the inner \`overflow-y-auto\` container couldn't scroll (short articles like Article 136 with only 2 paragraphs fit entirely within the body). Switched to \`block: 'nearest'\` so short articles pass through untouched and long articles only scroll when the target clause is below the fold.

## Test plan
- [ ] Open /learn, scroll to the Constitution reader, open Chapter 9 Article 146.
- [ ] Every reference in the prose is clickable: "Article 144", "145" (bare, after "or"), "Article 136", "Article 142(2)".
- [ ] Clicking "Article 142(2)" → viewer navigates to Art. 142, **only** paragraph (2) flashes yellow; paragraph (1) stays transparent.
- [ ] "Back to Article 146" pill appears in header; clicking it returns cleanly.
- [ ] Clicking plain "Article 144" from Article 146 → navigates, **no** paragraph highlights.
- [ ] Clicking a clause ref to a short article (e.g. any ref to Article 136) → the outer page does **not** scroll down, article stays in place.
- [ ] Multi-hop: 146 → 144 → back → 142 → back — each hop pushes/pops the pill correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)