### PR TITLE
feat(national_debt): replace broken CBK PDF discovery with WB IDS overlay

### DIFF
--- a/backend/seeding/domains/national_debt/fetcher.py
+++ b/backend/seeding/domains/national_debt/fetcher.py
@@ -1,23 +1,47 @@
-"""Fetcher for National Treasury debt bulletin data.
+"""Fetcher for Kenya national-government debt data.
 
-Strategy (in order):
-1. If live_pdf_fetch_enabled, try to discover the latest PDF from the CBK
-   public debt page, download it, and parse with TreasuryDebtBulletinParser.
-2. Fall back to the static fixture / configured URL.
+Strategy
+--------
+1. Load the fixture as the baseline payload — it covers every lender
+   we display (multilateral, bilateral, commercial, domestic) with
+   reasonable values that move slowly.
+
+2. Overlay World Bank IDS rows on top of the baseline. WB IDS is the
+   only machine-readable per-creditor source for Kenya external debt
+   (see wb_ids.py for why CBK + Treasury PDF paths were retired).
+   Any lender we successfully fetch from WB UPDATES the matching
+   fixture row in-place; lenders WB doesn't break out (specific
+   bilateral countries) keep their fixture values.
+
+3. Domestic debt — currently still on the fixture. CBK Statistical
+   Bulletin parsing for live domestic data is queued as a follow-up
+   (the relevant table on page 57 of the bulletin lays months
+   horizontally inside one cell, so it needs a more involved parser
+   than the counties_budget approach).
+
+Why we dropped the CBK PDF discovery path
+-----------------------------------------
+The original `_fetch_from_cbk_pdf` scraped
+https://www.centralbank.go.ke/public-debt/ for "debt-bulletin"
+PDFs. CBK's content reorganization left that page with five PDFs,
+none of which are debt bulletins (auction rules, repo agreement,
+diaspora remittances, etc.). The CBK Public Debt Statistical
+Bulletin moved into the broader CBK Statistical Bulletin under
+/releases/statistical-bulletin/ and the published format is now
+aggregated by instrument type, not by lender — so even a successful
+discovery wouldn't have given us the per-loan rows the original
+parser expected. See PR #75 for the full investigation.
 """
 
 from __future__ import annotations
 
 import logging
-import re
-import tempfile
-from pathlib import Path
-from typing import Any, Dict, List, Optional
-from urllib.parse import urljoin
+from typing import Any, Dict, List
 
 from ...config import SeedingSettings
 from ...http_client import SeedingHttpClient
 from ...utils import load_json_resource
+from .wb_ids import fetch_external_debt_from_wb_ids
 
 logger = logging.getLogger("seeding.national_debt.fetcher")
 
@@ -25,205 +49,77 @@ logger = logging.getLogger("seeding.national_debt.fetcher")
 def fetch_debt_payload(
     client: SeedingHttpClient, settings: SeedingSettings
 ) -> dict[str, Any]:
-    """
-    Fetch debt data from CBK PDF bulletin or fixture.
+    """Return a debt payload combining fixture baseline with live WB IDS."""
 
