### PR TITLE
fix(seeding): canonicalize slug at writer + drop job_id from provenance dedupe

### DIFF
--- a/backend/seeding/domains/audits/writer.py
+++ b/backend/seeding/domains/audits/writer.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from ...config import SeedingSettings
 from ...types import DomainRunContext
+from ...utils import canonicalize_slug
 from .parser import AuditRecord
 
 logger = logging.getLogger("seeding.audits.writer")
@@ -85,7 +86,11 @@ def _ensure_period(
 def _resolve_entity(
     session: Session, record: AuditRecord
 ) -> Tuple[Optional[Entity], Optional[str]]:
-    stmt = select(Entity).where(Entity.slug == record.entity_slug)
+    # Canonicalise the slug at lookup time so apostrophes in fixture or
+    # OAG-derived data ("murang'a-county") still match the DB row
+    # ("muranga-county"). Idempotent for already-clean slugs.
+    slug = canonicalize_slug(record.entity_slug)
+    stmt = select(Entity).where(Entity.slug == slug)
     entity = session.execute(stmt).scalar_one_or_none()
     if entity is None:
         msg = f"Unknown entity slug '{record.entity_slug}'"

--- a/backend/seeding/domains/counties_budget/writer.py
+++ b/backend/seeding/domains/counties_budget/writer.py
@@ -210,13 +210,20 @@ def persist_budget_records(
     in four bulk queries and resolves per-record work in-memory, so
     total DB round-trips for N records are O(1) + a single final flush.
     """
-    from ...utils import normalize_fiscal_label
+    from ...utils import canonicalize_slug, normalize_fiscal_label
 
     stats = PersistenceStats()
     records = list(records)
     stats.processed = len(records)
     if not records:
         return stats
+
+    # Re-canonicalise every incoming slug at the boundary. Fixtures and
+    # partner exports occasionally carry slugs with apostrophes or stray
+    # whitespace ("murang'a-county", "Muranga County"). Slugify here so
+    # the rest of the pipeline only sees the DB's canonical form.
+    for r in records:
+        r.entity_slug = canonicalize_slug(r.entity_slug)
 
     # ── 1. Bulk-load entities ────────────────────────────────────
     entity_slugs = {r.entity_slug for r in records}
@@ -446,12 +453,20 @@ def persist_budget_records(
             if provenance_entry:
                 provenance = list(existing.provenance or [])
 
+                # Dedupe key intentionally excludes ingestion_job_id and
+                # ingested_at so an idempotent re-seed (same dataset,
+                # same quality, same source label, no changed values)
+                # doesn't append a fresh entry and thereby mark the row
+                # dirty. Before this trim every nightly run added an
+                # entry per record → 1,880 UPDATE statements on a
+                # no-change re-seed (~3 min over Frankfurt RTT).
+                # The audit trail of "which job last touched the row"
+                # is still on the IngestionJob row itself.
                 def _dedupe_key(e: dict) -> tuple:
                     return (
                         e.get("dataset_id"),
                         e.get("data_quality"),
                         e.get("source_label"),
-                        e.get("ingestion_job_id"),
                     )
 
                 new_key = _dedupe_key(provenance_entry)

--- a/backend/seeding/utils.py
+++ b/backend/seeding/utils.py
@@ -147,6 +147,24 @@ _SLUG_STRIP_RE = _re.compile(r"[^a-z0-9]+")
 _APOSTROPHE_RE = _re.compile(r"['\u2019]")
 
 
+def canonicalize_slug(slug: str) -> str:
+    """Normalise an already-formed slug to canonical kebab-case.
+
+    Use on slugs coming in from JSON fixtures or partner exports before
+    you do an Entity-by-slug lookup. This is the SAFE re-canoncalisation:
+    strip apostrophes, collapse non-alphanumeric runs, trim edges. It
+    does NOT add or remove the ``-county`` suffix because national vs
+    county entities differ and we don't want ``national-government`` to
+    accidentally become ``national-government-county``.
+
+    Idempotent — applying twice yields the same result.
+    """
+    if not slug:
+        return ""
+    deaposted = _APOSTROPHE_RE.sub("", slug.strip().lower())
+    return _SLUG_STRIP_RE.sub("-", deaposted).strip("-")
+
+
 def slugify_entity(name: str, *, county_suffix: bool = True) -> str:
     """Canonicalise an entity name into the slug format used in the DB.
 
@@ -210,4 +228,5 @@ __all__ = [
     "compute_hash",
     "normalize_fiscal_label",
     "slugify_entity",
+    "canonicalize_slug",
 ]

--- a/backend/tests/test_seeding_utils.py
+++ b/backend/tests/test_seeding_utils.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from seeding.utils import slugify_entity
+from seeding.utils import canonicalize_slug, slugify_entity
 
 
 class TestSlugifyEntity:
@@ -61,3 +61,36 @@ class TestSlugifyEntity:
     def test_empty_input_returns_empty(self):
         assert slugify_entity("") == ""
         assert slugify_entity("   ") == ""
+
+
+class TestCanonicalizeSlug:
+    """canonicalize_slug normalises an EXISTING slug without touching
+    the -county suffix — used at the writer's lookup boundary so
+    fixture/JSON-derived slugs match the DB's canonical form even when
+    they carry apostrophes or stray whitespace."""
+
+    def test_strips_apostrophe_in_existing_slug(self):
+        # The exact prod regression: fixture had "murang'a-county",
+        # DB has "muranga-county", lookup failed and 6 audits were
+        # silently dropped each nightly run.
+        assert canonicalize_slug("murang'a-county") == "muranga-county"
+
+    def test_does_not_add_county_suffix(self):
+        # Unlike slugify_entity, this helper must NEVER append -county
+        # because callers may pass national-level slugs.
+        assert canonicalize_slug("national-government") == "national-government"
+
+    def test_idempotent(self):
+        canonical = "muranga-county"
+        assert canonicalize_slug(canonical) == canonical
+        assert canonicalize_slug(canonicalize_slug(canonical)) == canonical
+
+    def test_handles_uppercase_and_spaces(self):
+        assert canonicalize_slug("Muranga County") == "muranga-county"
+
+    def test_strips_unicode_apostrophe(self):
+        assert canonicalize_slug("murang\u2019a-county") == "muranga-county"
+
+    def test_empty_returns_empty(self):
+        assert canonicalize_slug("") == ""
+        assert canonicalize_slug("   ") == ""


### PR DESCRIPTION
## Why
Run [#24913692963](https://github.com/Rodgers31/audit_app/actions/runs/24913692963) succeeded but two problems persisted that PR #71 didn't catch:

### 1. \`Unknown entity slug 'murang'a-county'\` warnings still fired
PR #71's \`slugify_entity\` only patched the **fetcher** path. This run's data flowed through the **JSON-fixture fallback** (the live PDF parse failed mid-way). The fixture has \`murang'a-county\` baked in; the parser just lowercases; the writer's lookup never matched the DB's canonical \`muranga-county\`. 6 audits silently dropped.

### 2. \`counties_budget\` writer ran ~3 min on a no-change re-seed
Stats: \`processed=1880 / created=0 / updated=0\`. Yet the writer phase took 3 minutes. Cause: the provenance dedupe key included \`ingestion_job_id\`, so every nightly appended a new provenance entry per row (since job_id changes each run), marking 1,880 \`BudgetLine\`s dirty and emitting that many UPDATEs over Frankfurt's ~150 ms RTT.

## What's in this PR

- New \`canonicalize_slug(slug)\` helper in \`seeding/utils.py\` — strict normalisation (strip apostrophes incl. U+2019, collapse non-alphanumeric runs to hyphens) that DOES NOT touch the \`-county\` suffix. Idempotent.
- Wired into both \`audits/writer.py::_resolve_entity\` and the bulk preload in \`counties_budget/writer.py\`. Any slug source — JSON fixture, partner CSV, OAG PDF — gets normalised at the lookup boundary.
- Dropped \`ingestion_job_id\` (and the implicit \`ingested_at\`) from the provenance dedupe-key in \`counties_budget/writer.py\`. Same dataset + quality + source label is now treated as a duplicate across runs. The "which job touched the row" trail still lives on the \`IngestionJob\` table.
- Added \`TestCanonicalizeSlug\` in \`test_seeding_utils.py\` — 6 cases: murang'a, idempotency, no -county-suffix promotion, U+2019, empty/whitespace, uppercase.

## Test plan
- [ ] CI green.
- [ ] Merge → trigger \"Database Seeding & Data Refresh\".
- [ ] \`audits\` log shows **0** \"Unknown entity slug 'murang'a'\" warnings; \`processed\` and \`errors\` reflect the 6 newly-saved findings.
- [ ] \`counties_budget\` total writer phase drops from ~3 min to <30 s on a no-change re-seed.

## What's NOT in this PR
- The 6-min PDF parse failure (pdfplumber chewing on the 39 MB COB BIRR before giving up). Bounding the parser is a separate, riskier change — note for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)