### PR TITLE
fix(seeding/counties_budget): bulk upsert + robust WP-REST PDF selection

### DIFF
--- a/backend/seeding/domains/counties_budget/fetcher.py
+++ b/backend/seeding/domains/counties_budget/fetcher.py
@@ -187,10 +187,20 @@ def _discover_latest_county_birr_via_wp_api(
 ) -> Optional[str]:
     """Query the COB WordPress REST API for the latest county BIRR PDF.
 
-    The endpoint returns a JSON array of media items ordered newest-first.
-    We pick the first record whose title or filename matches a county
-    keyword. This avoids the HTML-scraping fragility and the 415/000
-    rejections we've seen from the CDN in front of the landing pages.
+    We can't blindly trust the API's `orderby=date&order=desc` or the
+    first "county" keyword match: empirically (CI run 24901989493) it
+    surfaced a 2015 single-county file as the "latest", which also
+    returned 404 because the CDN no longer hosts it. So:
+
+      1. Pull up to 100 PDFs (the API default cap).
+      2. Score each candidate by specificity — the *consolidated*
+         county BIRR is what we actually want, not ad-hoc single-
+         county files from years ago. Stronger keywords win.
+      3. Sort ourselves by (score desc, parsed date desc) to avoid
+         WordPress-plugin ordering quirks.
+      4. HEAD-probe each candidate in order; return the first 200.
+         Skipping 404s / 4xx / 5xx means a stale link in the API
+         feed no longer poisons the whole seeding run.
     """
     api_url = getattr(
         settings,
@@ -218,42 +228,101 @@ def _discover_latest_county_birr_via_wp_api(
         )
         return None
 
-    # Items are pre-sorted by upload date desc; pick the first county-
-    # related PDF. Fall back to the newest PDF overall if no keyword
-    # match — the downstream parser will reject non-BIRR documents by
-    # structure rather than by URL shape.
-    def _is_county(item: Dict[str, Any]) -> bool:
+    # Score reflects how specifically the filename/title screams "the
+    # consolidated, most-recent-BIRR-for-all-counties PDF". The same
+    # signal set as before is still used, but weighted — plain "county"
+    # alone is a weak hint; "consolidated" + "BIRR" + a FY marker win.
+    def _score(item: Dict[str, Any]) -> int:
         title = (item.get("title") or {}).get("rendered", "") or ""
         slug = item.get("slug") or ""
         source = item.get("source_url") or ""
         haystack = f"{title} {slug} {source}".lower()
-        return any(kw in haystack for kw in _COUNTY_PDF_KEYWORDS)
+        if not any(kw in haystack for kw in _COUNTY_PDF_KEYWORDS):
+            return 0
+        score = 1  # baseline for any county match
+        if "consolidated" in haystack:
+            score += 5
+        if "c-birr" in haystack or "cbirr" in haystack:
+            score += 3
+        if "budget-implementation-review" in haystack or "birr" in haystack:
+            score += 2
+        # FY markers — prefer recent years strongly.
+        # Matches "2024-25", "2024/25", "fy-2024-25", "fy2024-25", etc.
+        fy_match = re.search(r"(20\d{2})[-/](\d{2,4})", haystack)
+        if fy_match:
+            score += 1
+            year = int(fy_match.group(1))
+            # Give very recent fiscal years an extra nudge.
+            score += max(0, year - 2020)
+        return score
 
-    county_items = [i for i in items if isinstance(i, dict) and _is_county(i)]
-    chosen = county_items[0] if county_items else None
-    if chosen is None:
+    def _parsed_date(item: Dict[str, Any]) -> str:
+        # Fall back to empty string so sort is stable for items missing
+        # the field (they'll rank last).
+        return item.get("date") or ""
+
+    scored = [
+        (s, _parsed_date(i), i)
+        for i in items
+        if isinstance(i, dict) and (s := _score(i)) > 0
+    ]
+    if not scored:
         logger.warning(
             "COB WP REST API returned %d PDFs but none matched county keywords",
             len(items),
         )
         return None
+    scored.sort(key=lambda t: (t[0], t[1]), reverse=True)
 
-    source_url = chosen.get("source_url")
-    if not isinstance(source_url, str) or not source_url.lower().endswith(".pdf"):
-        logger.warning(
-            "COB WP REST API chose an item without a usable source_url: %r",
-            chosen.get("id"),
+    # Liveness probe candidates in order, skipping 404s / 4xx / 5xx.
+    # Keeps the failure mode of a stale feed entry (common with the
+    # COB WP-Download-Manager plugin's orphaned links) local: one bad
+    # URL just moves us on to the next candidate instead of poisoning
+    # the whole domain run.
+    head_headers = {
+        "User-Agent": _BROWSER_UA,
+        "Accept": "application/pdf,*/*;q=0.8",
+    }
+    for score, date, item in scored[:10]:
+        source_url = item.get("source_url")
+        if not isinstance(source_url, str) or not source_url.lower().endswith(".pdf"):
+            continue
+        try:
+            head = client.head(
+                source_url,
+                raise_for_status=False,
+                headers=head_headers,
+                timeout=20.0,
+            )
+        except Exception as exc:
+            logger.info(
+                "Candidate %s HEAD failed (%s); trying next",
+                source_url,
+                exc,
+            )
+            continue
+        if head.status_code >= 400:
+            logger.info(
+                "Candidate %s returned HTTP %d; trying next",
+                source_url,
+                head.status_code,
+            )
+            continue
+        title = (item.get("title") or {}).get("rendered", "")
+        logger.info(
+            "COB WP REST API selected BIRR PDF: %s (date=%s, score=%d, title=%r)",
+            source_url,
+            date,
+            score,
+            title,
         )
-        return None
+        return source_url
 
-    title = (chosen.get("title") or {}).get("rendered", "")
-    logger.info(
-        "COB WP REST API selected BIRR PDF: %s (date=%s, title=%r)",
-        source_url,
-        chosen.get("date"),
-        title,
+    logger.warning(
+        "COB WP REST API: %d scored candidates but none passed HEAD probe",
+        len(scored),
     )
-    return source_url
+    return None
 
 
 def _discover_latest_county_birr_via_html(

--- a/backend/seeding/domains/counties_budget/writer.py
+++ b/backend/seeding/domains/counties_budget/writer.py
@@ -201,36 +201,191 @@ def persist_budget_records(
     settings: SeedingSettings,
     context: DomainRunContext,
 ) -> PersistenceStats:
+    """Upsert a batch of budget records.
+
+    Performance-critical: previously this ran the SELECT-then-upsert
+    sequence ONCE PER RECORD (4 round-trips × N records). Against a
+    remote Supabase at ~150 ms RTT that blew past the per-domain 10-min
+    budget on fixture-scale inputs. The rewrite preloads all lookups
+    in four bulk queries and resolves per-record work in-memory, so
+    total DB round-trips for N records are O(1) + a single final flush.
+    """
+    from ...utils import normalize_fiscal_label
+
     stats = PersistenceStats()
+    records = list(records)
+    stats.processed = len(records)
+    if not records:
+        return stats
 
+    # ── 1. Bulk-load entities ────────────────────────────────────
+    entity_slugs = {r.entity_slug for r in records}
+    entities_by_slug: dict[str, Entity] = {}
+    if entity_slugs:
+        rows = session.execute(
+            select(Entity).where(Entity.slug.in_(entity_slugs))
+        ).scalars().all()
+        entities_by_slug = {e.slug: e for e in rows}
+
+    # Drop records whose entity we can't resolve; surface once-each.
+    resolvable: List[BudgetRecord] = []
+    unknown_slugs_reported: set[str] = set()
     for record in records:
-        stats.processed += 1
-
-        entity, error = _resolve_entity(session, record)
-        if error:
-            stats.errors.append(error)
-            stats.skipped += 1
+        if record.entity_slug in entities_by_slug:
+            resolvable.append(record)
             continue
-        assert entity is not None
+        stats.skipped += 1
+        msg = f"Unknown entity slug '{record.entity_slug}'"
+        stats.errors.append(msg)
+        if record.entity_slug not in unknown_slugs_reported:
+            logger.warning(msg, extra={"entity_slug": record.entity_slug})
+            unknown_slugs_reported.add(record.entity_slug)
 
-        source = _ensure_source_document(session, entity.country_id, settings, record)
-        period = _ensure_period(session, entity.country_id, record)
+    if not resolvable:
+        return stats
 
-        stmt = select(BudgetLine).where(
-            and_(
-                BudgetLine.entity_id == entity.id,
-                BudgetLine.period_id == period.id,
-                BudgetLine.category == record.category,
-                BudgetLine.subcategory == record.subcategory,
-            )
+    now = datetime.now(timezone.utc)
+
+    # ── 2. Bulk-load + touch source documents ────────────────────
+    # SourceDocument is keyed by url. One query for everything we'll
+    # reference; meta/title refreshes happen in-memory per-record so
+    # the "latest record wins" semantics of the old code are preserved.
+    urls = {
+        (r.source_url or settings.budgets_dataset_url) for r in resolvable
+    }
+    existing_sources = {
+        s.url: s
+        for s in session.execute(
+            select(SourceDocument).where(SourceDocument.url.in_(urls))
         )
-        existing = session.execute(stmt).scalar_one_or_none()
+        .scalars()
+        .all()
+    }
+    sources_by_url: dict[str, SourceDocument] = {}
+    for record in resolvable:
+        url = record.source_url or settings.budgets_dataset_url
+        source = sources_by_url.get(url) or existing_sources.get(url)
+
+        if source is None:
+            entity = entities_by_slug[record.entity_slug]
+            initial_meta: dict = {}
+            if record.dataset_id:
+                initial_meta["dataset_id"] = record.dataset_id
+            if record.data_quality and record.data_quality != "unknown":
+                initial_meta["data_quality"] = record.data_quality
+            if record.source_label:
+                initial_meta["source_label"] = record.source_label
+            source = SourceDocument(
+                country_id=entity.country_id,
+                publisher="Controller of Budget",
+                title=record.source_label or settings.dataset_title("budgets"),
+                url=url,
+                file_path=None,
+                fetch_date=now,
+                doc_type=DocumentType.BUDGET,
+                md5=None,
+                meta=initial_meta,
+            )
+            session.add(source)
+        else:
+            meta = dict(source.meta or {})
+            if record.dataset_id and "dataset_id" not in meta:
+                meta["dataset_id"] = record.dataset_id
+            # Latest-wins: re-seeds with real COB data should upgrade
+            # a prior "estimated" fixture row to "official".
+            if record.data_quality and record.data_quality != "unknown":
+                meta["data_quality"] = record.data_quality
+            if record.source_label:
+                meta["source_label"] = record.source_label
+                source.title = record.source_label
+            source.meta = meta
+
+        source.status = DocumentStatus.AVAILABLE
+        source.last_seen_at = now
+        sources_by_url[url] = source
+
+    # ── 3. Bulk-load + ensure fiscal periods ─────────────────────
+    # Compose the set of (country_id, canonical_label) pairs we need.
+    period_keys: set[Tuple[int, str]] = set()
+    for record in resolvable:
+        entity = entities_by_slug[record.entity_slug]
+        period_keys.add(
+            (entity.country_id, normalize_fiscal_label(record.period_label))
+        )
+
+    existing_periods: dict[Tuple[int, str], FiscalPeriod] = {}
+    if period_keys:
+        country_ids = {cid for cid, _ in period_keys}
+        labels = {lbl for _, lbl in period_keys}
+        rows = session.execute(
+            select(FiscalPeriod).where(
+                FiscalPeriod.country_id.in_(country_ids),
+                FiscalPeriod.label.in_(labels),
+            )
+        ).scalars().all()
+        existing_periods = {(p.country_id, p.label): p for p in rows}
+
+    periods_by_key: dict[Tuple[int, str], FiscalPeriod] = {}
+    for record in resolvable:
+        entity = entities_by_slug[record.entity_slug]
+        canonical = normalize_fiscal_label(record.period_label)
+        key = (entity.country_id, canonical)
+        if key in periods_by_key:
+            continue
+        period = existing_periods.get(key)
+        if period is None:
+            period = FiscalPeriod(
+                country_id=entity.country_id,
+                label=canonical,
+                start_date=datetime.combine(
+                    record.start_date, time.min, tzinfo=timezone.utc
+                ),
+                end_date=datetime.combine(
+                    record.end_date, time.max, tzinfo=timezone.utc
+                ),
+            )
+            session.add(period)
+        periods_by_key[key] = period
+
+    # Flush so new SourceDocuments and FiscalPeriods get primary keys
+    # before we reference them in BudgetLines below.
+    session.flush()
+
+    # ── 4. Bulk-load existing BudgetLines by (entity, period) ────
+    # Over-selects if records only cover a subset of entity×period
+    # combos, but typical run is ~47 counties × ~3 FYs × ~20 categories
+    # ≈ a few thousand rows — trivial compared with what we avoid.
+    entity_ids = {entities_by_slug[r.entity_slug].id for r in resolvable}
+    period_ids = {
+        periods_by_key[
+            (
+                entities_by_slug[r.entity_slug].country_id,
+                normalize_fiscal_label(r.period_label),
+            )
+        ].id
+        for r in resolvable
+    }
+    existing_lines: dict[Tuple[int, int, str, Optional[str]], BudgetLine] = {}
+    if entity_ids and period_ids:
+        rows = session.execute(
+            select(BudgetLine).where(
+                BudgetLine.entity_id.in_(entity_ids),
+                BudgetLine.period_id.in_(period_ids),
+            )
+        ).scalars().all()
+        existing_lines = {
+            (l.entity_id, l.period_id, l.category, l.subcategory): l for l in rows
+        }
+
+    # ── 5. Resolve every record against the in-memory dicts ──────
+    for record in resolvable:
+        entity = entities_by_slug[record.entity_slug]
+        url = record.source_url or settings.budgets_dataset_url
+        source = sources_by_url[url]
+        canonical = normalize_fiscal_label(record.period_label)
+        period = periods_by_key[(entity.country_id, canonical)]
 
         currency = record.currency or settings.budget_default_currency
-        # April-2026: every provenance entry carries data_quality so the
-        # /budget/overview trust probe can read it back without joining
-        # through SourceDocument. Also captured: free-text source_label
-        # (for human-readable attribution) and the ingestion job id.
         provenance_entry: dict[str, object] = {}
         if record.dataset_id:
             provenance_entry["dataset_id"] = record.dataset_id
@@ -243,6 +398,8 @@ def persist_budget_records(
         provenance_entry["ingested_at"] = datetime.now(timezone.utc).isoformat()
 
         record_hash = _record_hash(record, currency)
+        key = (entity.id, period.id, record.category, record.subcategory)
+        existing = existing_lines.get(key)
 
         if existing is None:
             line = BudgetLine(
@@ -260,6 +417,7 @@ def persist_budget_records(
                 source_hash=record_hash,
             )
             session.add(line)
+            existing_lines[key] = line  # guard duplicates within the batch
             stats.created += 1
         else:
             if _apply_line(existing, record, currency, source.id, record_hash):
@@ -272,8 +430,7 @@ def persist_budget_records(
 
             if provenance_entry:
                 provenance = list(existing.provenance or [])
-                # Dedupe on the non-timestamp keys so re-seeds don't
-                # bloat the array with identical entries each cron run.
+
                 def _dedupe_key(e: dict) -> tuple:
                     return (
                         e.get("dataset_id"),

--- a/backend/tests/test_counties_budget_fetcher.py
+++ b/backend/tests/test_counties_budget_fetcher.py
@@ -73,8 +73,10 @@ class TestWpApiDiscovery:
     newest county-tagged PDF."""
 
     def test_picks_newest_county_pdf_from_api(self, settings):
-        """The API returns items date-desc; fetcher should take the
-        first one whose title or URL looks county-related."""
+        """The API returns items date-desc; fetcher should pick the
+        best-scoring county-related PDF that also responds 200 to a
+        HEAD probe (the liveness check guards against stale feed
+        entries — cf. prod bug where a 2015 404'd link was chosen)."""
         captured_requests: List[httpx.Request] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -113,6 +115,10 @@ class TestWpApiDiscovery:
                 return httpx.Response(
                     200, json=body, request=request
                 )
+            # HEAD probes of PDF URLs: report 200 so the liveness
+            # check accepts the chosen candidate.
+            if request.method == "HEAD" and request.url.path.endswith(".pdf"):
+                return httpx.Response(200, request=request)
             # Any other URL is unexpected — force an obvious failure
             return httpx.Response(500, request=request)
 
@@ -161,6 +167,69 @@ class TestWpApiDiscovery:
                 client, settings
             )
         assert url is None
+
+    def test_falls_through_when_top_candidate_404s(self, settings):
+        """Regression: CI run 24901989493 returned a 2015 Makueni file
+        as 'latest' and that URL had since been removed from the CDN,
+        returning 404. The selector must HEAD-probe candidates in
+        rank order and skip dead ones, falling through to a live
+        alternate rather than poisoning the whole domain run."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if "wp-json/wp/v2/media" in request.url.path:
+                return httpx.Response(
+                    200,
+                    json=_wp_api_payload(
+                        [
+                            # Top-ranked by score (consolidated + c-birr)
+                            # but the CDN has since deleted it.
+                            {
+                                "id": 50,
+                                "date": "2025-04-01T00:00:00",
+                                "slug": "consolidated-county-birr-fy2025-26",
+                                "title": {
+                                    "rendered": "Consolidated County BIRR FY2025/26"
+                                },
+                                "mime_type": "application/pdf",
+                                "source_url": (
+                                    "https://cob.go.ke/wp-content/uploads/"
+                                    "2025/04/stale.pdf"
+                                ),
+                            },
+                            # Lower score (only matches "county") but
+                            # still alive — should be returned after
+                            # the first candidate 404s.
+                            {
+                                "id": 40,
+                                "date": "2025-03-01T00:00:00",
+                                "slug": "county-backup-report",
+                                "title": {
+                                    "rendered": "County Backup Report"
+                                },
+                                "mime_type": "application/pdf",
+                                "source_url": (
+                                    "https://cob.go.ke/wp-content/uploads/"
+                                    "2025/03/alive.pdf"
+                                ),
+                            },
+                        ]
+                    ),
+                    request=request,
+                )
+            if request.method == "HEAD":
+                if "stale.pdf" in request.url.path:
+                    return httpx.Response(404, request=request)
+                if "alive.pdf" in request.url.path:
+                    return httpx.Response(200, request=request)
+            return httpx.Response(500, request=request)
+
+        with _make_client(settings, handler) as client:
+            url = cb_fetcher._discover_latest_county_birr_via_wp_api(
+                client, settings
+            )
+
+        assert url is not None
+        assert url.endswith("alive.pdf"), f"expected fallthrough to alive.pdf, got {url}"
 
     def test_skips_items_without_pdf_source_url(self, settings):
         """Items whose source_url is missing or not a .pdf must be
@@ -334,6 +403,9 @@ class TestFetchBudgetPayloadStrategyOrder:
                     ],
                     request=request,
                 )
+            # Liveness-probe HEAD on the chosen PDF must succeed.
+            if request.method == "HEAD" and request.url.path.endswith(".pdf"):
+                return httpx.Response(200, request=request)
             # Any other URL is an unexpected code path.
             return httpx.Response(500, request=request)
 


### PR DESCRIPTION
## Context
Yesterday's scheduled seeding run ([24901989493](https://github.com/Rodgers31/audit_app/actions/runs/24901989493)) hit the new 10-min per-domain budget on \`counties_budget\`. The SIGALRM stack trace pointed at two orthogonal bugs, both fixed here.

## 1. Writer: N+1 SELECT-per-record → 4 bulk SELECTs

\`persist_budget_records\` ran 4 serial SELECTs per input record (entity → source doc → fiscal period → existing budget line). Against Supabase at ~150ms RTT, a fixture-scale batch of a few hundred rows easily exceeded 10 min.

**Rewrite:** four bulk preload queries up front, per-record loop does O(1) dict lookups, single \`session.flush()\` at the end. Same semantics preserved:
- latest-record-wins \`SourceDocument\` meta/title refresh
- provenance dedupe on non-timestamp keys
- notes / data_quality upgrade-in-place

Expected outcome: counties_budget finishes in seconds instead of being cut off at 10 min.

## 2. WP-REST selector: 2015 404 link was chosen as \"latest\"

In the same run the feed returned \`makueni-county-budget-implementation-report-4th-quarter-2012-13.pdf\` as the top county match — a 2015 single-county file the CDN had since deleted. The first-match-wins logic trusted the server ordering and didn't verify the link was alive.

**Three fixes:**
- **Specificity score** — \`consolidated\` / \`c-birr\` / recent FY markers carry weight; plain \`county\` is a weak signal.
- **Client-side sort** by (score desc, date desc). Don't trust WordPress \`orderby=date\`.
- **HEAD liveness probe** — iterate candidates in rank order, skip 4xx/5xx, return first 200. One stale entry no longer poisons the domain.

## 3. Tests
- Updated two existing tests to 200 on HEAD probes so the new liveness check passes.
- **New**: \`test_falls_through_when_top_candidate_404s\` pins the exact prod bug — top-ranked candidate 404s, the lower-ranked but live one is returned instead.

## Test plan
- [ ] Merge → manual trigger of \"Database Seeding & Data Refresh\".
- [ ] counties_budget completes well under 10 min (look for \"Committed changes\" for domain=counties_budget in the log).
- [ ] WP REST log line shows the chosen PDF's score and date — and that date is recent, not 2015.
- [ ] If the top-ranked candidate happens to 404, expect a \"returned HTTP 404; trying next\" line followed by a successful selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)