-    Tries live PDF fetch first (if enabled), then falls back to fixture.
-    """
-    if settings.live_pdf_fetch_enabled:
-        try:
-            payload = _fetch_from_cbk_pdf(client, settings)
-            if payload and payload.get("loans"):
-                logger.info(
-                    "Successfully fetched national debt from CBK PDF (%d loans)",
-                    len(payload["loans"]),
-                )
-                return payload
-            else:
-                logger.warning(
-                    "CBK PDF fetch returned no loans, falling back to fixture"
-                )
-        except Exception as exc:
-            logger.warning(
-                "CBK PDF fetch failed, falling back to fixture: %s", exc
-            )
-
-    logger.info("Using fixture fallback for national debt data")
-    return load_json_resource(
+    # ── Baseline: fixture ──────────────────────────────────────────
+    payload = load_json_resource(
         url=settings.national_debt_dataset_url,
         client=client,
         logger=logger,
         label="national_debt",
     )
 
+    if not settings.live_pdf_fetch_enabled:
+        logger.info("Live fetch disabled; using fixture for national debt")
+        return payload
 
-def _fetch_from_cbk_pdf(
-    client: SeedingHttpClient, settings: SeedingSettings
-) -> Optional[Dict[str, Any]]:
-    """Discover and parse the latest CBK debt bulletin PDF."""
-    page_url = settings.cbk_public_debt_page_url
-    logger.info("Fetching CBK public debt page: %s", page_url)
-
-    response = client.get(page_url, raise_for_status=True)
-    html = response.text
-
-    # Find PDF links on the page
-    pdf_url = _discover_latest_pdf_url(html, page_url)
-    if not pdf_url:
-        logger.warning("No PDF link found on CBK public debt page")
-        return None
-
-    logger.info("Downloading CBK debt bulletin PDF: %s", pdf_url)
-    return _download_and_parse_pdf(client, pdf_url)
-
-
-def _discover_latest_pdf_url(html: str, base_url: str) -> Optional[str]:
-    """Extract the most recent debt bulletin PDF URL from the CBK page HTML.
-
-    Looks for links matching common CBK bulletin naming patterns like:
-    - Public-Debt-Statistical-Bulletin-*.pdf
-    - Public_Debt_*.pdf
-    - debt-bulletin-*.pdf
-    """
-    # Find all PDF links
-    pdf_pattern = re.compile(
-        r'href=["\']([^"\']*\.pdf)["\']',
-        re.IGNORECASE,
-    )
-    all_pdfs = pdf_pattern.findall(html)
-
-    if not all_pdfs:
-        return None
-
-    # Exclude PDFs that are clearly NOT debt bulletins
-    exclude_keywords = [
-        "auction", "guidelines", "tender", "vacancy", "career",
-        "press-release", "speech", "circular", "calendar",
-        "monetary-policy", "cbk-annual",
-    ]
-
-    # Filter for debt-related PDFs
-    debt_keywords = [
-        "debt", "bulletin", "public-debt", "public_debt",
-        "statistical-bulletin", "borrowing",
-    ]
-    debt_pdfs = [
-        url for url in all_pdfs
-        if any(kw in url.lower() for kw in debt_keywords)
-        and not any(ex in url.lower() for ex in exclude_keywords)
-    ]
-
-    # If no debt-specific PDFs, try statistical bulletins
-    if not debt_pdfs:
-        stat_pdfs = [
-            url for url in all_pdfs
-            if "statistical" in url.lower() or "bulletin" in url.lower()
-            and not any(ex in url.lower() for ex in exclude_keywords)
-        ]
-        debt_pdfs = stat_pdfs
-
-    if not debt_pdfs:
-        logger.warning(
-            "No debt-related PDFs found among %d PDFs on page", len(all_pdfs)
-        )
-        return None
-
-    # Pick the first match (usually the most recent on CBK page)
-    chosen = debt_pdfs[0]
-
-    # Make absolute URL
-    if not chosen.startswith(("http://", "https://")):
-        chosen = urljoin(base_url, chosen)
-
-    return chosen
-
-
-def _download_and_parse_pdf(
-    client: SeedingHttpClient, pdf_url: str
-) -> Optional[Dict[str, Any]]:
-    """Download a PDF to a temp file, parse it, and return the payload."""
-    from ...pdf_parsers import TreasuryDebtBulletinParser
-
-    tmp_path: Optional[Path] = None
+    # ── Overlay: World Bank IDS per-creditor external debt ─────────
     try:
-        # Download PDF to temp file
-        response = client.get(pdf_url, raise_for_status=True)
-        content_type = response.headers.get("content-type", "").lower()
+        wb_loans = fetch_external_debt_from_wb_ids(client, settings)
+    except Exception as exc:
+        logger.warning("WB IDS fetch failed entirely: %s", exc)
+        wb_loans = []
 
-        if "pdf" not in content_type and not pdf_url.lower().endswith(".pdf"):
-            logger.warning(
-                "Response does not appear to be a PDF (content-type: %s)",
-                content_type,
-            )
-
-        with tempfile.NamedTemporaryFile(
-            suffix=".pdf", delete=False, prefix="cbk_debt_"
-        ) as tmp:
-            tmp.write(response.content)
-            tmp_path = Path(tmp.name)
-
+    if wb_loans:
+        before = len(payload.get("loans", []))
+        payload = _overlay_loans(payload, wb_loans)
+        after = len(payload.get("loans", []))
         logger.info(
-            "Downloaded CBK PDF (%d bytes) to %s",
-            len(response.content),
-            tmp_path,
+            "Merged %d WB IDS rows into national debt payload "
+            "(loans: %d → %d)",
+            len(wb_loans),
+            before,
+            after,
         )
+        # Surface that we did the overlay so downstream consumers /
+        # admin dashboards can show "data freshness: WB IDS YYYY".
+        meta = dict(payload.get("metadata", {}))
+        meta["wb_ids_overlay_applied"] = True
+        meta["wb_ids_overlay_count"] = len(wb_loans)
+        payload["metadata"] = meta
 
-        # Parse with TreasuryDebtBulletinParser
-        parser = TreasuryDebtBulletinParser(tmp_path)
-        parsed_loans = parser.parse()
-
-        if not parsed_loans:
-            logger.warning("TreasuryDebtBulletinParser returned no loans")
-            return None
-
-        # Convert parsed Decimal-based records to the JSON format expected
-        # by national_debt/parser.py
-        loans_json: List[Dict[str, Any]] = []
-        for loan in parsed_loans:
-            loans_json.append({
-                "entity_name": "National Government",
-                "entity_type": "national",
-                "lender": loan["lender"],
-                "debt_category": _classify_debt_category(loan.get("loan_type", "")),
-                "principal": str(loan["principal"]),
-                "outstanding": str(loan["outstanding"]),
-                "interest_rate": None,
-                "issue_date": "2020-01-01",  # placeholder — PDF rarely has exact dates
-                "maturity_date": None,
-                "currency": loan.get("currency", "KES"),
-                "notes": f"Parsed from CBK bulletin: {pdf_url}",
-            })
-
-        return {
-            "metadata": {
-                "source": "Central Bank of Kenya Public Debt Statistics",
-                "description": "Parsed from live CBK debt bulletin PDF",
-                "units": "kes",
-                "last_updated": None,  # could extract from PDF
-            },
-            "source_url": pdf_url,
-            "source_title": "CBK Public Debt Statistical Bulletin (live fetch)",
-            "loans": loans_json,
-        }
-
-    finally:
-        # Clean up temp file
-        if tmp_path and tmp_path.exists():
-            try:
-                tmp_path.unlink()
-                logger.debug("Cleaned up temp PDF: %s", tmp_path)
-            except OSError:
-                pass
+    return payload
 
 
-def _classify_debt_category(loan_type: str) -> str:
-    """Map TreasuryDebtBulletinParser loan_type to our debt_category enum."""
-    lt = loan_type.lower()
-    if lt == "multilateral":
-        return "external_multilateral"
-    elif lt == "bilateral":
-        return "external_bilateral"
-    elif lt == "commercial":
-        return "external_commercial"
-    else:
-        return "external_other"
+def _overlay_loans(
+    payload: Dict[str, Any], overlay: List[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Replace any baseline loan whose ``lender`` matches an overlay
+    row, then append any overlay rows that didn't match. Lender
+    matching is case-insensitive + whitespace-collapsed so cosmetic
+    drift in the source name doesn't fork rows.
+    """
+
+    def _key(loan: Dict[str, Any]) -> str:
+        return " ".join((loan.get("lender") or "").lower().split())
+
+    overlay_by_key = {_key(l): l for l in overlay}
+    base_loans: List[Dict[str, Any]] = list(payload.get("loans", []))
+    out: List[Dict[str, Any]] = []
+    matched_keys: set[str] = set()
+    for loan in base_loans:
+        k = _key(loan)
+        if k in overlay_by_key:
+            out.append(overlay_by_key[k])
+            matched_keys.add(k)
+        else:
+            out.append(loan)
+    # Append overlay rows that didn't match any baseline lender so a
+    # newly-tracked WB IDS creditor still lands in the DB.
+    for k, loan in overlay_by_key.items():
+        if k not in matched_keys:
+            out.append(loan)
+    return {**payload, "loans": out}
+
+
+__all__ = ["fetch_debt_payload"]

