### PR TITLE
fix(seeding): 3 layers of protection against a single-domain stall

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -242,6 +242,13 @@ jobs:
 
       - name: Seed all domains
         if: github.event.inputs.domain == '' || github.event.inputs.domain == null
+        # Step-level cap below the job's 30-min timeout so the
+        # 'Check ingestion job results' step downstream (which runs on
+        # `if: always()`) still has room to persist partial-run data
+        # before the runner is torn down. Combined with the per-domain
+        # timeout in seeding/cli.py, a single stuck domain no longer
+        # swallows the whole nightly window.
+        timeout-minutes: 25
         run: |
           cd backend
           python -m seeding.cli seed --all ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}

--- a/backend/seeding/cli.py
+++ b/backend/seeding/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import signal
 import sys
+import threading
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -62,16 +63,29 @@ def _domain_timeout(seconds: int) -> Iterator[None]:
 
     Uses POSIX SIGALRM so the timeout actually kills Python-level work
     (including `time.sleep`, `httpx` connect/read, and pdfplumber between
-    its Python frames). Only installs the handler when we're on the main
-    thread of a POSIX system — the seeding CLI always is in CI, but the
-    guard keeps pytest runs on Windows / non-main-threads graceful.
+    its Python frames). Three preconditions must hold to install the
+    handler; if any fail we silently yield without a timeout so callers
+    in unsupported contexts degrade gracefully:
+
+      * `seconds > 0`
+      * SIGALRM exists (POSIX only — Windows has no equivalent)
+      * we are on the main thread (CPython's `signal.signal` raises
+        ValueError otherwise, which would crash rather than degrade).
+
+    The seeding CLI always runs in the main thread in CI; the main-
+    thread guard is there for pytest and embedded-runner scenarios
+    that invoke the CLI from a worker thread.
 
     Caveat: code stuck in a blocking C extension call that never yields
     to Python (e.g. some tabula JVM bridge calls) won't be interruptible
     until it returns. In practice SIGALRM catches most real-world stalls
     we've seen.
     """
-    if seconds <= 0 or not hasattr(signal, "SIGALRM"):
+    if (
+        seconds <= 0
+        or not hasattr(signal, "SIGALRM")
+        or threading.current_thread() is not threading.main_thread()
+    ):
         yield
         return
 

--- a/backend/seeding/cli.py
+++ b/backend/seeding/cli.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import argparse
+import signal
 import sys
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Optional, Sequence
+from typing import Iterable, Iterator, Optional, Sequence
 
 from dotenv import load_dotenv
 
@@ -48,6 +50,43 @@ def _collect_domains(requested: Iterable[str], include_all: bool) -> Sequence[st
     if unknown:
         raise ValueError(f"Unknown domain(s) requested: {', '.join(sorted(unknown))}")
     return domains
+
+
+class DomainTimeoutError(RuntimeError):
+    """Raised when a single domain handler exceeds its time budget."""
+
+
+@contextmanager
+def _domain_timeout(seconds: int) -> Iterator[None]:
+    """Abort the wrapped block with DomainTimeoutError after `seconds`.
+
+    Uses POSIX SIGALRM so the timeout actually kills Python-level work
+    (including `time.sleep`, `httpx` connect/read, and pdfplumber between
+    its Python frames). Only installs the handler when we're on the main
+    thread of a POSIX system — the seeding CLI always is in CI, but the
+    guard keeps pytest runs on Windows / non-main-threads graceful.
+
+    Caveat: code stuck in a blocking C extension call that never yields
+    to Python (e.g. some tabula JVM bridge calls) won't be interruptible
+    until it returns. In practice SIGALRM catches most real-world stalls
+    we've seen.
+    """
+    if seconds <= 0 or not hasattr(signal, "SIGALRM"):
+        yield
+        return
+
+    def _handler(signum, frame):  # pragma: no cover - signal path
+        raise DomainTimeoutError(
+            f"domain exceeded {seconds}s budget; aborted by the CLI"
+        )
+
+    previous = signal.signal(signal.SIGALRM, _handler)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous)
 
 
 def _ensure_db_sessionlocal() -> None:
@@ -114,7 +153,13 @@ def run_seed_command(args: argparse.Namespace, settings: SeedingSettings) -> int
 
                 context = DomainRunContext(since=since, dry_run=dry_run, job_id=job_id)
 
-                result = handler(session=session, settings=settings, context=context)
+                # Per-domain timeout so one stuck domain (e.g. a stalled
+                # PDF parse in counties_budget) can't take down the whole
+                # `seed --all` run. Falls through to the except below,
+                # which rolls back the session, marks the job FAILED,
+                # and lets the outer loop move to the next domain.
+                with _domain_timeout(settings.domain_timeout_seconds):
+                    result = handler(session=session, settings=settings, context=context)
 
                 # Update job with results
                 job.finished_at = datetime.now(timezone.utc)

--- a/backend/seeding/cli.py
+++ b/backend/seeding/cli.py
@@ -164,6 +164,13 @@ def run_seed_command(args: argparse.Namespace, settings: SeedingSettings) -> int
                 session.add(job)
                 session.flush()
                 job_id = job.id
+                # Commit the RUNNING record immediately so it survives a
+                # later session.rollback() (e.g. on DomainTimeoutError or
+                # any other handler exception). Without this commit the
+                # job insert is inside the same transaction as the handler
+                # work, so rollback erases it and error_session.get(…)
+                # returns None, leaving no trace of the failed domain run.
+                session.commit()
 
                 context = DomainRunContext(since=since, dry_run=dry_run, job_id=job_id)
 
@@ -191,10 +198,44 @@ def run_seed_command(args: argparse.Namespace, settings: SeedingSettings) -> int
                     job.status = IngestionStatus.COMPLETED
 
                 if dry_run:
+                    finished_at_dry = datetime.now(timezone.utc)
                     session.rollback()
                     logger.info(
                         "Dry run - rolled back all changes", extra={"domain": domain}
                     )
+                    # The rollback above also undoes the in-flight job status
+                    # update (job was committed as RUNNING before the handler
+                    # ran). Persist the final status in a separate session so
+                    # the record doesn't stay orphaned in RUNNING state.
+                    if job_id:
+                        final_status = (
+                            IngestionStatus.COMPLETED_WITH_ERRORS
+                            if result and result.errors
+                            else IngestionStatus.COMPLETED
+                        )
+                        try:
+                            with SessionLocal() as status_session:
+                                dry_job = status_session.get(IngestionJob, job_id)
+                                if dry_job:
+                                    dry_job.status = final_status
+                                    dry_job.finished_at = finished_at_dry
+                                    dry_job.items_processed = (
+                                        result.items_processed if result else 0
+                                    )
+                                    dry_job.items_created = (
+                                        result.items_created if result else 0
+                                    )
+                                    dry_job.items_updated = (
+                                        result.items_updated if result else 0
+                                    )
+                                    dry_job.errors = result.errors if result else []
+                                    status_session.commit()
+                        except Exception:  # pragma: no cover - best-effort
+                            logger.warning(
+                                "Failed to update dry-run job status",
+                                extra={"domain": domain, "job_id": job_id},
+                                exc_info=True,
+                            )
                 else:
                     session.commit()
                     logger.info(

--- a/backend/seeding/config.py
+++ b/backend/seeding/config.py
@@ -23,6 +23,15 @@ class SeedingSettings(BaseSettings):
         default=30.0,
         description="HTTP request timeout in seconds for upstream fetches.",
     )
+    # Hard cap on how long a single domain handler may run before the CLI
+    # aborts it and moves to the next domain. Protects `seed --all` from
+    # a single stuck domain (e.g. counties_budget blocking on a slow PDF
+    # parse) eating the whole nightly window. 10 min is generous — the
+    # slowest healthy domain runs in ~5 min.
+    domain_timeout_seconds: int = Field(
+        default=600,
+        description="Per-domain hard timeout; aborts one domain without killing the run.",
+    )
     max_retries: int = Field(
         default=3, description="Maximum retry attempts for transient HTTP failures."
     )

--- a/backend/seeding/config.py
+++ b/backend/seeding/config.py
@@ -30,6 +30,7 @@ class SeedingSettings(BaseSettings):
     # slowest healthy domain runs in ~5 min.
     domain_timeout_seconds: int = Field(
         default=600,
+        ge=1,
         description="Per-domain hard timeout; aborts one domain without killing the run.",
     )
     max_retries: int = Field(

--- a/backend/seeding/domains/counties_budget/fetcher.py
+++ b/backend/seeding/domains/counties_budget/fetcher.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 import re
 import tempfile
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urljoin
@@ -398,12 +399,20 @@ def _download_and_parse_county_pdf(
             "User-Agent": _BROWSER_UA,
             "Accept": "application/pdf,*/*;q=0.8",
         }
+        # Explicit phase logging — this domain stalled in CI without any
+        # signal between fetch-start and job timeout, so we couldn't tell
+        # whether the CDN was slow or the parser hung. The download and
+        # parse lines below bracket each phase and time them so future
+        # stalls point at the real culprit.
+        logger.info("Starting COB county BIRR PDF download: %s", pdf_url)
+        download_start = time.monotonic()
         response = client.get(
             pdf_url,
             raise_for_status=True,
             headers=pdf_headers,
             timeout=180.0,
         )
+        download_elapsed = time.monotonic() - download_start
 
         with tempfile.NamedTemporaryFile(
             suffix=".pdf", delete=False, prefix="cob_county_birr_"
@@ -412,13 +421,22 @@ def _download_and_parse_county_pdf(
             tmp_path = Path(tmp.name)
 
         logger.info(
-            "Downloaded COB county BIRR PDF (%d bytes) to %s",
+            "Downloaded COB county BIRR PDF (%d bytes, %.1fs) to %s",
             len(response.content),
+            download_elapsed,
             tmp_path,
         )
 
+        logger.info("Parsing COB county BIRR PDF: %s", tmp_path)
+        parse_start = time.monotonic()
         parser = CoBQuarterlyReportParser(tmp_path)
         parsed_records = parser.parse()
+        parse_elapsed = time.monotonic() - parse_start
+        logger.info(
+            "Parsed COB county BIRR PDF (%d records, %.1fs)",
+            len(parsed_records) if parsed_records else 0,
+            parse_elapsed,
+        )
 
         if not parsed_records:
             logger.warning("CoBQuarterlyReportParser returned no records")


### PR DESCRIPTION
## Context
Last night's scheduled seeding run ([24870363825](https://github.com/Rodgers31/audit_app/actions/runs/24870363825)) hit the job's 30-min hard timeout after \`counties_budget\` stalled for ~24 minutes with zero log output between the COB index fetch and the next expected line. Every domain after it (\`imf_weo\`, \`budgets\`, \`population\`, \`economic_indicators\`…) never got to run because \`seed --all\` runs domains sequentially in one Python process.

## Fixes — three independent layers

### 1. Per-domain \`SIGALRM\` timeout (the real fix)
New \`_domain_timeout(seconds)\` context manager in [seeding/cli.py](backend/seeding/cli.py) wraps the handler call inside \`run_seed_command\`. If a domain exceeds the budget (default **600s / 10 min**, configurable via \`SeedingSettings.domain_timeout_seconds\`), the alarm fires a \`DomainTimeoutError\`. The existing \`except\` block catches it — session rolled back, \`IngestionJob\` row marked FAILED, outer loop moves to the next domain. One stuck domain no longer cascades.

POSIX-only guard around \`signal.SIGALRM\` so non-POSIX environments (pytest on Windows) don't blow up; CI runs on \`ubuntu-latest\`.

### 2. Phase logging in \`_download_and_parse_county_pdf\`
Added \"Starting download → Downloaded (N bytes, Xs) → Parsing → Parsed (M records, Ys)\" with \`time.monotonic()\` around both phases. Next time \`counties_budget\` stalls we'll know whether it's the slow CDN or \`pdfplumber\`/\`tabula\`.

### 3. Step-level \`timeout-minutes: 25\`
On the \`Seed all domains\` step in [.github/workflows/seed.yml](.github/workflows/seed.yml). Leaves 5 min of headroom under the job's 30-min cap so the downstream \"Check ingestion job results\" step (which runs on \`if: always()\`) still has room to persist partial-run data.

## Orthogonal note
The audits domain emitted 6 warnings in the same run: \`Unknown entity slug 'murang'a-county'\`. The apostrophe in Murang'a is breaking the slug lookup. Not fixed here — worth a small follow-up PR.

## Test plan
- [ ] Merge → manually trigger the 'Database Seeding & Data Refresh' workflow.
- [ ] Confirm \`counties_budget\` logs now include \"Starting download\" / \"Parsing\" / \"Parsed\" lines on a normal run.
- [ ] (Optional) Flip \`SEED_DOMAIN_TIMEOUT_SECONDS=5\` in env via workflow override to force a timeout and confirm the CLI logs the abort, marks the job FAILED, and continues to the next domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)