### PR TITLE
fix(pdf): invariant-anchored CoB BIRR parser \u2014 county-name match + header synonyms

### DIFF
--- a/backend/seeding/pdf_parsers.py
+++ b/backend/seeding/pdf_parsers.py
@@ -276,12 +276,21 @@ def find_table_by_row_anchors(
     apostrophes are stripped so "Murang'a" lines up with the
     canonical "Muranga".
     """
-    normalised_anchors = [
-        a.lower().replace("'", "").replace("\u2019", "") for a in anchors
-    ]
+    # Normalise on both sides: COB sometimes prints hyphenated forms
+    # ("Taita-Taveta", "Trans-Nzoia") that wouldn't substring-match a
+    # space-separated canonical anchor. Also collapse all unicode
+    # apostrophes and dashes, then squish whitespace.
+    def _normalise(s: str) -> str:
+        s = s.lower().replace("'", "").replace("\u2019", "")
+        # Map every dash variant (ASCII + unicode \u2010-\u2015) to a space.
+        for ch in ("-", "\u2010", "\u2011", "\u2012", "\u2013", "\u2014", "\u2015"):
+            s = s.replace(ch, " ")
+        return re.sub(r"\s+", " ", s).strip()
+
+    normalised_anchors = [_normalise(a) for a in anchors]
 
     def _strip(s: str) -> str:
-        return s.lower().replace("'", "").replace("\u2019", "")
+        return _normalise(s)
 
     candidates: List[Tuple[int, int, ExtractedTable]] = []  # (anchor_score, header_score, table)
     for table in tables:
@@ -312,9 +321,11 @@ def find_table_by_row_anchors(
 
     if not candidates:
         return None
-    # Rank: header_score desc (when synonyms passed) then anchor_score desc.
-    # Stable sort means PDF-order is the final tiebreaker (earliest wins).
-    candidates.sort(key=lambda t: (t[1], t[0]), reverse=True)
+    # Rank: anchor_score primary (the whole point of "invariant-anchored"),
+    # header_score as the tiebreaker for the common case where MANY tables
+    # in one report happen to list all 47 counties (revenue, arrears,
+    # expenditure …). Stable sort means PDF-order is the final tiebreaker.
+    candidates.sort(key=lambda t: (t[0], t[1]), reverse=True)
     return candidates[0][2]
 
 
@@ -359,9 +370,15 @@ def flatten_grouped_headers(table: ExtractedTable) -> ExtractedTable:
         if cell:
             last_group = cell
         filled_groups.append(last_group)
+    # zip_longest, not zip — pdfplumber occasionally returns ragged
+    # tables where the sub-row is shorter than the group-row. Truncating
+    # would silently drop trailing columns and break find_column_index
+    # downstream. Fillvalue "" so missing sub-labels just leave the
+    # group label intact.
+    from itertools import zip_longest
     combined = [
         " ".join(filter(None, [grp, sub])).strip()
-        for grp, sub in zip(filled_groups, sub_row)
+        for grp, sub in zip_longest(filled_groups, sub_row, fillvalue="")
     ]
     return ExtractedTable(
         page_number=table.page_number,
@@ -599,6 +616,22 @@ class CoBQuarterlyReportParser:
             # We only require the allocated and absorbed columns;
             # absorption rate is derivable when missing.
             if allocated_col is None or absorbed_col is None:
+                # Log at INFO not WARNING — categories CAN legitimately be
+                # missing (e.g. older PDFs only carry the Total column;
+                # the Recurrent / Development synonyms then won't match).
+                # But silent-skip-without-signal makes partial-parse
+                # failures invisible in nightly runs, so emit the
+                # available headers so an operator can confirm.
+                logger.info(
+                    "Skipping consolidated category — required columns not resolved",
+                    extra={
+                        "source": str(self.pdf_path),
+                        "category": category,
+                        "available_headers": budget_table.headers,
+                        "allocated_col": allocated_col,
+                        "absorbed_col": absorbed_col,
+                    },
+                )
                 continue
             records.extend(
                 self._rows_from_columns(

--- a/backend/seeding/pdf_parsers.py
+++ b/backend/seeding/pdf_parsers.py
@@ -247,6 +247,185 @@ def find_table_by_header(
     return None
 
 
+def find_table_by_row_anchors(
+    tables: List[ExtractedTable],
+    anchors: List[str],
+    *,
+    min_matches: int = 30,
+    column: int = 0,
+    header_synonyms: Optional[List[List[str]]] = None,
+) -> Optional[ExtractedTable]:
+    """Find the table whose ``column`` matches the most ``anchors``.
+
+    Robust alternative to ``find_table_by_header`` for cases where the
+    table you want has a stable invariant in its row labels (e.g., a
+    consolidated county table is the only table in the report whose
+    first column lists 47 Kenyan counties — the column header text
+    can drift forever and this still works).
+
+    A real report typically has SEVERAL tables that all list every
+    county (revenue, arrears, budget execution, expenditure, …). To
+    pick the right one, callers can pass ``header_synonyms`` — the
+    same shape as for ``find_column_index`` — and tables whose
+    flattened header text doesn't satisfy at least one synonym group
+    are demoted in the ranking. Anchor count is still primary; header
+    match is the tiebreaker.
+
+    Returns the highest-ranked table, or None if no candidate reaches
+    ``min_matches`` anchors. Matching is case-insensitive substring;
+    apostrophes are stripped so "Murang'a" lines up with the
+    canonical "Muranga".
+    """
+    normalised_anchors = [
+        a.lower().replace("'", "").replace("\u2019", "") for a in anchors
+    ]
+
+    def _strip(s: str) -> str:
+        return s.lower().replace("'", "").replace("\u2019", "")
+
+    candidates: List[Tuple[int, int, ExtractedTable]] = []  # (anchor_score, header_score, table)
+    for table in tables:
+        if not table.rows:
+            continue
+        col_values = [
+            _strip(row[column]) if len(row) > column else ""
+            for row in table.rows
+        ]
+        anchor_score = sum(
+            1 for a in normalised_anchors if any(a in v for v in col_values)
+        )
+        if anchor_score < min_matches:
+            continue
+        header_score = 0
+        if header_synonyms is not None:
+            # Combine the original header row + the first data row so
+            # two-row "group / sub-label" headers are scored as one.
+            haystack = " ".join(table.headers).lower()
+            if table.rows:
+                haystack += " " + " ".join(table.rows[0]).lower()
+            header_score = sum(
+                1
+                for group in header_synonyms
+                if all(kw.lower() in haystack for kw in group)
+            )
+        candidates.append((anchor_score, header_score, table))
+
+    if not candidates:
+        return None
+    # Rank: header_score desc (when synonyms passed) then anchor_score desc.
+    # Stable sort means PDF-order is the final tiebreaker (earliest wins).
+    candidates.sort(key=lambda t: (t[1], t[0]), reverse=True)
+    return candidates[0][2]
+
+
+def flatten_grouped_headers(table: ExtractedTable) -> ExtractedTable:
+    """Fold a two-row "group label / sub-label" header into single labels.
+
+    Many financial PDFs render headers like::
+
+        | County | Budget Estimates       | Actual Expenditure     | Absorption |
+        |        | Rec | Dev | Total      | Rec | Dev | Total      | Rec | ...  |
+
+    pdfplumber treats the first row as the header and the second as
+    data, which destroys positional column lookups. This helper
+    detects that pattern (the second row has no numeric content but
+    repeated short labels like Rec/Dev/Total/Q1/etc.) and produces a
+    new ExtractedTable whose headers carry the combined label
+    ("Budget Estimates Total"). Group labels forward-fill across
+    empty cells.
+
+    Returns the input unchanged when no grouping is detected.
+    """
+    if not table.rows:
+        return table
+    sub_row = [c.strip() for c in table.rows[0]]
+    if not sub_row or all(not c for c in sub_row):
+        return table
+    # Heuristic: every non-empty cell must be SHORT and NON-NUMERIC for
+    # the row to count as a sub-header (rules out actual data rows
+    # whose first cell happens to be a county name).
+    non_empty = [c for c in sub_row if c]
+    looks_like_subheader = all(
+        len(c) <= 25 and not _re_compiled_numeric.search(c) for c in non_empty
+    )
+    if not looks_like_subheader:
+        return table
+    # Forward-fill group labels across empties so each column inherits
+    # the most recent group label.
+    filled_groups: List[str] = []
+    last_group = ""
+    for cell in table.headers:
+        cell = (cell or "").strip()
+        if cell:
+            last_group = cell
+        filled_groups.append(last_group)
+    combined = [
+        " ".join(filter(None, [grp, sub])).strip()
+        for grp, sub in zip(filled_groups, sub_row)
+    ]
+    return ExtractedTable(
+        page_number=table.page_number,
+        table_index=table.table_index,
+        headers=combined,
+        rows=table.rows[1:],
+        bbox=table.bbox,
+    )
+
+
+def find_column_index(
+    headers: List[str], synonym_groups: List[List[str]]
+) -> Optional[int]:
+    """Pick the first column whose header satisfies any synonym group.
+
+    Each synonym group is a list of keywords ALL of which must appear
+    (case-insensitive substring) in the header cell. The first group
+    that matches any column wins. Useful when terminology has drifted
+    across report vintages — pass multiple synonym groups in priority
+    order and the matcher tries each in turn.
+
+    Example::
+
+        find_column_index(
+            headers,
+            [
+                ["budget", "estimates", "total"],   # H1 FY2025/26 wording
+                ["approved", "budget", "total"],    # alt phrasing
+                ["allocated", "total"],             # legacy
+                ["allocated"],                      # bare-bones legacy
+            ],
+        )
+    """
+    lowered = [(h or "").lower() for h in headers]
+    for group in synonym_groups:
+        for col_idx, header in enumerate(lowered):
+            if all(kw.lower() in header for kw in group):
+                return col_idx
+    return None
+
+
+# Module-level compiled regex used by flatten_grouped_headers. A digit
+# appearing anywhere in a "sub-header" cell is a strong signal that
+# we're looking at actual data, not headers.
+_re_compiled_numeric = re.compile(r"\d")
+
+
+# ──────────────────────────────────────────────────────────────────
+# Canonical entity lists used as row-anchors for invariant-based
+# table identification. Keep these in sync with the entities table.
+# ──────────────────────────────────────────────────────────────────
+KENYAN_COUNTIES: Tuple[str, ...] = (
+    "Baringo", "Bomet", "Bungoma", "Busia", "Elgeyo Marakwet", "Embu",
+    "Garissa", "Homa Bay", "Isiolo", "Kajiado", "Kakamega", "Kericho",
+    "Kiambu", "Kilifi", "Kirinyaga", "Kisii", "Kisumu", "Kitui", "Kwale",
+    "Laikipia", "Lamu", "Machakos", "Makueni", "Mandera", "Marsabit",
+    "Meru", "Migori", "Mombasa", "Murang'a", "Nairobi", "Nakuru", "Nandi",
+    "Narok", "Nyamira", "Nyandarua", "Nyeri", "Samburu", "Siaya",
+    "Taita Taveta", "Tana River", "Tharaka Nithi", "Trans Nzoia",
+    "Turkana", "Uasin Gishu", "Vihiga", "Wajir", "West Pokot",
+)
+assert len(KENYAN_COUNTIES) == 47, "Kenya has 47 counties"
+
+
 class CoBQuarterlyReportParser:
     """Parser for Controller of Budget quarterly budget execution reports."""
 
@@ -304,25 +483,135 @@ class CoBQuarterlyReportParser:
         """
         self.tables = extract_all_tables(self.pdf_path)
 
-        # ── Aggregate (always required) ────────────────────────────
-        budget_table = find_table_by_header(
-            self.tables, ["county", "allocated", "absorbed"]
+        # ── Primary path: invariant-anchored lookup ────────────────
+        # COB reword the table headers every couple of vintages
+        # ("Allocated"/"Absorbed" → "Budget Estimates"/"Actual
+        # Expenditure" in FY2025/26), but the row labels stay constant
+        # — there are always 47 Kenyan counties down the left column.
+        # Find the table by counting county-name matches; that
+        # survives any future header drift.
+        #
+        # Header synonyms are passed as a tiebreaker because a single
+        # report typically lists all 47 counties in MANY tables
+        # (revenue, arrears, expenditure, …). We want the
+        # budget-execution table specifically, identified by header
+        # words that survive each rewording cycle.
+        anchored = find_table_by_row_anchors(
+            self.tables,
+            list(KENYAN_COUNTIES),
+            min_matches=30,
+            header_synonyms=[
+                ["budget", "expenditure"],
+                ["budget", "estimates", "actual"],
+                ["approved", "actual"],
+                ["allocated", "absorbed"],
+                ["budget", "absorption"],
+            ],
         )
-        if not budget_table:
+
+        # ── Legacy fallback: original 3-keyword header probe ───────
+        # Kept so the existing test fixtures and any older PDFs that
+        # still use the literal "allocated"/"absorbed" wording still
+        # work. The anchor pass above handles every vintage we've
+        # seen since 2024.
+        if anchored is None:
+            anchored = find_table_by_header(
+                self.tables, ["county", "allocated", "absorbed"]
+            )
+        if anchored is None:
             raise TableNotFoundError(
                 "Could not find county budget execution table in report"
             )
 
-        records: List[Dict[str, Any]] = []
-        records.extend(
-            self._rows_to_records(budget_table, category="Total")
-        )
+        # Two-row "group / sub" headers (Budget Estimates over
+        # Rec/Dev/Total) collapse to flat labels like "Budget Estimates
+        # Total" so the column-index lookup below has something
+        # unambiguous to match.
+        budget_table = flatten_grouped_headers(anchored)
 
-        # ── Recurrent / Development / Personnel Emoluments ─────────
-        # Best-effort: each helper logs a warning and returns [] when
-        # the table isn't in this particular PDF.
-        records.extend(self._extract_category("Recurrent", ["recurrent"]))
-        records.extend(self._extract_category("Development", ["development"]))
+        records: List[Dict[str, Any]] = []
+
+        # ── Extract Total / Recurrent / Development from the same
+        # consolidated table by picking different sub-columns ──────
+        for category, allocated_synonyms, absorbed_synonyms, rate_synonyms in [
+            (
+                "Total",
+                [
+                    ["budget", "estimates", "total"],
+                    ["approved", "budget", "total"],
+                    ["allocated", "total"],
+                    ["allocated"],  # legacy single-column tables
+                ],
+                [
+                    ["actual", "expenditure", "total"],
+                    ["expenditure", "total"],
+                    ["absorbed", "total"],
+                    ["absorbed"],
+                ],
+                [
+                    ["absorption", "rate", "total"],
+                    ["absorption", "total"],
+                    ["absorption", "rate"],
+                    ["absorption"],
+                    ["rate"],  # legacy fixture / older PDFs
+                ],
+            ),
+            (
+                "Recurrent",
+                [
+                    ["budget", "estimates", "rec"],
+                    ["approved", "budget", "rec"],
+                    ["recurrent", "allocated"],
+                    ["recurrent", "budget"],
+                ],
+                [
+                    ["actual", "expenditure", "rec"],
+                    ["recurrent", "expenditure"],
+                    ["recurrent", "absorbed"],
+                ],
+                [
+                    ["absorption", "rate", "rec"],
+                    ["recurrent", "absorption"],
+                ],
+            ),
+            (
+                "Development",
+                [
+                    ["budget", "estimates", "dev"],
+                    ["approved", "budget", "dev"],
+                    ["development", "allocated"],
+                    ["development", "budget"],
+                ],
+                [
+                    ["actual", "expenditure", "dev"],
+                    ["development", "expenditure"],
+                    ["development", "absorbed"],
+                ],
+                [
+                    ["absorption", "rate", "dev"],
+                    ["development", "absorption"],
+                ],
+            ),
+        ]:
+            allocated_col = find_column_index(budget_table.headers, allocated_synonyms)
+            absorbed_col = find_column_index(budget_table.headers, absorbed_synonyms)
+            rate_col = find_column_index(budget_table.headers, rate_synonyms)
+            # We only require the allocated and absorbed columns;
+            # absorption rate is derivable when missing.
+            if allocated_col is None or absorbed_col is None:
+                continue
+            records.extend(
+                self._rows_from_columns(
+                    budget_table,
+                    category=category,
+                    allocated_col=allocated_col,
+                    absorbed_col=absorbed_col,
+                    rate_col=rate_col,
+                )
+            )
+
+        # Personnel Emoluments still lives in its own table when
+        # present — the consolidated table doesn't break PE out.
         records.extend(
             self._extract_category(
                 "Personnel Emoluments",
@@ -367,6 +656,62 @@ class CoBQuarterlyReportParser:
             )
             return []
         return self._rows_to_records(table, category=category, subcategory=subcategory)
+
+    def _rows_from_columns(
+        self,
+        table: ExtractedTable,
+        *,
+        category: str,
+        allocated_col: int,
+        absorbed_col: int,
+        rate_col: Optional[int],
+        subcategory: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Like ``_rows_to_records`` but picks values by EXPLICIT column
+        index instead of fixed positions 1/2/3. Required for multi-column
+        consolidated tables where the same row contains Rec / Dev / Total
+        sub-columns for both budget-estimates AND actual-expenditure
+        sides — fixed positions can't address them all."""
+        out: List[Dict[str, Any]] = []
+        for row in table.rows:
+            try:
+                county_name = (row[0] or "").strip()
+                if not county_name:
+                    continue
+                low = county_name.lower()
+                if any(
+                    kw in low
+                    for kw in ("total", "average", "summary", "grand total")
+                ):
+                    continue
+                # Defensive: skip if the row is shorter than the
+                # column we want to read.
+                if len(row) <= max(allocated_col, absorbed_col):
+                    continue
+
+                allocated, currency = parse_currency(row[allocated_col])
+                absorbed, _ = parse_currency(row[absorbed_col])
+                absorption_rate = None
+                if rate_col is not None and len(row) > rate_col:
+                    absorption_rate = parse_percentage(row[rate_col])
+
+                out.append(
+                    {
+                        "county": county_name,
+                        "category": category,
+                        "subcategory": subcategory,
+                        "allocated": allocated,
+                        "absorbed": absorbed,
+                        "absorption_rate": absorption_rate,
+                        "currency": currency,
+                        "quarter": self._extract_quarter(),
+                        "fiscal_year": self._extract_fiscal_year(),
+                    }
+                )
+            except (IndexError, ValueError) as e:
+                logger.warning("Failed to parse row %s: %s", row, e)
+                continue
+        return out
 
     def _rows_to_records(
         self,

--- a/backend/seeding/pdf_parsers.py
+++ b/backend/seeding/pdf_parsers.py
@@ -643,6 +643,29 @@ class CoBQuarterlyReportParser:
                 )
             )
 
+        # ── Backward-compat fallbacks for older PDF formats ────────
+        # Pre-FY2024 reports published Recurrent / Development as
+        # SEPARATE tables rather than as sub-columns of a consolidated
+        # one. The new parser path above prefers the consolidated table,
+        # but if a category came up empty we try the legacy separate-
+        # table path before giving up — so old fixtures and any older
+        # vintage that resurfaces still produce useful output.
+        extracted_categories = {r["category"] for r in records}
+        for category, header_keywords in (
+            ("Recurrent", ["recurrent"]),
+            ("Development", ["development"]),
+        ):
+            if category in extracted_categories:
+                continue
+            fallback = self._extract_category(category, header_keywords)
+            if fallback:
+                logger.info(
+                    "%s category extracted via legacy separate-table fallback "
+                    "(consolidated table didn't carry it)",
+                    category,
+                )
+                records.extend(fallback)
+
         # Personnel Emoluments still lives in its own table when
         # present — the consolidated table doesn't break PE out.
         records.extend(
@@ -724,9 +747,21 @@ class CoBQuarterlyReportParser:
 
                 allocated, currency = parse_currency(row[allocated_col])
                 absorbed, _ = parse_currency(row[absorbed_col])
-                absorption_rate = None
+                absorption_rate: Optional[float] = None
                 if rate_col is not None and len(row) > rate_col:
                     absorption_rate = parse_percentage(row[rate_col])
+                # Derive when missing or unparseable. Some vintages drop
+                # the absorption-rate sub-column entirely; downstream
+                # consumers (the /budget/overview probe in particular)
+                # expect this field, so compute it ourselves rather than
+                # leaving a None that propagates as a UI gap.
+                if (
+                    absorption_rate is None
+                    and allocated
+                    and absorbed is not None
+                    and allocated != Decimal("0")
+                ):
+                    absorption_rate = float(absorbed / allocated * Decimal("100"))
 
                 out.append(
                     {

--- a/backend/tests/test_pdf_parsers.py
+++ b/backend/tests/test_pdf_parsers.py
@@ -299,6 +299,60 @@ class TestCoBQuarterlyReportParser:
         assert "Elgeyo-Marakwet" in counties
 
     @patch("seeding.pdf_parsers.extract_all_tables")
+    def test_derives_absorption_rate_when_column_missing(self, mock_extract):
+        """Some BIRR vintages drop the absorption-rate sub-column.
+        We should compute it ourselves from absorbed/allocated rather
+        than leak a None into downstream consumers (the
+        /budget/overview probe expects this field)."""
+        from seeding.pdf_parsers import KENYAN_COUNTIES
+
+        # Headers cover Total only — no rate column.
+        mock_extract.return_value = [
+            ExtractedTable(
+                page_number=1, table_index=0,
+                headers=["County", "Budget Estimates Total", "Actual Expenditure Total"],
+                rows=[[c, "1000", "500"] for c in KENYAN_COUNTIES],
+                bbox=(0, 0, 100, 100),
+            )
+        ]
+        records = CoBQuarterlyReportParser(Path("no-rate.pdf")).parse()
+        total = next(r for r in records if r["category"] == "Total")
+        assert total["absorption_rate"] == 50.0
+
+    @patch("seeding.pdf_parsers.extract_all_tables")
+    def test_falls_back_to_separate_recurrent_table_for_legacy_format(
+        self, mock_extract
+    ):
+        """Pre-FY2024 BIRR PDFs published Recurrent / Development as
+        SEPARATE tables instead of as sub-columns of a consolidated
+        one. The new parser should still pick them up via the legacy
+        _extract_category fallback when the consolidated table didn't
+        carry that category — otherwise we silently drop categories
+        for older vintages that resurface."""
+        from seeding.pdf_parsers import KENYAN_COUNTIES
+
+        consolidated_total_only = ExtractedTable(
+            page_number=1, table_index=0,
+            headers=["County", "Budget Estimates Total", "Actual Expenditure Total"],
+            rows=[[c, "1000", "500"] for c in KENYAN_COUNTIES],
+            bbox=(0, 0, 100, 100),
+        )
+        recurrent_separate = ExtractedTable(
+            page_number=2, table_index=0,
+            headers=["County", "Recurrent Allocated", "Recurrent Absorbed", "Rate"],
+            rows=[[c, "600", "400", "67"] for c in KENYAN_COUNTIES],
+            bbox=(0, 0, 100, 100),
+        )
+        mock_extract.return_value = [consolidated_total_only, recurrent_separate]
+
+        records = CoBQuarterlyReportParser(Path("legacy.pdf")).parse()
+        cats = {r["category"] for r in records}
+        assert "Total" in cats
+        assert "Recurrent" in cats, "legacy separate-table fallback should fire"
+        rec_sample = next(r for r in records if r["category"] == "Recurrent")
+        assert rec_sample["allocated"] == Decimal("600")
+
+    @patch("seeding.pdf_parsers.extract_all_tables")
     def test_anchor_score_outranks_header_score(self, mock_extract):
         """Pin sort precedence: anchor count is primary, header
         synonyms are only the tiebreaker. A junk-header table with

--- a/backend/tests/test_pdf_parsers.py
+++ b/backend/tests/test_pdf_parsers.py
@@ -188,6 +188,113 @@ class TestCoBQuarterlyReportParser:
         with pytest.raises(TableNotFoundError):
             parser.parse()
 
+    @patch("seeding.pdf_parsers.extract_all_tables")
+    def test_parse_h1_fy2025_26_layout(self, mock_extract):
+        """Regression: COB H1 FY2025/26 reword headers from
+        Allocated/Absorbed → Budget Estimates / Actual Expenditure
+        and added a two-row "group / Rec/Dev/Total" sub-header.
+        The new parser must:
+          (a) find the table by 47-county anchor (not literal keywords),
+          (b) flatten the two-row header into combined labels,
+          (c) extract Total + Recurrent + Development from one table
+              by addressing different sub-columns.
+        """
+        from seeding.pdf_parsers import KENYAN_COUNTIES
+
+        # Header row + sub-row + 47 county data rows.
+        group_headers = [
+            "County",
+            "Budget Estimates (Kshs.Million)", "", "",
+            "Actual Expenditure (Kshs.Million)", "", "",
+            "Absorption Rate(%)", "", "",
+        ]
+        sub_row = [
+            "", "Rec", "Dev", "Total",
+            "Rec", "Dev", "Total",
+            "Rec", "Dev", "Total",
+        ]
+        county_rows = [
+            [c, "5,000", "3,000", "8,000",
+                 "2,500", "1,200", "3,700",
+                 "50", "40", "46"]
+            for c in KENYAN_COUNTIES
+        ]
+        mock_extract.return_value = [
+            ExtractedTable(
+                page_number=55, table_index=0,
+                headers=group_headers,
+                rows=[sub_row, *county_rows],
+                bbox=(0, 0, 100, 100),
+            )
+        ]
+
+        parser = CoBQuarterlyReportParser(
+            Path("h1-fy2025-26-county-birr.pdf")
+        )
+        records = parser.parse()
+
+        # 47 counties × 3 categories = 141 records (no PE table).
+        assert len(records) == 141
+        cats = {r["category"] for r in records}
+        assert cats == {"Total", "Recurrent", "Development"}
+        counties_seen = {r["county"] for r in records if r["category"] == "Total"}
+        assert "Murang'a" in counties_seen, "apostrophe county must round-trip"
+        assert len(counties_seen) == 47
+
+        # Pin the column-resolution: "Total" must read sub-columns
+        # 3 (Budget Estimates Total) and 6 (Actual Expenditure Total).
+        sample = next(r for r in records if r["county"] == "Nairobi" and r["category"] == "Total")
+        assert sample["allocated"] == Decimal("8000")
+        assert sample["absorbed"] == Decimal("3700")
+        assert sample["absorption_rate"] == 46.0
+
+    @patch("seeding.pdf_parsers.extract_all_tables")
+    def test_picks_budget_table_when_multiple_county_tables_present(
+        self, mock_extract
+    ):
+        """A real BIRR has many tables that all list the 47 counties
+        (revenue, arrears, expenditure, …). The header_synonyms
+        tiebreaker must prefer the budget-execution table over
+        unrelated ones — otherwise we'd parse the arrears table on
+        page 52 instead of the budget table on page 55."""
+        from seeding.pdf_parsers import KENYAN_COUNTIES
+
+        arrears = ExtractedTable(
+            page_number=52, table_index=0,
+            headers=["County", "Arrears as at 31st December 2025", "", "", ""],
+            rows=[
+                ["", "Ordinary OSR", "FIF", "Equitable Share", "Totals"],
+                *[[c, "10", "5", "8", "23"] for c in KENYAN_COUNTIES],
+            ],
+            bbox=(0, 0, 100, 100),
+        )
+        budget = ExtractedTable(
+            page_number=55, table_index=0,
+            headers=[
+                "County",
+                "Budget Estimates (Kshs.Million)", "", "",
+                "Actual Expenditure (Kshs.Million)", "", "",
+            ],
+            rows=[
+                ["", "Rec", "Dev", "Total", "Rec", "Dev", "Total"],
+                *[[c, "1", "2", "3", "1", "1", "2"] for c in KENYAN_COUNTIES],
+            ],
+            bbox=(0, 0, 100, 100),
+        )
+
+        # Arrears comes FIRST in the list — without a header tiebreaker
+        # it would win the anchor match and yield zero useful records.
+        mock_extract.return_value = [arrears, budget]
+        parser = CoBQuarterlyReportParser(Path("multi-table.pdf"))
+        records = parser.parse()
+
+        assert len(records) > 0, "should pick the budget table over arrears"
+        # All records must have come from the budget table — its
+        # alloc=3 / abs=2 values are unambiguous.
+        sample = records[0]
+        assert sample["allocated"] == Decimal("3")
+        assert sample["absorbed"] == Decimal("2")
+
 
 class TestOAGAuditReportParser:
     """Test OAG audit report parser."""

--- a/backend/tests/test_pdf_parsers.py
+++ b/backend/tests/test_pdf_parsers.py
@@ -249,6 +249,90 @@ class TestCoBQuarterlyReportParser:
         assert sample["absorption_rate"] == 46.0
 
     @patch("seeding.pdf_parsers.extract_all_tables")
+    def test_anchor_matches_hyphenated_county_forms(self, mock_extract):
+        """Regression: COB sometimes prints "Taita-Taveta" /
+        "Trans-Nzoia" / "Tharaka-Nithi" / "Elgeyo-Marakwet" with a
+        hyphen instead of a space. The canonical anchor list uses the
+        space form. Without hyphen normalisation those rows wouldn't
+        substring-match and we'd silently lose 4 counties from the
+        anchor count — possibly dropping us under the min_matches
+        threshold. Both sides of the comparison must normalise."""
+        from seeding.pdf_parsers import KENYAN_COUNTIES
+
+        hyphen_rows = [
+            ["Taita-Taveta", "1", "2", "3", "1", "1", "2"],
+            ["Tharaka-Nithi", "1", "2", "3", "1", "1", "2"],
+            ["Trans-Nzoia", "1", "2", "3", "1", "1", "2"],
+            ["Elgeyo-Marakwet", "1", "2", "3", "1", "1", "2"],
+        ]
+        # Pad with enough extra space-form counties to clear the
+        # min_matches=30 threshold the parser uses.
+        others = [
+            c for c in KENYAN_COUNTIES
+            if c not in ("Taita Taveta", "Tharaka Nithi", "Trans Nzoia", "Elgeyo Marakwet")
+        ]
+        extra_rows = [[c, "1", "2", "3", "1", "1", "2"] for c in others[:27]]
+        mock_extract.return_value = [
+            ExtractedTable(
+                page_number=55, table_index=0,
+                headers=[
+                    "County",
+                    "Budget Estimates (Kshs.Million)", "", "",
+                    "Actual Expenditure (Kshs.Million)", "", "",
+                ],
+                rows=[
+                    ["", "Rec", "Dev", "Total", "Rec", "Dev", "Total"],
+                    *hyphen_rows,
+                    *extra_rows,
+                ],
+                bbox=(0, 0, 100, 100),
+            )
+        ]
+        records = CoBQuarterlyReportParser(Path("hyphenated.pdf")).parse()
+        counties = {r["county"] for r in records}
+        # The parser preserves the original spelling — the hyphenated
+        # rows are still extracted (we don't rewrite the row label,
+        # only the matching code is hyphen-insensitive).
+        assert "Taita-Taveta" in counties
+        assert "Tharaka-Nithi" in counties
+        assert "Trans-Nzoia" in counties
+        assert "Elgeyo-Marakwet" in counties
+
+    @patch("seeding.pdf_parsers.extract_all_tables")
+    def test_anchor_score_outranks_header_score(self, mock_extract):
+        """Pin sort precedence: anchor count is primary, header
+        synonyms are only the tiebreaker. A junk-header table with
+        all 47 counties must beat a clean-header table with only 2
+        counties — otherwise "invariant-anchored" loses to vocabulary
+        matching, which is the whole bug we're trying to fix."""
+        from seeding.pdf_parsers import (
+            KENYAN_COUNTIES, find_table_by_row_anchors,
+        )
+
+        big_anchor_junk_header = ExtractedTable(
+            page_number=99, table_index=0,
+            headers=["County", "Junk Header"],
+            rows=[["", "x"], *[[c, "1"] for c in KENYAN_COUNTIES]],
+            bbox=(0, 0, 100, 100),
+        )
+        small_anchor_clean_header = ExtractedTable(
+            page_number=1, table_index=0,
+            headers=["County", "Budget Estimates Total", "Actual Expenditure Total"],
+            rows=[["Mombasa", "5", "2"], ["Kwale", "3", "1"]],
+            bbox=(0, 0, 100, 100),
+        )
+        result = find_table_by_row_anchors(
+            [big_anchor_junk_header, small_anchor_clean_header],
+            list(KENYAN_COUNTIES),
+            min_matches=2,
+            header_synonyms=[["budget", "expenditure"]],
+        )
+        assert result is big_anchor_junk_header, (
+            "anchor count must outrank header_score; got page "
+            f"{result.page_number if result else 'None'}"
+        )
+
+    @patch("seeding.pdf_parsers.extract_all_tables")
     def test_picks_budget_table_when_multiple_county_tables_present(
         self, mock_extract
     ):


### PR DESCRIPTION
## Why

The CoB H1 FY2025/26 BIRR was returning **0 records** from live PDF parse, forcing fallback to the static fixture every nightly run. Ran the actual 36 MB report from cob.go.ke through pdfplumber locally and confirmed: the data IS there — the parser's keyword filter just doesn't speak the new vocabulary.

## Two compounding bugs in the old parser

1. **Vocabulary drift** — parser hard-coded `[\"county\", \"allocated\", \"absorbed\"]` as the table-finding keyword set. The H1 PDF uses **\"Budget Estimates\"** and **\"Actual Expenditure\"** — the literal tokens \"allocated\"/\"absorbed\" don't appear anywhere in the relevant tables.
2. **Two-row group/sub headers** — the page-55 budget-execution table now spans two header rows: group label \"Budget Estimates\" over Rec/Dev/Total sub-columns. pdfplumber treats only row 0 as headers, so positional row[1]/row[2] extraction couldn't find the right columns even when keywords matched.

## The fix: invariant-anchored extraction (Layer 1)

Three new helpers in `seeding/pdf_parsers.py`:

- **`find_table_by_row_anchors(tables, anchors, header_synonyms=...)`** — finds the table whose first column matches the most canonical row labels (e.g., 47 Kenyan counties). Header keywords serve only as **tiebreaker**. Survives arbitrary header rewording — row labels stay stable on a decade scale.
- **`flatten_grouped_headers(table)`** — folds the second row into the first when it looks like a sub-header continuation (short cells, no digits), forward-filling group labels across empty cells. Turns `\"Budget Estimates\" / \"\" / \"\" / \"Rec\" / \"Dev\" / \"Total\"` into `\"Budget Estimates Rec\" / \"Budget Estimates Dev\" / \"Budget Estimates Total\"`.
- **`find_column_index(headers, synonym_groups)`** — accepts multiple synonym groups in priority order; returns the first column whose header satisfies any group. Lets one parser handle both legacy (\"Allocated\") and current (\"Budget Estimates Total\") tables without separate code paths.

`KENYAN_COUNTIES` constant added (47 entries, assert at import time).

## CoBQuarterlyReportParser wiring (Layer 2)

- Anchor pass (47 counties + budget header tiebreaker) is now primary; the original 3-keyword `find_table_by_header` is kept as fallback so existing test fixtures + older PDFs still work.
- After anchoring, headers are flattened, then Total / Recurrent / Development are extracted from **a single consolidated table** by addressing different sub-columns (was: scan for three separate tables, typically only finding Total).
- Personnel Emoluments still uses the legacy single-table extraction (lives in its own table).

## Verified against the real PDF

Local parse of pages 50-60 of `cob_h1_fy2025-26.pdf`:

```
TOTAL RECORDS: 120  (40 counties × 3 categories)
by category: {'Total': 40, 'Recurrent': 40, 'Development': 40}
Sample: Baringo Total alloc=9542.03 abs=2463.58 rate=26.0  ← real KSh-millions
```

Up from **0 records** before. (40 < 47 — pdfplumber misses some rows on page boundaries; separate, lower-priority issue.)

## Tests

- `test_parse_budget_execution_report` — legacy 4-column fixture still passes via fallback path.
- `test_raises_error_when_table_not_found` — preserved.
- **`test_parse_h1_fy2025_26_layout`** (new) — 47 counties × 3 categories = 141 records, including Murang'a apostrophe.
- **`test_picks_budget_table_when_multiple_county_tables_present`** (new) — pins the tiebreaker: arrears + budget tables both list 47 counties; parser must pick the budget one.

All four pass locally.

## Test plan
- [ ] CI green.
- [ ] Merge → trigger \"Database Seeding & Data Refresh\".
- [ ] `counties_budget` log shows \"Parsed COB county BIRR PDF (N records, …)\" with **N >> 0** (likely 100-141 instead of 0).
- [ ] Database receives real H1 FY2025/26 data, not just the fixture.

## Scope reminder

This is **Option 1** — Layer 1 helpers + counties_budget wiring only. The same Layer 1 helpers will benefit Treasury / national_budget / pending_bills passively (they share `find_table_by_header` and `extract_all_tables`), but they don't gain their own invariant anchors yet. If this lands cleanly we'll do **Option 2** in a follow-up: wire `TreasuryDebtBulletinParser` to anchor on canonical lender names, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)