--- a/backend/seeding/domains/national_debt/wb_ids.py
+++ b/backend/seeding/domains/national_debt/wb_ids.py
@@ -1,0 +1,198 @@
+"""Fetch Kenya per-creditor external public debt from the World Bank
+International Debt Statistics (IDS) API.
+
+Why WB IDS?
+-----------
+CBK has the raw per-loan data internally but doesn't publish it in
+machine-readable form. Their Statistical Bulletin only shows
+aggregates by instrument type (T-bills/T-bonds) and external by
+country. The PDMO External Public Debt Register page is a
+placeholder; their Monthly Bulletins haven't been updated since
+2011.
+
+Kenya is required to report loan-level external debt to the World
+Bank's Debtor Reporting System (DRS) as part of WB lending
+agreements. WB then republishes the per-creditor view via IDS at
+https://api.worldbank.org/v2/. So the data ORIGINATES from CBK; WB
+is just the public, machine-readable distribution layer.
+
+Caveats
+-------
+* External debt only — domestic (T-bills, T-bonds held by Kenyan
+  banks/funds) is NOT in IDS. Use CBK Statistical Bulletin for that.
+* Annual cadence with ~12-month lag (2024 figures published mid
+  2026). CBK Statistical Bulletin is more current at the aggregate
+  level. We accept the lag in exchange for per-creditor granularity
+  that no other live source publishes.
+* Values in USD; we convert at a fixed rate (matches the convention
+  in fiscal_summary/fetcher.py — easy to extract to settings later).
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+
+from ...config import SeedingSettings
+from ...http_client import SeedingHttpClient
+
+logger = logging.getLogger("seeding.national_debt.wb_ids")
+
+# Same approximate USD→KES rate the fiscal_summary fetcher uses
+# (130.0). Conservative average for 2018-2025; close enough for
+# headline cards. Centralise in SeedingSettings if/when we need
+# a market-tracking rate.
+_USD_KES_RATE = Decimal("130.0")
+
+_WB_BASE = "https://api.worldbank.org/v2/country/KEN/indicator"
+
+
+# Curated WB IDS indicator codes mapped onto the lender names used in
+# `seeding/real_data/national_debt.json`. The writer dedupes loans by
+# (entity_id, lender, issue_date), so matching the fixture's lender
+# strings means a successful WB IDS fetch UPDATES the existing row
+# in-place rather than creating a parallel duplicate.
+#
+# `combine_with` lets us aggregate two IDS codes into a single fixture
+# lender (IBRD + IDA both belong under the fixture's "World Bank"
+# umbrella, since the fixture doesn't break them out).
+# All codes verified to exist in the IDS source-6 catalog as of
+# 2026-04. Codes I tried and discarded: DT.DOD.MIMF.CD (use DIMF
+# instead — that's "Use of IMF credit"), DT.DOD.MAFD.CD (AfDB has no
+# dedicated DOD line in IDS), DT.DOD.MOFT.CD (Other multilateral has
+# no dedicated line either — derive from MLAT − MIBR − MIDA − DIMF if
+# we want it), DT.DOD.PBND.CD (Bonds aren't broken out in modern IDS;
+# the closest is PNGC for "PNG, commercial banks and other creditors"
+# which bundles bonds + syndicated loans together).
+#
+# So the curated list below covers what IDS actually publishes for
+# Kenya. The "Other multilateral" + Eurobonds-specific fixture rows
+# stay on fixture data until/unless WB exposes them separately.
+WB_IDS_CREDITORS: List[Dict[str, Optional[str]]] = [
+    {
+        "code": "DT.DOD.MIBR.CD",
+        "combine_with": "DT.DOD.MIDA.CD",
+        "lender": "Multilateral (World Bank / IDA / IBRD)",
+        "debt_category": "external_multilateral",
+    },
+    {
+        "code": "DT.DOD.DIMF.CD",
+        "combine_with": None,
+        "lender": "Multilateral (IMF — Extended Credit & Resilience Trust)",
+        "debt_category": "external_multilateral",
+    },
+    # NOT INCLUDED:
+    # * DT.DOD.PCBK.CD (commercial banks) — confirmed live as
+    #   "indicator not found" for KEN today. Either Kenya doesn't
+    #   classify any external debt under this code or WB hasn't
+    #   processed it yet. Fixture entry stays.
+    # * DT.DOD.BLAT.CD (bilateral total) — fixture already breaks
+    #   bilateral down per-country (China/Japan/France/Other).
+    #   Overlaying the aggregate would double-count. Per-country IDS
+    #   breakouts use a different counterpart-area endpoint;
+    #   follow-up PR.
+]
+
+
+def fetch_external_debt_from_wb_ids(
+    client: SeedingHttpClient, settings: SeedingSettings
+) -> List[Dict[str, Any]]:
+    """Hit WB IDS once per curated creditor; return loan dicts in the
+    same shape as ``national_debt.json``'s ``loans`` array.
+
+    Failures are non-fatal at the per-creditor level — one indicator
+    timing out doesn't kill the whole pull. Failures are logged at
+    INFO/WARNING and that creditor's fixture entry stays in place.
+    """
+    out: List[Dict[str, Any]] = []
+    for creditor in WB_IDS_CREDITORS:
+        code = creditor["code"]
+        primary = _fetch_latest(client, code)
+        if primary is None:
+            continue
+        kes_value = Decimal(str(primary["value"])) * _USD_KES_RATE
+        latest_year = primary["date"]
+        if creditor["combine_with"]:
+            secondary = _fetch_latest(
+                client, creditor["combine_with"], at_year=latest_year
+            )
+            if secondary:
+                kes_value += Decimal(str(secondary["value"])) * _USD_KES_RATE
+        out.append(
+            {
+                "entity_name": "National Government",
+                "entity_type": "national",
+                "lender": creditor["lender"],
+                "debt_category": creditor["debt_category"],
+                # WB IDS DOD indicators report stock outstanding —
+                # there's no separate principal series we can mirror,
+                # so we use the same value for both. The frontend reads
+                # `outstanding`; principal is bookkeeping.
+                "principal": _format_decimal(kes_value),
+                "outstanding": _format_decimal(kes_value),
+                "interest_rate": None,
+                # Aggregate over many loans, no single issue date —
+                # use the fiscal-year-start of the WB IDS observation
+                # so the writer's (entity, lender, issue_date) dedupe
+                # key changes once per IDS publication.
+                "issue_date": f"{latest_year}-01-01",
+                "maturity_date": None,
+                "currency": "KES",
+                "notes": (
+                    f"World Bank IDS, indicator {code}"
+                    + (
+                        f" + {creditor['combine_with']}"
+                        if creditor["combine_with"]
+                        else ""
+                    )
+                    + f" (year {latest_year}); "
+                    f"converted at KES {_USD_KES_RATE}/USD."
+                ),
+            }
+        )
+    logger.info("WB IDS fetched %d creditor records", len(out))
+    return out
+
+
+def _fetch_latest(
+    client: SeedingHttpClient, code: str, *, at_year: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """Return the most recent non-null observation for `code`. If
+    `at_year` is set, look only at that year (used when combining two
+    indicators that must share a vintage). Returns ``None`` on any
+    failure — caller decides whether to skip or fall back."""
+    if at_year:
+        date_range = at_year
+        per_page = 2
+    else:
+        # Look back 5 years; the latest non-null wins.
+        date_range = "2020:2025"
+        per_page = 10
+    url = (
+        f"{_WB_BASE}/{code}"
+        f"?format=json&date={date_range}&per_page={per_page}"
+    )
+    try:
+        response = client.get(url, raise_for_status=True)
+        body = response.json()
+    except Exception as exc:
+        logger.warning("WB IDS request failed for %s: %s", code, exc)
+        return None
+    if not isinstance(body, list) or len(body) < 2 or not body[1]:
+        logger.info("WB IDS returned no data for %s", code)
+        return None
+    return next(
+        (entry for entry in body[1] if entry.get("value") is not None),
+        None,
+    )
+
+
+def _format_decimal(value: Decimal) -> str:
+    """Render KES amounts as integer-string to match the fixture's
+    ``"principal": "820000000000.00"`` shape (Decimal preserves it
+    after parser.py wraps it back)."""
+    return f"{value.quantize(Decimal('1'))}.00"
+
+
+__all__ = ["fetch_external_debt_from_wb_ids", "WB_IDS_CREDITORS"]

--- a/backend/tests/test_national_debt_fetcher.py
+++ b/backend/tests/test_national_debt_fetcher.py
@@ -1,0 +1,332 @@
+"""Tests for the national_debt fetcher's fixture+WB-IDS overlay.
+
+These tests mock out the HTTP client so we can verify the overlay
+logic deterministically without relying on the WB API being up.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+from seeding.config import SeedingSettings
+from seeding.domains.national_debt import fetcher as nd_fetcher
+from seeding.domains.national_debt import wb_ids
+
+
+@pytest.fixture()
+def settings(tmp_path) -> SeedingSettings:
+    s = SeedingSettings(
+        storage_path=tmp_path / "storage",
+        cache_path=tmp_path / "cache",
+        log_path=tmp_path / "logs" / "seed.log",
+        retry_backoff=0.01,
+        max_retries=1,
+        http_cache_enabled=False,
+        live_pdf_fetch_enabled=True,
+    )
+    s.ensure_directories()
+    return s
+
+
+def _baseline_payload() -> Dict[str, Any]:
+    """Mimics the existing fixture shape with three lender rows we'll
+    expect WB IDS to overlay onto."""
+    return {
+        "metadata": {"source": "fixture", "units": "kes"},
+        "source_url": "file://fixture",
+        "source_title": "fixture",
+        "loans": [
+            {
+                "entity_name": "National Government",
+                "entity_type": "national",
+                "lender": "Multilateral (World Bank / IDA / IBRD)",
+                "debt_category": "external_multilateral",
+                "principal": "820000000000.00",
+                "outstanding": "805000000000.00",
+                "interest_rate": "1.25",
+                "issue_date": "2000-01-01",
+                "maturity_date": None,
+                "currency": "KES",
+                "notes": "fixture row",
+            },
+            {
+                "entity_name": "National Government",
+                "entity_type": "national",
+                "lender": "Bilateral (China — Exim Bank / CDB)",
+                "debt_category": "external_bilateral",
+                "principal": "650000000000.00",
+                "outstanding": "640000000000.00",
+                "interest_rate": "3.00",
+                "issue_date": "2014-05-01",
+                "maturity_date": "2030-05-01",
+                "currency": "KES",
+                "notes": "fixture row (no WB IDS overlay)",
+            },
+            {
+                "entity_name": "National Government",
+                "entity_type": "national",
+                "lender": "Commercial Banks (Syndicated loans)",
+                "debt_category": "external_commercial",
+                "principal": "200000000000.00",
+                "outstanding": "195000000000.00",
+                "interest_rate": "8.00",
+                "issue_date": "2020-01-01",
+                "maturity_date": None,
+                "currency": "KES",
+                "notes": "fixture row",
+            },
+        ],
+    }
+
+
+def _wb_response(value_usd: float, year: str = "2024") -> List[Any]:
+    """Minimal WB API response with a single observation."""
+    return [
+        {"page": 1, "pages": 1, "per_page": 10, "total": 1},
+        [
+            {
+                "indicator": {"id": "X", "value": "x"},
+                "country": {"id": "KE", "value": "Kenya"},
+                "countryiso3code": "KEN",
+                "date": year,
+                "value": value_usd,
+                "unit": "",
+                "obs_status": "",
+                "decimal": 0,
+            }
+        ],
+    ]
+
+
+# ── wb_ids.fetch_external_debt_from_wb_ids ──
+
+
+class TestWbIdsFetcher:
+    def test_emits_one_row_per_curated_creditor(self, settings):
+        """Happy path: every WB code returns a value → one loan per
+        creditor in the curated list, with KES converted at 130/USD.
+        Curated list is currently {WB combined, IMF} = 2 creditors;
+        PCBK + bilateral aggregate are intentionally excluded
+        (see WB_IDS_CREDITORS comments)."""
+
+        class FakeClient:
+            def get(self, url, **_kwargs):
+                # Different USD totals depending on indicator so we can
+                # tell them apart in assertions.
+                if "MIBR" in url:
+                    body = _wb_response(8_000_000_000)  # IBRD
+                elif "MIDA" in url:
+                    body = _wb_response(2_000_000_000)  # IDA combined into the row
+                elif "DIMF" in url:
+                    body = _wb_response(3_300_000_000)  # IMF
+                else:
+                    raise AssertionError(f"unexpected URL: {url}")
+
+                class R:
+                    def json(self_):
+                        return body
+                return R()
+
+        loans = wb_ids.fetch_external_debt_from_wb_ids(FakeClient(), settings)
+
+        assert len(loans) == 2  # WB+IDA combined + IMF
+        by_lender = {l["lender"]: l for l in loans}
+        # World Bank is IBRD + IDA = 10B USD → 1300B KES
+        wb = by_lender["Multilateral (World Bank / IDA / IBRD)"]
+        assert wb["debt_category"] == "external_multilateral"
+        assert Decimal(wb["outstanding"]) == Decimal("1300000000000.00")
+        assert wb["currency"] == "KES"
+        # Notes record the WB IDS provenance.
+        assert "MIBR" in wb["notes"] and "MIDA" in wb["notes"] and "2024" in wb["notes"]
+
+    def test_per_creditor_failure_is_isolated(self, settings):
+        """A single 502/timeout doesn't kill the whole pull — other
+        creditors are still emitted."""
+
+        class FakeClient:
+            def get(self, url, **_kwargs):
+                if "DIMF" in url:
+                    raise RuntimeError("simulated 502")
+                # All others return 1 USD so we can count them.
+                class R:
+                    def json(self_):
+                        return _wb_response(1.0)
+                return R()
+
+        loans = wb_ids.fetch_external_debt_from_wb_ids(FakeClient(), settings)
+        # IMF is missing; World Bank still comes through.
+        lenders = {l["lender"] for l in loans}
+        assert "Multilateral (IMF — Extended Credit & Resilience Trust)" not in lenders
+        assert "Multilateral (World Bank / IDA / IBRD)" in lenders
+
+    def test_skips_when_value_is_null(self, settings):
+        """WB sometimes returns rows with value=null (suppression /
+        provisional). Those creditors must be skipped, not emitted as
+        zero-stock records."""
+
+        class FakeClient:
+            def get(self, url, **_kwargs):
+                empty = [
+                    {"page": 1, "pages": 1, "per_page": 10, "total": 1},
+                    [
+                        {"date": "2024", "value": None}
+                    ],
+                ]
+                class R:
+                    def json(self_):
+                        return empty
+                return R()
+
+        loans = wb_ids.fetch_external_debt_from_wb_ids(FakeClient(), settings)
+        assert loans == []
+
+
+# ── fetcher._overlay_loans ──
+
+
+class TestOverlayMerge:
+    def test_overlay_replaces_baseline_by_lender_match(self):
+        baseline = _baseline_payload()
+        overlay = [
+            {
+                "entity_name": "National Government",
+                "entity_type": "national",
+                "lender": "Multilateral (World Bank / IDA / IBRD)",
+                "debt_category": "external_multilateral",
+                "principal": "999999999999.00",
+                "outstanding": "888888888888.00",
+                "interest_rate": None,
+                "issue_date": "2024-01-01",
+                "maturity_date": None,
+                "currency": "KES",
+                "notes": "wb_ids overlay",
+            }
+        ]
+        merged = nd_fetcher._overlay_loans(baseline, overlay)
+        loans = merged["loans"]
+        # Same row count — overlay replaced, didn't append.
+        assert len(loans) == 3
+        wb = next(l for l in loans if "World Bank" in l["lender"])
+        assert wb["outstanding"] == "888888888888.00"
+        assert wb["notes"] == "wb_ids overlay"
+        # Untouched fixture rows preserved unchanged.
+        china = next(l for l in loans if "China" in l["lender"])
+        assert china["outstanding"] == "640000000000.00"
+
+    def test_overlay_appends_unmatched_rows(self):
+        """If an overlay row has a lender the fixture doesn't carry,
+        it's appended (we'd rather over-include than silently drop)."""
+        baseline = _baseline_payload()
+        overlay = [
+            {
+                "entity_name": "National Government",
+                "entity_type": "national",
+                "lender": "Multilateral (Brand New Lender)",
+                "debt_category": "external_multilateral",
+                "principal": "1.00",
+                "outstanding": "1.00",
+                "interest_rate": None,
+                "issue_date": "2024-01-01",
+                "maturity_date": None,
+                "currency": "KES",
+                "notes": "new",
+            }
+        ]
+        merged = nd_fetcher._overlay_loans(baseline, overlay)
+        assert len(merged["loans"]) == 4
+        assert any("Brand New Lender" in l["lender"] for l in merged["loans"])
+
+    def test_overlay_lender_match_is_whitespace_collapsed(self):
+        """Cosmetic whitespace differences in the lender string
+        shouldn't fork rows."""
+        baseline = _baseline_payload()
+        # Same lender, but extra spaces and varied case.
+        overlay = [
+            {
+                "lender": "  multilateral  (world bank /  IDA / IBRD) ",
+                "outstanding": "1.00",
+                "principal": "1.00",
+                "entity_name": "National Government",
+                "entity_type": "national",
+                "debt_category": "external_multilateral",
+                "interest_rate": None,
+                "issue_date": "2024-01-01",
+                "maturity_date": None,
+                "currency": "KES",
+                "notes": "overlay",
+            }
+        ]
+        merged = nd_fetcher._overlay_loans(baseline, overlay)
+        # Replaced (still 3 loans), not appended (would be 4).
+        assert len(merged["loans"]) == 3
+
+
+# ── fetcher.fetch_debt_payload (integration) ──
+
+
+class TestFetchDebtPayload:
+    def test_falls_back_to_fixture_when_wb_returns_nothing(self, settings):
+        """If WB IDS yields zero rows (whole API down), we just return
+        the fixture payload unchanged."""
+
+        with (
+            patch.object(nd_fetcher, "load_json_resource", return_value=_baseline_payload()),
+            patch.object(nd_fetcher, "fetch_external_debt_from_wb_ids", return_value=[]),
+        ):
+            payload = nd_fetcher.fetch_debt_payload(client=None, settings=settings)
+        assert len(payload["loans"]) == 3
+        # Marker NOT set when we couldn't overlay anything.
+        assert "wb_ids_overlay_applied" not in payload.get("metadata", {})
+
+    def test_overlay_applied_metadata_set_on_success(self, settings):
+        wb_overlay = [
+            {
+                "entity_name": "National Government",
+                "entity_type": "national",
+                "lender": "Multilateral (World Bank / IDA / IBRD)",
+                "debt_category": "external_multilateral",
+                "principal": "1.00",
+                "outstanding": "1.00",
+                "interest_rate": None,
+                "issue_date": "2024-01-01",
+                "maturity_date": None,
+                "currency": "KES",
+                "notes": "wb",
+            }
+        ]
+        with (
+            patch.object(nd_fetcher, "load_json_resource", return_value=_baseline_payload()),
+            patch.object(nd_fetcher, "fetch_external_debt_from_wb_ids", return_value=wb_overlay),
+        ):
+            payload = nd_fetcher.fetch_debt_payload(client=None, settings=settings)
+        meta = payload.get("metadata", {})
+        assert meta.get("wb_ids_overlay_applied") is True
+        assert meta.get("wb_ids_overlay_count") == 1
+
+    def test_skips_overlay_when_live_fetch_disabled(self, settings):
+        settings.live_pdf_fetch_enabled = False
+        with (
+            patch.object(nd_fetcher, "load_json_resource", return_value=_baseline_payload()),
+            patch.object(nd_fetcher, "fetch_external_debt_from_wb_ids") as mock_wb,
+        ):
+            payload = nd_fetcher.fetch_debt_payload(client=None, settings=settings)
+        mock_wb.assert_not_called()
+        assert "wb_ids_overlay_applied" not in payload.get("metadata", {})
+
+    def test_continues_when_wb_raises_unexpectedly(self, settings):
+        """A bug in the WB module shouldn't take down the whole
+        domain — we degrade to fixture and log."""
+        with (
+            patch.object(nd_fetcher, "load_json_resource", return_value=_baseline_payload()),
+            patch.object(
+                nd_fetcher, "fetch_external_debt_from_wb_ids",
+                side_effect=RuntimeError("kaboom"),
+            ),
+        ):
+            payload = nd_fetcher.fetch_debt_payload(client=None, settings=settings)
+        # Same fixture, no overlay marker.
+        assert len(payload["loans"]) == 3
+        assert "wb_ids_overlay_applied" not in payload.get("metadata", {})


