### PR TITLE
fix(pdf): walk anchored candidates + validate columns before committing

### DIFF
--- a/backend/seeding/pdf_parsers.py
+++ b/backend/seeding/pdf_parsers.py
@@ -329,6 +329,66 @@ def find_table_by_row_anchors(
     return candidates[0][2]
 
 
+def rank_tables_by_row_anchors(
+    tables: List[ExtractedTable],
+    anchors: List[str],
+    *,
+    min_matches: int = 30,
+    column: int = 0,
+    header_synonyms: Optional[List[List[str]]] = None,
+) -> List[ExtractedTable]:
+    """Like ``find_table_by_row_anchors`` but returns ALL qualifying
+    candidates ranked best-first, instead of only the top hit.
+
+    Why this exists: in real reports, ranking-by-anchor-count can be
+    fooled. A 700-page CoB BIRR has multiple tables that list all 47
+    counties (Arrears, Expenditure, Pending Bills, …). The single-pick
+    version commits to the top-scoring candidate even if that candidate
+    turns out to be unparseable for the caller's use-case (e.g. Arrears
+    has no "allocated" column). With the ranked list the caller can
+    walk it, validating each table — if column resolution fails on
+    candidate #1, fall through to candidate #2, etc. That makes the
+    pipeline robust to noisy pdfplumber output and to PDFs where the
+    "right" table isn't the highest-scoring one.
+
+    Same scoring/normalisation as the single-pick version. Stable sort
+    so PDF order breaks ties beyond anchor + header score.
+    """
+    def _normalise(s: str) -> str:
+        s = s.lower().replace("'", "").replace("\u2019", "")
+        for ch in ("-", "\u2010", "\u2011", "\u2012", "\u2013", "\u2014", "\u2015"):
+            s = s.replace(ch, " ")
+        return re.sub(r"\s+", " ", s).strip()
+
+    normalised_anchors = [_normalise(a) for a in anchors]
+    candidates: List[Tuple[int, int, ExtractedTable]] = []
+    for table in tables:
+        if not table.rows:
+            continue
+        col_values = [
+            _normalise(row[column]) if len(row) > column else ""
+            for row in table.rows
+        ]
+        anchor_score = sum(
+            1 for a in normalised_anchors if any(a in v for v in col_values)
+        )
+        if anchor_score < min_matches:
+            continue
+        header_score = 0
+        if header_synonyms is not None:
+            haystack = " ".join(table.headers).lower()
+            if table.rows:
+                haystack += " " + " ".join(table.rows[0]).lower()
+            header_score = sum(
+                1
+                for group in header_synonyms
+                if all(kw.lower() in haystack for kw in group)
+            )
+        candidates.append((anchor_score, header_score, table))
+    candidates.sort(key=lambda t: (t[0], t[1]), reverse=True)
+    return [t for _, _, t in candidates]
+
+
 def flatten_grouped_headers(table: ExtractedTable) -> ExtractedTable:
     """Fold a two-row "group label / sub-label" header into single labels.
 
@@ -500,20 +560,33 @@ class CoBQuarterlyReportParser:
         """
         self.tables = extract_all_tables(self.pdf_path)
 
-        # ── Primary path: invariant-anchored lookup ────────────────
+        # ── Primary path: invariant-anchored, validator-driven ─────
         # COB reword the table headers every couple of vintages
         # ("Allocated"/"Absorbed" → "Budget Estimates"/"Actual
         # Expenditure" in FY2025/26), but the row labels stay constant
         # — there are always 47 Kenyan counties down the left column.
-        # Find the table by counting county-name matches; that
-        # survives any future header drift.
         #
-        # Header synonyms are passed as a tiebreaker because a single
-        # report typically lists all 47 counties in MANY tables
-        # (revenue, arrears, expenditure, …). We want the
-        # budget-execution table specifically, identified by header
-        # words that survive each rewording cycle.
-        anchored = find_table_by_row_anchors(
+        # A 700-page BIRR typically has SEVERAL tables that list all
+        # 47 counties (Arrears, Pending Bills, Recurrent/Development
+        # Expenditure, the consolidated Budget Execution table, …).
+        # Anchor-count ranking alone picks the wrong one in real PDFs:
+        # the Arrears table on page 52 had 45 county hits and beat the
+        # actual budget table on page 55 (39 hits) in CI run
+        # 24934906752. The header-synonym tiebreaker is too easy to
+        # spoof when pdfplumber returns degraded headers.
+        #
+        # Robust answer: get the RANKED candidate list and walk it,
+        # validating each one against the parser's actual needs (can
+        # we resolve a "Total allocated" column?). First validating
+        # candidate wins; reject others with a debug log so future
+        # mis-picks are visible.
+        primary_total_synonyms: List[List[str]] = [
+            ["budget", "estimates", "total"],
+            ["approved", "budget", "total"],
+            ["allocated", "total"],
+            ["allocated"],
+        ]
+        ranked = rank_tables_by_row_anchors(
             self.tables,
             list(KENYAN_COUNTIES),
             min_matches=30,
@@ -526,25 +599,34 @@ class CoBQuarterlyReportParser:
             ],
         )
 
+        budget_table: Optional[ExtractedTable] = None
+        for candidate in ranked:
+            flat = flatten_grouped_headers(candidate)
+            if find_column_index(flat.headers, primary_total_synonyms) is not None:
+                budget_table = flat
+                break
+            logger.info(
+                "Anchored candidate at page %d rejected — no Total allocated column",
+                candidate.page_number,
+                extra={"page": candidate.page_number, "headers": flat.headers},
+            )
+
         # ── Legacy fallback: original 3-keyword header probe ───────
         # Kept so the existing test fixtures and any older PDFs that
         # still use the literal "allocated"/"absorbed" wording still
         # work. The anchor pass above handles every vintage we've
         # seen since 2024.
-        if anchored is None:
-            anchored = find_table_by_header(
+        if budget_table is None:
+            legacy = find_table_by_header(
                 self.tables, ["county", "allocated", "absorbed"]
             )
-        if anchored is None:
+            if legacy is not None:
+                budget_table = flatten_grouped_headers(legacy)
+
+        if budget_table is None:
             raise TableNotFoundError(
                 "Could not find county budget execution table in report"
             )
-
-        # Two-row "group / sub" headers (Budget Estimates over
-        # Rec/Dev/Total) collapse to flat labels like "Budget Estimates
-        # Total" so the column-index lookup below has something
-        # unambiguous to match.
-        budget_table = flatten_grouped_headers(anchored)
 
         records: List[Dict[str, Any]] = []
 

--- a/backend/tests/test_pdf_parsers.py
+++ b/backend/tests/test_pdf_parsers.py
@@ -353,6 +353,59 @@ class TestCoBQuarterlyReportParser:
         assert rec_sample["allocated"] == Decimal("600")
 
     @patch("seeding.pdf_parsers.extract_all_tables")
+    def test_validator_falls_through_top_anchor_when_columns_unresolvable(
+        self, mock_extract
+    ):
+        """Regression for the seeding run on 2026-04-25
+        ([24934906752](https://github.com/Rodgers31/audit_app/actions/runs/24934906752)):
+
+        Real BIRR PDF had FIVE tables with >=30 county anchors. The
+        Arrears table on page 52 ranked highest (45 anchors, no
+        budget keywords); the Budget Execution table on page 55 ranked
+        third (39 anchors). Tiebreaker rules can't recover from this —
+        the parser must validate each candidate against its actual
+        column needs and fall through when the top pick can't supply
+        a usable Total/allocated column.
+        """
+        from seeding.pdf_parsers import KENYAN_COUNTIES
+
+        # Top-ranked: many county rows but no budget column.
+        arrears_high_anchor = ExtractedTable(
+            page_number=52, table_index=0,
+            headers=["County", "Arrears (Kshs.Million)", "", "", ""],
+            rows=[
+                ["", "Ordinary OSR", "FIF", "Equitable Share", "Totals"],
+                *[[c, "10", "5", "8", "23"] for c in KENYAN_COUNTIES],  # 47 hits
+            ],
+            bbox=(0, 0, 100, 100),
+        )
+        # Lower-ranked: fewer counties but the actual budget data.
+        budget_lower_anchor = ExtractedTable(
+            page_number=55, table_index=0,
+            headers=[
+                "County",
+                "Budget Estimates (Kshs.Million)", "", "",
+                "Actual Expenditure (Kshs.Million)", "", "",
+            ],
+            rows=[
+                ["", "Rec", "Dev", "Total", "Rec", "Dev", "Total"],
+                # Only 35 counties → 35 anchors, less than arrears_high's 47.
+                *[[c, "1", "2", "3", "1", "1", "2"]
+                  for c in KENYAN_COUNTIES[:35]],
+            ],
+            bbox=(0, 0, 100, 100),
+        )
+        mock_extract.return_value = [arrears_high_anchor, budget_lower_anchor]
+
+        records = CoBQuarterlyReportParser(Path("validator.pdf")).parse()
+
+        assert records, "validator must fall through arrears to budget"
+        # Budget table values are alloc=3 / abs=2 — Arrears would have
+        # been alloc=8 (Equitable Share) / abs=23 (Totals).
+        assert records[0]["allocated"] == Decimal("3")
+        assert records[0]["absorbed"] == Decimal("2")
+
+    @patch("seeding.pdf_parsers.extract_all_tables")
     def test_anchor_score_outranks_header_score(self, mock_extract):
         """Pin sort precedence: anchor count is primary, header
         synonyms are only the tiebreaker. A junk-header table with


### PR DESCRIPTION
## What this run revealed

Last seeding run after PR #73 ([24934906752](https://github.com/Rodgers31/audit_app/actions/runs/24934906752)) **partially worked but picked the wrong table**:

```
counties_budget: completed | created=20 updated=0 processed=20
```

20 records came from the legacy `_extract_category(\"Recurrent\"/\"Development\")` fallback — meaning the consolidated extraction returned nothing. The log gave us exactly why:

```
Skipping consolidated category — required columns not resolved
  available_headers: [
    \"County\",
    \"Arrears as at 31st December 2025(Kshs.Million) Ordinary OSR\",
    \"Arrears as at 31st December 2025(Kshs.Million) FIF\",
    ...
  ]
```

That's the **Arrears table** on page 52, not the budget table on page 55.

## Diagnostic

Walked the full PDF, dumped every table with ≥30 county anchors:

| page | anchors | budget kw | expend kw |
|---|---|---|---|
| 52 (Arrears) | **45** | ❌ | ❌ |  ← currently picked  |
| 54 | 36 | ❌ | ✅ |
| **55 (Budget)** | 39 | **✅** | **✅** | ← what we want |
| 57 | 30 | ✅ | ✅ |
| 58 | 43 | ✅ | ❌ |

No fixed sort key recovers from this. Anchor-primary picks Arrears (45 hits); header-primary would over-promote tiny tables. The unit tests passed because in synthetic data the budget table cleanly wins both scores; real PDFs are noisier.

## Fix

The parser must **validate each candidate against its actual extraction needs** and fall through if the top pick can't supply a usable Total/allocated column.

- New helper `rank_tables_by_row_anchors(...)` returns the **full list** of qualifying candidates ranked best-first (was: only top hit).
- `CoBQuarterlyReportParser.parse()` walks the list. For each candidate it flattens grouped headers and tries to resolve the Total/allocated column. First success wins; rejected candidates are logged at INFO so future mis-picks are visible.
- Legacy `find_table_by_header(...)` fallback preserved for pre-FY2024 fixtures.
- Single-pick `find_table_by_row_anchors(...)` kept for callers that don't need the validator pattern.

## Verified against the real PDF

Pages 50-60 of `cob_h1_fy2025-26.pdf` with both Arrears and Budget tables in the candidate set:

```
records: 120  (40 counties × Total + Recurrent + Development)
sample: Baringo Total alloc=9542.03 abs=2463.58 rate=26.0
```

Up from **20 records** the broken selection produced in CI.

## Test

`test_validator_falls_through_top_anchor_when_columns_unresolvable` pins the exact production scenario: arrears table with 47 anchors but no budget keywords beats budget table with 35 anchors on ranking; validator must reject arrears and pick budget anyway.

All 11 tests in `TestCoBQuarterlyReportParser` pass.

## Test plan
- [ ] CI green.
- [ ] Merge → trigger seeding workflow.
- [ ] `counties_budget` log shows ≥100 records (likely 120-141), not 20.
- [ ] Log shows \"Anchored candidate at page 52 rejected — no Total allocated column\" before the successful pick on page 55. Means the validator is doing its job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)