### PR TITLE
fix(seeding): bulk INSERT for BudgetLine + canonical slugify_entity

### DIFF
--- a/backend/seeding/domains/audits/fetcher.py
+++ b/backend/seeding/domains/audits/fetcher.py
@@ -21,7 +21,7 @@ from urllib.parse import urljoin
 
 from ...config import SeedingSettings
 from ...http_client import SeedingHttpClient
-from ...utils import load_json_resource
+from ...utils import load_json_resource, slugify_entity
 
 logger = logging.getLogger("seeding.audits.fetcher")
 
@@ -295,9 +295,11 @@ def _extract_findings_from_text(
                     pass
 
             entity = current_county or "National Government"
-            entity_slug = entity.lower().replace(" ", "-")
-            if current_county:
-                entity_slug += "-county"
+            # slugify_entity collapses punctuation (incl. apostrophes) so
+            # "Murang'a" normalises to "muranga" — matches the DB slug
+            # format. Prior `.lower().replace(" ", "-")` left apostrophes
+            # in place and triggered "Unknown entity slug" warnings.
+            entity_slug = slugify_entity(entity, county_suffix=bool(current_county))
 
             # Truncate finding text to reasonable length
             finding_text = section.strip()[:500]

--- a/backend/seeding/domains/counties_budget/fetcher.py
+++ b/backend/seeding/domains/counties_budget/fetcher.py
@@ -24,7 +24,7 @@ from urllib.parse import urljoin
 
 from ...config import SeedingSettings
 from ...http_client import SeedingHttpClient
-from ...utils import load_json_resource
+from ...utils import load_json_resource, slugify_entity
 
 logger = logging.getLogger("seeding.counties_budget.fetcher")
 
@@ -523,7 +523,7 @@ def _download_and_parse_county_pdf(
         dropped_no_fy = 0
         for record in parsed_records:
             county = record.get("county", "Unknown")
-            entity_slug = county.lower().replace(" ", "-") + "-county"
+            entity_slug = slugify_entity(county)
             fy = record.get("fiscal_year", "")
 
             start_iso, end_iso = _derive_fiscal_year_dates(fy)

--- a/backend/seeding/domains/counties_budget/writer.py
+++ b/backend/seeding/domains/counties_budget/writer.py
@@ -16,7 +16,7 @@ from models import (
     FiscalPeriod,
     SourceDocument,
 )
-from sqlalchemy import and_, select
+from sqlalchemy import and_, insert, select
 from sqlalchemy.orm import Session
 
 from ...config import SeedingSettings
@@ -378,6 +378,15 @@ def persist_budget_records(
         }
 
     # ── 5. Resolve every record against the in-memory dicts ──────
+    # New rows are buffered into `new_line_values` and emitted as a
+    # single Core-level INSERT at the end of the pass. This replaces
+    # the previous session.add()-per-row path whose implicit flush
+    # issued one round-trip per row against Supabase — on a 1,880-row
+    # fixture that was ~5 min just for the INSERTs. A single
+    # INSERT ... VALUES (...), (...), (...) collapses that to one trip.
+    new_line_values: List[dict] = []
+    claimed_keys: set[Tuple[int, int, str, Optional[str]]] = set()
+
     for record in resolvable:
         entity = entities_by_slug[record.entity_slug]
         url = record.source_url or settings.budgets_dataset_url
@@ -402,22 +411,28 @@ def persist_budget_records(
         existing = existing_lines.get(key)
 
         if existing is None:
-            line = BudgetLine(
-                entity_id=entity.id,
-                period_id=period.id,
-                category=record.category,
-                subcategory=record.subcategory,
-                currency=currency,
-                allocated_amount=record.allocated_amount,
-                actual_spent=record.actual_amount,
-                committed_amount=record.committed_amount,
-                source_document_id=source.id,
-                notes=record.notes,
-                provenance=[provenance_entry] if provenance_entry else [],
-                source_hash=record_hash,
+            # Guard against the same (entity, period, category, subcategory)
+            # appearing twice in one batch — the DB's unique constraint
+            # would otherwise kill the bulk INSERT mid-flight.
+            if key in claimed_keys:
+                continue
+            claimed_keys.add(key)
+            new_line_values.append(
+                {
+                    "entity_id": entity.id,
+                    "period_id": period.id,
+                    "category": record.category,
+                    "subcategory": record.subcategory,
+                    "currency": currency,
+                    "allocated_amount": record.allocated_amount,
+                    "actual_spent": record.actual_amount,
+                    "committed_amount": record.committed_amount,
+                    "source_document_id": source.id,
+                    "notes": record.notes,
+                    "provenance": [provenance_entry] if provenance_entry else [],
+                    "source_hash": record_hash,
+                }
             )
-            session.add(line)
-            existing_lines[key] = line  # guard duplicates within the batch
             stats.created += 1
         else:
             if _apply_line(existing, record, currency, source.id, record_hash):
@@ -443,6 +458,10 @@ def persist_budget_records(
                 if not any(_dedupe_key(p) == new_key for p in provenance):
                     provenance.append(provenance_entry)
                     existing.provenance = provenance
+
+    # ── 6. Bulk-INSERT all the new rows in one statement ─────────
+    if new_line_values:
+        session.execute(insert(BudgetLine), new_line_values)
 
     return stats
 

--- a/backend/seeding/utils.py
+++ b/backend/seeding/utils.py
@@ -140,29 +140,43 @@ _FY_PATTERN = _re.compile(r"^(?:FY\s*)?(\d{4})[/\-](\d{2,4})$")
 
 
 _SLUG_STRIP_RE = _re.compile(r"[^a-z0-9]+")
+# Apostrophes (ASCII + Unicode right-single-quote) are *stripped*
+# rather than replaced with a hyphen so "Murang'a" → "muranga"
+# matches the canonical DB slug. Everything else non-alphanumeric
+# collapses to a hyphen.
+_APOSTROPHE_RE = _re.compile(r"['\u2019]")
 
 
 def slugify_entity(name: str, *, county_suffix: bool = True) -> str:
     """Canonicalise an entity name into the slug format used in the DB.
 
-    The ``entities`` table's ``slug`` column is kept in kebab-case with no
-    punctuation — e.g. ``muranga-county``, not ``murang'a-county``. Callers
-    historically did a naive ``name.lower().replace(" ", "-")`` which
-    produced ``murang'a-county`` for Murang'a and then failed the lookup,
-    generating the "Unknown entity slug" warnings we saw every run.
+    The ``entities`` table's ``slug`` column is kept in kebab-case with
+    no punctuation — e.g. ``muranga-county``, not ``murang'a-county``.
+    Callers historically did a naive ``name.lower().replace(" ", "-")``
+    which produced ``murang'a-county`` for Murang'a and then failed the
+    lookup, generating the "Unknown entity slug" warnings we saw every
+    run.
 
     Rules:
       * ASCII-lowercase.
-      * Every non-alphanumeric run collapses to a single hyphen (so
-        apostrophes, commas, dots, em-dashes, multi-spaces all normalise).
+      * Apostrophes are stripped (so Murang'a → muranga, O'Brien → obrien).
+      * Every other non-alphanumeric run collapses to a single hyphen
+        (commas, dots, em-dashes, multi-spaces all normalise).
       * Leading / trailing hyphens trimmed.
+      * Whitespace-only input returns "" (no stray ``-county`` leaks).
       * Optionally appends ``-county`` — set to False when the caller
-        passes an already-fully-qualified entity name.
+        passes an already-fully-qualified entity name like
+        "National Government".
     """
     if not name:
         return ""
     lowered = name.strip().lower()
-    collapsed = _SLUG_STRIP_RE.sub("-", lowered).strip("-")
+    # Strip apostrophes BEFORE the non-alphanumeric collapse so they
+    # don't leave hyphens behind.
+    deaposted = _APOSTROPHE_RE.sub("", lowered)
+    collapsed = _SLUG_STRIP_RE.sub("-", deaposted).strip("-")
+    if not collapsed:
+        return ""
     if county_suffix and not collapsed.endswith("-county"):
         collapsed = f"{collapsed}-county"
     return collapsed

--- a/backend/seeding/utils.py
+++ b/backend/seeding/utils.py
@@ -139,6 +139,35 @@ import re as _re
 _FY_PATTERN = _re.compile(r"^(?:FY\s*)?(\d{4})[/\-](\d{2,4})$")
 
 
+_SLUG_STRIP_RE = _re.compile(r"[^a-z0-9]+")
+
+
+def slugify_entity(name: str, *, county_suffix: bool = True) -> str:
+    """Canonicalise an entity name into the slug format used in the DB.
+
+    The ``entities`` table's ``slug`` column is kept in kebab-case with no
+    punctuation — e.g. ``muranga-county``, not ``murang'a-county``. Callers
+    historically did a naive ``name.lower().replace(" ", "-")`` which
+    produced ``murang'a-county`` for Murang'a and then failed the lookup,
+    generating the "Unknown entity slug" warnings we saw every run.
+
+    Rules:
+      * ASCII-lowercase.
+      * Every non-alphanumeric run collapses to a single hyphen (so
+        apostrophes, commas, dots, em-dashes, multi-spaces all normalise).
+      * Leading / trailing hyphens trimmed.
+      * Optionally appends ``-county`` — set to False when the caller
+        passes an already-fully-qualified entity name.
+    """
+    if not name:
+        return ""
+    lowered = name.strip().lower()
+    collapsed = _SLUG_STRIP_RE.sub("-", lowered).strip("-")
+    if county_suffix and not collapsed.endswith("-county"):
+        collapsed = f"{collapsed}-county"
+    return collapsed
+
+
 def normalize_fiscal_label(raw: str) -> str:
     """Normalise any fiscal-year string to the canonical ``FY{YYYY}/{YY}`` form.
 
@@ -166,4 +195,5 @@ __all__ = [
     "load_json_resource",
     "compute_hash",
     "normalize_fiscal_label",
+    "slugify_entity",
 ]

--- a/backend/tests/test_seeding_utils.py
+++ b/backend/tests/test_seeding_utils.py
@@ -1,0 +1,56 @@
+"""Unit tests for the small helper functions in ``seeding.utils``.
+
+Focused on slugify_entity because it's the regression point behind the
+recurring "Unknown entity slug 'murang'a-county'" warnings: a naive
+``name.lower().replace(" ", "-")`` left the apostrophe in place and
+didn't match the DB's canonical ``muranga-county`` slug format.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seeding.utils import slugify_entity
+
+
+class TestSlugifyEntity:
+    """Every character that isn't [a-z0-9] must collapse to a hyphen."""
+
+    def test_strips_apostrophe_from_muranga(self):
+        # Regression: the exact prod warning line was "Unknown entity
+        # slug 'murang'a-county'". Canonical DB slug is "muranga-county".
+        assert slugify_entity("Murang'a") == "muranga-county"
+
+    def test_strips_apostrophe_regardless_of_position(self):
+        assert slugify_entity("O'Brien") == "o-brien-county"
+
+    def test_keeps_simple_name_untouched(self):
+        assert slugify_entity("Nairobi") == "nairobi-county"
+
+    def test_collapses_multi_word_with_space(self):
+        assert slugify_entity("Taita Taveta") == "taita-taveta-county"
+
+    def test_collapses_repeated_punctuation_to_single_hyphen(self):
+        # "Homa-Bay" and "Homa — Bay" must both produce "homa-bay-county".
+        assert slugify_entity("Homa-Bay") == "homa-bay-county"
+        assert slugify_entity("Homa — Bay") == "homa-bay-county"
+
+    def test_trims_leading_trailing_hyphens(self):
+        assert slugify_entity(" -Nakuru- ") == "nakuru-county"
+
+    def test_idempotent_when_input_already_has_suffix(self):
+        # Don't append "-county" twice.
+        assert slugify_entity("Muranga County") == "muranga-county"
+        assert slugify_entity("muranga-county") == "muranga-county"
+
+    def test_county_suffix_opt_out(self):
+        # National Government is not a county; the caller passes
+        # county_suffix=False to keep the bare slug.
+        assert (
+            slugify_entity("National Government", county_suffix=False)
+            == "national-government"
+        )
+
+    def test_empty_input_returns_empty(self):
+        assert slugify_entity("") == ""
+        assert slugify_entity("   ") == ""

--- a/backend/tests/test_seeding_utils.py
+++ b/backend/tests/test_seeding_utils.py
@@ -22,7 +22,14 @@ class TestSlugifyEntity:
         assert slugify_entity("Murang'a") == "muranga-county"
 
     def test_strips_apostrophe_regardless_of_position(self):
-        assert slugify_entity("O'Brien") == "o-brien-county"
+        # Apostrophe is stripped, not replaced with a hyphen — so
+        # "O'Brien" → "obrien", not "o-brien".
+        assert slugify_entity("O'Brien") == "obrien-county"
+
+    def test_strips_unicode_right_single_quote(self):
+        # Some upstream JSON uses "Murang\u2019a" (curly apostrophe)
+        # instead of the ASCII form — both must normalise identically.
+        assert slugify_entity("Murang\u2019a") == "muranga-county"
 
     def test_keeps_simple_name_untouched(self):
         assert slugify_entity("Nairobi") == "nairobi-county"


### PR DESCRIPTION
## Why
Run [#24908017106](https://github.com/Rodgers31/audit_app/actions/runs/24908017106) succeeded but two things were worth fixing proactively:

1. \`counties_budget\` took ~10 min end-to-end (close to the 600s per-domain cap). If the dataset grows or Supabase slows we'd time out again.
2. \`audits\` kept logging \"Unknown entity slug 'murang'a-county'\" every run — 6 findings silently dropped per nightly.

## Fix 1 — bulk Core INSERT for new BudgetLine rows

The writer was doing \`session.add()\`-per-row; SQLAlchemy's unit-of-work flush emitted one INSERT round-trip per row against Supabase-Frankfurt (~150 ms RTT ≈ 5 min for 1,880 rows all by itself).

**Refactor:** buffer new rows into a list, then one call:
\`\`\`python
session.execute(insert(BudgetLine), new_line_values)
\`\`\`
One SQL statement for all new rows → ~5 min → ~1 s of network. Same unique-constraint semantics preserved via an in-batch \`claimed_keys\` dedupe set. Update path (existing rows) still uses ORM mutation — fine for healthy re-seeds since nothing actually changes.

## Fix 2 — \`slugify_entity\` helper

Old code: \`name.lower().replace(\" \", \"-\")\` — left apostrophes in place so \"Murang'a\" → \"murang'a\" never matched the DB's canonical \"muranga-county\".

New helper in \`seeding/utils.py\` collapses any non-alphanumeric run to a single hyphen, trims edges, optionally appends \`-county\`, and is idempotent. Wired into both \`audits/fetcher.py\` and \`counties_budget/fetcher.py\`. Also silently fixes a latent double-suffix bug — old code would have produced \`nairobi-county-county\` if the parser had ever returned \"Nairobi County\".

Unit tests pin Murang'a + 7 other edge cases (O'Brien, em-dashes, whitespace, idempotency, National Government opt-out).

## Test plan
- [ ] Merge → manually trigger \"Database Seeding & Data Refresh\".
- [ ] \`counties_budget\` total duration drops from ~10 min to roughly (parse time + 1 INSERT round-trip).
- [ ] \`audits\` log no longer contains \"Unknown entity slug 'murang'a\" warnings; \`processed\` and \`created\` numbers go up correspondingly.
- [ ] All 14 domains still complete cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)