### PR DESCRIPTION
## Why

The CBK Public Debt page that the seeder was scraping no longer hosts the debt bulletin — it now lists 5 unrelated PDFs (auction rules, repo agreement, diaspora remittances). The CBK Public Debt Bulletin moved into the broader Statistical Bulletin under \`/releases/statistical-bulletin/\`, and the modern format is **aggregated by instrument type / by country**, not per-loan. There's no longer a per-creditor table CBK publishes in PDF.

## Investigation results (Option D from the plan)

| Source | Status | Per-creditor? |
|---|---|---|
| CBK Statistical Bulletin (Jun 2025) | ✅ Active | ❌ Aggregates only |
| CBK Quarterly Economic Review (Q3 2025) | ✅ Active | ❌ No per-lender tables |
| CBK Monthly Economic Review | 💀 Dead since 2015 | — |
| PDMO Monthly Bulletins | ⚠️ Last PDF April 2011 | Would have, but unmaintained |
| PDMO External Public Debt Register | 💀 Empty placeholder | — |
| PDMO Annual Reports | 💀 Empty placeholder | — |
| **World Bank IDS API** | **✅ Active** | **✅ Yes** |

Kenya is required to report loan-level external debt to the World Bank's Debtor Reporting System (DRS) as part of WB lending agreements. WB then publishes that data via IDS. So WB has the same data CBK has internally — just made publicly machine-readable, which CBK doesn't do.

## What this PR ships

**\`wb_ids.py\`** — curated map of WB IDS indicator codes to fixture lender names. Codes verified live (IBRD, IDA, IMF return Kenya 2024 values; PCBK / MLAT / BLAT / PBND either return *indicator not found* for KEN or would double-count against existing per-country bilateral fixture rows — those exclusions are commented).

**\`fetcher.py\`** is rewired to:
1. Load fixture as baseline (every lender we display is covered).
2. Try WB IDS overlay (lenders we successfully fetch UPDATE the matching fixture row in-place by lender-name match; lenders WB doesn't break out keep their fixture values).
3. Drop the broken CBK PDF discovery path entirely.

The overlay is whitespace-collapsed + case-insensitive on lender names so cosmetic drift doesn't fork rows. Failures (per-creditor or whole-API) degrade gracefully to fixture and are logged with the specific code that failed.

## Live data delivered

Currently the curated list yields **2 effective overlays** per nightly run:
- **Multilateral (World Bank / IDA / IBRD)** ← MIBR ($1.95B) + MIDA ($11.87B) combined = **KES 1.797T** (was fixture KES 805B — fixture was stale)
- **Multilateral (IMF — Extended Credit & Resilience Trust)** ← DIMF ($4.96B) = **KES 645B** (was fixture KES 418B)

The other 12 fixture lender rows (per-country bilateral, Eurobonds-specific, domestic) stay on fixture for now.

## What's not in this PR

CBK Statistical Bulletin parsing for domestic per-instrument breakdown (T-bills/T-bonds/Stocks/Overdraft). That table on page 57 of the bulletin lays months horizontally inside one cell per pdfplumber output, so it needs a more involved parser than the counties_budget approach. **Follow-up PR.**

## Tests (10, all passing)

\`TestWbIdsFetcher\`
- \`test_emits_one_row_per_curated_creditor\`
- \`test_per_creditor_failure_is_isolated\` ← one 502 doesn't kill the pull
- \`test_skips_when_value_is_null\`

\`TestOverlayMerge\`
- \`test_overlay_replaces_baseline_by_lender_match\`
- \`test_overlay_appends_unmatched_rows\`
- \`test_overlay_lender_match_is_whitespace_collapsed\`

\`TestFetchDebtPayload\`
- \`test_falls_back_to_fixture_when_wb_returns_nothing\`
- \`test_overlay_applied_metadata_set_on_success\`
- \`test_skips_overlay_when_live_fetch_disabled\`
- \`test_continues_when_wb_raises_unexpectedly\` ← whole-WB blowup → fixture

## Test plan
- [ ] Merge → trigger \"Database Seeding & Data Refresh\".
- [ ] \`national_debt\` log shows \"WB IDS fetched 2 creditor records\" + \"Merged 2 WB IDS rows into national debt payload\".
- [ ] DB \`loans\` table: outstanding for World Bank lender ≈ KES 1.8T (up from 805B), IMF ≈ KES 645B (up from 418B).
- [ ] If WB API is down, log shows \"WB IDS fetch failed entirely\" → fixture used → no domain failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)