### PR TITLE
feat(national_debt): overlay CBK Statistical Bulletin domestic debt

### DIFF
--- a/backend/seeding/config.py
+++ b/backend/seeding/config.py
@@ -171,6 +171,22 @@ class SeedingSettings(BaseSettings):
             "Monthly Statistical Bulletin PDF link."
         ),
     )
+    cbk_statistical_bulletin_url: Optional[str] = Field(
+        default=None,
+        description=(
+            "Direct URL to the latest CBK Statistical Bulletin PDF. "
+            "When set, the national_debt domain extracts Table 4.1.4 "
+            "('Composition of Government Gross Domestic Debt by "
+            "Instrument') and overlays per-instrument domestic debt "
+            "values onto the fixture. When unset (the default) or the "
+            "URL 404s, domestic debt stays on fixture values. "
+            "Example: https://www.centralbank.go.ke/uploads/cbk_"
+            "statistical_bulletins/<hash>/sbull_jun25.pdf — the path "
+            "changes each release, so this is opt-in via env var. "
+            "Auto-discovery from the CBK statistics page is a planned "
+            "follow-up."
+        ),
+    )
     cob_birr_page_url: str = Field(
         default="https://cob.go.ke/publications/national-government-budget-implementation-review-reports/",
         description=(

--- a/backend/seeding/domains/national_debt/cbk_bulletin.py
+++ b/backend/seeding/domains/national_debt/cbk_bulletin.py
@@ -1,0 +1,242 @@
+"""Fetch Kenya domestic debt from the CBK Statistical Bulletin.
+
+Why CBK Statistical Bulletin?
+-----------------------------
+World Bank IDS (see ``wb_ids.py``) covers external debt only —
+domestic debt (T-bills, T-bonds held by Kenyan banks/funds) is not
+in IDS. CBK publishes Table 4.1.4 ("Composition of Government Gross
+Domestic Debt by Instrument") in its biannual Statistical Bulletin,
+broken down by month and instrument type. This is the cleanest
+machine-extractable source for the domestic side.
+
+Caveats
+-------
+* Biannual cadence (June & December bulletins). Latest figures lag
+  by ~3 months.
+* Values are reported in KES millions; we scale to whole KES to
+  match the fixture's per-loan units.
+* pdfplumber's ``extract_tables()`` is broken on this layout — every
+  data cell gets concatenated with newlines. We use
+  ``extract_text()`` and parse line-by-line, which produces clean
+  per-month rows.
+* The bulletin URL pattern at CBK changes each release. When the
+  configured URL 404s or the parser can't find Table 4.1.4 (CBK
+  occasionally renumbers tables between issues), we degrade silently
+  to fixture and log a warning.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import date
+from decimal import Decimal
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pdfplumber
+
+from ...config import SeedingSettings
+from ...http_client import SeedingHttpClient
+
+logger = logging.getLogger("seeding.national_debt.cbk_bulletin")
+
+# The page text begins:
+#   "Table 4.1.4: Composition of Government Gross Domestic Debt"
+# We anchor on the substring after the table number so a future
+# renumbering (4.1.4 → 4.1.5) doesn't break detection.
+_TABLE_TITLE_ANCHOR = "Composition of Government Gross Domestic Debt"
+
+# Fiscal year section headers look like "2024/2025" on their own line.
+_FY_HEADER_RE = re.compile(r"^(\d{4})/(\d{4})$")
+
+# Month rows look like:
+#   "January 723,139.8 3,304,897.0 0.0 75,150.5 6,301.6 631.5 4,110,120.5"
+# 7 numeric columns (TBills / TBonds / GovStocks / Overdraft / Advances
+# / Other / Total). Numbers carry comma separators and decimals.
+_MONTH_NAMES: Tuple[str, ...] = (
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+)
+_NUM_RE = r"-?[\d,]+\.\d+|-?[\d,]+"
+_MONTH_ROW_RE = re.compile(
+    r"^(?P<month>" + "|".join(_MONTH_NAMES) + r")\s+"
+    + r"\s+".join(f"(?P<c{i}>{_NUM_RE})" for i in range(7))
+    + r"\s*$"
+)
+
+# Map (column index after the month, fixture lender, debt_category).
+# Column 2 (Government Stocks) is always 0 in modern bulletins → omit.
+# Column 6 (Total Domestic Debt) is a sum line, not its own loan → omit.
+# Bills/Bonds/Overdraft match existing fixture lenders so the overlay
+# REPLACES rather than appends. Advances + Other become NEW rows
+# alongside the fixture set (the writer dedupes by entity+lender+date).
+_COLUMN_MAPPINGS: Tuple[Tuple[int, str, str], ...] = (
+    (0, "Domestic Treasury Bills (91-day, 182-day, 364-day)", "domestic_bills"),
+    (1, "Domestic Treasury Bonds", "domestic_bonds"),
+    (3, "CBK Overdraft Facility", "domestic_overdraft"),
+    (4, "Advances from Commercial Banks", "domestic_overdraft"),
+    (5, "Other Domestic Debt", "other"),
+)
+
+# CBK reports values in shillings million; scale to whole KES to
+# match the fixture convention.
+_KES_MILLIONS_SCALE = Decimal("1000000")
+
+
+def fetch_domestic_debt_from_cbk_bulletin(
+    client: SeedingHttpClient, settings: SeedingSettings
+) -> List[Dict[str, Any]]:
+    """Download the CBK Statistical Bulletin, locate Table 4.1.4, and
+    return loan dicts in fixture format.
+
+    Returns ``[]`` on any failure — fetch, missing table, or unparseable
+    rows. Caller (``fetcher._overlay_loans``) treats an empty result as
+    "no overlay applied" and the fixture stays.
+    """
+    url = settings.cbk_statistical_bulletin_url
+    if not url:
+        logger.info("CBK Statistical Bulletin URL not configured; skipping.")
+        return []
+
+    try:
+        pdf_bytes = _download_pdf(client, url)
+    except Exception as exc:
+        logger.warning("CBK bulletin download failed (%s): %s", url, exc)
+        return []
+
+    try:
+        page_text = _extract_domestic_debt_page_text(pdf_bytes)
+    except Exception as exc:
+        logger.warning("CBK bulletin PDF parse failed: %s", exc)
+        return []
+    if page_text is None:
+        logger.info(
+            "CBK bulletin had no Table 4.1.4 page; skipping."
+        )
+        return []
+
+    latest = _parse_latest_month_row(page_text)
+    if latest is None:
+        logger.info(
+            "CBK bulletin yielded no parseable month rows; skipping."
+        )
+        return []
+
+    measurement_date, fiscal_year_start, values = latest
+    loans = _build_loan_records(
+        measurement_date=measurement_date,
+        fiscal_year_start=fiscal_year_start,
+        values=values,
+        source_url=url,
+    )
+    logger.info(
+        "CBK bulletin parsed %d domestic-debt rows (latest: %s)",
+        len(loans), measurement_date.isoformat(),
+    )
+    return loans
+
+
+def _download_pdf(client: SeedingHttpClient, url: str) -> bytes:
+    """Fetch PDF bytes. ``file://`` URLs are read from disk so tests
+    and offline runs don't need a live HTTP path."""
+    if url.startswith("file://"):
+        return Path(url[len("file://"):]).read_bytes()
+    response = client.get(url, raise_for_status=True)
+    return response.content
+
+
+def _extract_domestic_debt_page_text(pdf_bytes: bytes) -> Optional[str]:
+    """Walk pages, return the first one whose text contains the
+    Table 4.1.4 anchor. Returns ``None`` if no page matches."""
+    with pdfplumber.open(BytesIO(pdf_bytes)) as pdf:
+        for page in pdf.pages:
+            text = page.extract_text() or ""
+            if _TABLE_TITLE_ANCHOR in text:
+                return text
+    return None
+
+
+def _parse_latest_month_row(
+    page_text: str,
+) -> Optional[Tuple[date, int, List[Decimal]]]:
+    """Walk lines, tracking the active fiscal-year section header and
+    matching month rows. Return (measurement_date, fy_start, values)
+    for the LAST matching row, or ``None`` if nothing matched.
+
+    Kenya FY runs Jul–Jun. Within FY YYYY/(YYYY+1):
+    Jul–Dec rows fall in calendar year YYYY; Jan–Jun rows fall in
+    calendar year YYYY+1.
+    """
+    fy_start: Optional[int] = None
+    last: Optional[Tuple[date, int, List[Decimal]]] = None
+    for raw in page_text.splitlines():
+        line = raw.strip()
+        m_fy = _FY_HEADER_RE.match(line)
+        if m_fy:
+            fy_start = int(m_fy.group(1))
+            continue
+        m_row = _MONTH_ROW_RE.match(line)
+        if m_row and fy_start is not None:
+            month_name = m_row.group("month")
+            month_idx = _MONTH_NAMES.index(month_name) + 1
+            cal_year = fy_start if month_idx >= 7 else fy_start + 1
+            values = [
+                Decimal(m_row.group(f"c{i}").replace(",", ""))
+                for i in range(7)
+            ]
+            last = (date(cal_year, month_idx, 1), fy_start, values)
+    return last
+
+
+def _build_loan_records(
+    *,
+    measurement_date: date,
+    fiscal_year_start: int,
+    values: List[Decimal],
+    source_url: str,
+) -> List[Dict[str, Any]]:
+    """Map the 7-column row to a list of loan dicts in fixture shape.
+
+    Uses ``issue_date = f"{fy_start}-07-01"`` so repeated bulletin
+    pulls within a fiscal year UPDATE the same row (writer dedupes by
+    entity+lender+issue_date), while a new fiscal year produces a new
+    row — same convention as ``wb_ids.py``. The actual measurement
+    month lives in ``notes`` for human traceability.
+    """
+    issue_date_iso = f"{fiscal_year_start}-07-01"
+    loans: List[Dict[str, Any]] = []
+    for col_idx, lender, category in _COLUMN_MAPPINGS:
+        kes_value = values[col_idx] * _KES_MILLIONS_SCALE
+        if kes_value <= 0:
+            continue
+        loans.append(
+            {
+                "entity_name": "National Government",
+                "entity_type": "national",
+                "lender": lender,
+                "debt_category": category,
+                "principal": _format_decimal(kes_value),
+                "outstanding": _format_decimal(kes_value),
+                "interest_rate": None,
+                "issue_date": issue_date_iso,
+                "maturity_date": None,
+                "currency": "KES",
+                "notes": (
+                    f"CBK Statistical Bulletin Table 4.1.4 "
+                    f"(month-end {measurement_date.isoformat()}); "
+                    f"KES millions scaled to whole KES."
+                ),
+            }
+        )
+    return loans
+
+
+def _format_decimal(value: Decimal) -> str:
+    """Render KES amounts as integer-string to match the fixture's
+    ``"820000000000.00"`` shape."""
+    return f"{value.quantize(Decimal('1'))}.00"
+
+
+__all__ = ["fetch_domestic_debt_from_cbk_bulletin"]

--- a/backend/seeding/domains/national_debt/fetcher.py
+++ b/backend/seeding/domains/national_debt/fetcher.py
@@ -13,11 +13,12 @@ Strategy
    fixture row in-place; lenders WB doesn't break out (specific
    bilateral countries) keep their fixture values.
 
-3. Domestic debt — currently still on the fixture. CBK Statistical
-   Bulletin parsing for live domestic data is queued as a follow-up
-   (the relevant table on page 57 of the bulletin lays months
-   horizontally inside one cell, so it needs a more involved parser
-   than the counties_budget approach).
+3. Overlay CBK Statistical Bulletin Table 4.1.4 ("Composition of
+   Government Gross Domestic Debt by Instrument") on top, when the
+   bulletin URL is configured. CBK is the only live source for the
+   per-instrument domestic split (T-bills/T-bonds/overdraft). See
+   ``cbk_bulletin.py`` for the parsing approach (text-mode regex
+   because pdfplumber's table extractor smushes the cells).
 
 Why we dropped the CBK PDF discovery path
 -----------------------------------------
@@ -41,6 +42,7 @@ from typing import Any, Dict, List
 from ...config import SeedingSettings
 from ...http_client import SeedingHttpClient
 from ...utils import load_json_resource
+from .cbk_bulletin import fetch_domestic_debt_from_cbk_bulletin
 from .wb_ids import fetch_external_debt_from_wb_ids
 
 logger = logging.getLogger("seeding.national_debt.fetcher")
@@ -86,6 +88,33 @@ def fetch_debt_payload(
         meta = dict(payload.get("metadata", {}))
         meta["wb_ids_overlay_applied"] = True
         meta["wb_ids_overlay_count"] = len(wb_loans)
+        payload["metadata"] = meta
+
+    # ── Overlay: CBK Statistical Bulletin domestic debt ────────────
+    # Disjoint from WB IDS — CBK covers the domestic instruments
+    # (T-bills, T-bonds, overdraft) that IDS doesn't publish. Same
+    # overlay merge: fixture lender names that match get replaced;
+    # new lenders (Advances, Other) get appended.
+    try:
+        cbk_loans = fetch_domestic_debt_from_cbk_bulletin(client, settings)
+    except Exception as exc:
+        logger.warning("CBK bulletin fetch failed entirely: %s", exc)
+        cbk_loans = []
+
+    if cbk_loans:
+        before = len(payload.get("loans", []))
+        payload = _overlay_loans(payload, cbk_loans)
+        after = len(payload.get("loans", []))
+        logger.info(
+            "Merged %d CBK bulletin rows into national debt payload "
+            "(loans: %d → %d)",
+            len(cbk_loans),
+            before,
+            after,
+        )
+        meta = dict(payload.get("metadata", {}))
+        meta["cbk_bulletin_overlay_applied"] = True
+        meta["cbk_bulletin_overlay_count"] = len(cbk_loans)
         payload["metadata"] = meta
 
     return payload

--- a/backend/tests/test_national_debt_fetcher.py
+++ b/backend/tests/test_national_debt_fetcher.py
@@ -1,17 +1,22 @@
-"""Tests for the national_debt fetcher's fixture+WB-IDS overlay.
+"""Tests for the national_debt fetcher's fixture+overlay strategy.
 
-These tests mock out the HTTP client so we can verify the overlay
-logic deterministically without relying on the WB API being up.
+The fetcher composes two live overlays (WB IDS for external
+creditors, CBK Statistical Bulletin for domestic instruments) onto a
+fixture baseline. These tests mock out the HTTP client so the
+overlay logic is verified deterministically without depending on
+either upstream being reachable.
 """
 
 from __future__ import annotations
 
+from datetime import date
 from decimal import Decimal
 from typing import Any, Dict, List
 from unittest.mock import patch
 
 import pytest
 from seeding.config import SeedingSettings
+from seeding.domains.national_debt import cbk_bulletin
 from seeding.domains.national_debt import fetcher as nd_fetcher
 from seeding.domains.national_debt import wb_ids
 
@@ -264,6 +269,201 @@ class TestOverlayMerge:
         assert len(merged["loans"]) == 3
 
 
+# ── cbk_bulletin (parser internals) ──
+
+
+# A trimmed slice of real Table 4.1.4 page text covering two fiscal
+# years and a handful of months — enough to exercise the FY-to-
+# calendar-year mapping and the "latest row wins" rule. Numbers are
+# from the June 2025 bulletin (KES millions).
+_REAL_PAGE_TEXT = """\
+4.1 GOVERNMENT FINANCE
+Financing and Stock of Government Debt
+Table 4.1.4: Composition of Government Gross Domestic Debt
+by Instrument Shillings million
+Treasury Treasury Government Overdraft at Advances from Other Domestic Total Domestic
+Fiscal Year
+Bills* Bonds Stocks Central Bank Commercial Banks Debt** Debt***
+2023/2024
+July 602,312.8 4,097,244.5 0.0 61,117.8 14,531.3 98,320.9 4,873,527.3
+August 584,879.9 4,139,722.8 0.0 72,054.1 16,246.8 99,435.4 4,912,338.9
+2024/2025
+July 667,963.1 4,637,887.2 0.0 60,529.1 2,487.1 84,129.1 5,452,995.5
+June 1,052,945.0 5,110,010.0 0.0 67,628.8 14,791.8 80,633.7 6,326,009.3
+* The stock of Treasury bills includes Repos.
+"""
+
+
+class TestCbkBulletinParserInternals:
+    def test_picks_last_month_row_in_page(self):
+        """The latest data point in the page is the only one we keep —
+        prior months are observable history but only the most recent
+        bulletin row drives the overlay."""
+        result = cbk_bulletin._parse_latest_month_row(_REAL_PAGE_TEXT)
+        assert result is not None
+        measurement_date, fy_start, values = result
+        # Last row in the page text is "June ..." inside FY 2024/2025.
+        assert measurement_date == date(2025, 6, 1)
+        assert fy_start == 2024
+        # Values match the June 2025 line: bills, bonds, stocks,
+        # overdraft, advances, other, total.
+        assert values == [
+            Decimal("1052945.0"),
+            Decimal("5110010.0"),
+            Decimal("0.0"),
+            Decimal("67628.8"),
+            Decimal("14791.8"),
+            Decimal("80633.7"),
+            Decimal("6326009.3"),
+        ]
+
+    def test_jul_dec_rows_use_first_calendar_year_of_fy(self):
+        """FY 2024/2025 → July rows are calendar 2024, June rows are
+        calendar 2025. This catches accidental off-by-one in the
+        FY→calendar mapping (a real bug we'd silently ship otherwise)."""
+        july_only = """\
+Table 4.1.4: Composition of Government Gross Domestic Debt
+2024/2025
+July 1.0 2.0 0.0 3.0 4.0 5.0 15.0
+"""
+        result = cbk_bulletin._parse_latest_month_row(july_only)
+        assert result is not None
+        measurement_date, fy_start, _ = result
+        assert measurement_date == date(2024, 7, 1)
+        assert fy_start == 2024
+
+    def test_returns_none_when_no_month_rows(self):
+        """A page that has the title but no data rows (e.g. a
+        renumbered bulletin where only the heading lines up) should
+        be a clean None, not a crash."""
+        bare = """\
+Table 4.1.4: Composition of Government Gross Domestic Debt
+no usable rows here
+"""
+        assert cbk_bulletin._parse_latest_month_row(bare) is None
+
+    def test_returns_none_when_month_rows_lack_fy_header(self):
+        """If we somehow read month rows without ever passing through
+        a fiscal-year header, we can't infer calendar year — bail
+        rather than guess."""
+        no_fy = """\
+Table 4.1.4: Composition of Government Gross Domestic Debt
+June 1.0 2.0 0.0 3.0 4.0 5.0 15.0
+"""
+        assert cbk_bulletin._parse_latest_month_row(no_fy) is None
+
+    def test_build_loan_records_skips_zero_columns(self):
+        """Columns that come in at zero (e.g. Government Stocks
+        always) shouldn't emit noisy zero-stock loans. Same applies
+        to a temporarily-zero overdraft month."""
+        # Only Bills + Bonds non-zero.
+        values = [
+            Decimal("100"),    # bills
+            Decimal("200"),    # bonds
+            Decimal("0"),      # gov stocks (always skipped via mapping)
+            Decimal("0"),      # overdraft
+            Decimal("0"),      # advances
+            Decimal("0"),      # other
+            Decimal("300"),    # total (always skipped via mapping)
+        ]
+        loans = cbk_bulletin._build_loan_records(
+            measurement_date=date(2025, 6, 1),
+            fiscal_year_start=2024,
+            values=values,
+            source_url="file://fake.pdf",
+        )
+        lenders = {l["lender"] for l in loans}
+        assert lenders == {
+            "Domestic Treasury Bills (91-day, 182-day, 364-day)",
+            "Domestic Treasury Bonds",
+        }
+
+    def test_build_loan_records_uses_fy_start_as_issue_date(self):
+        """issue_date pins to fiscal-year-start so within-FY pulls
+        UPDATE the same writer row (dedupe key entity+lender+date)
+        instead of forking new rows. Measurement month is preserved
+        in notes."""
+        loans = cbk_bulletin._build_loan_records(
+            measurement_date=date(2025, 6, 1),
+            fiscal_year_start=2024,
+            values=[Decimal("1")] * 7,
+            source_url="file://fake.pdf",
+        )
+        assert all(l["issue_date"] == "2024-07-01" for l in loans)
+        assert all("month-end 2025-06-01" in l["notes"] for l in loans)
+
+
+# ── cbk_bulletin.fetch_domestic_debt_from_cbk_bulletin (boundary) ──
+
+
+class TestCbkBulletinFetcher:
+    def test_returns_empty_when_url_not_configured(self, settings):
+        """Default config (URL unset) means CBK overlay is opt-in.
+        Must NOT attempt any download."""
+        settings.cbk_statistical_bulletin_url = None
+        # If anything tried to download, this would raise — proves we
+        # short-circuit before touching the client.
+        loans = cbk_bulletin.fetch_domestic_debt_from_cbk_bulletin(
+            client=None, settings=settings
+        )
+        assert loans == []
+
+    def test_returns_empty_when_pdf_lacks_table(self, settings):
+        """If CBK renumbers the table or the wrong PDF is configured,
+        we get an empty result instead of a crash."""
+        settings.cbk_statistical_bulletin_url = "file:///fake.pdf"
+        with (
+            patch.object(cbk_bulletin, "_download_pdf", return_value=b"%PDF-fake"),
+            patch.object(
+                cbk_bulletin,
+                "_extract_domestic_debt_page_text",
+                return_value=None,
+            ),
+        ):
+            loans = cbk_bulletin.fetch_domestic_debt_from_cbk_bulletin(
+                client=None, settings=settings
+            )
+        assert loans == []
+
+    def test_returns_empty_when_download_fails(self, settings):
+        """A 404 / network drop on the bulletin URL must degrade
+        silently — fixture stays in play."""
+        settings.cbk_statistical_bulletin_url = "https://cbk.example/missing.pdf"
+        with patch.object(
+            cbk_bulletin, "_download_pdf", side_effect=RuntimeError("404")
+        ):
+            loans = cbk_bulletin.fetch_domestic_debt_from_cbk_bulletin(
+                client=None, settings=settings
+            )
+        assert loans == []
+
+    def test_end_to_end_against_synthetic_page_text(self, settings):
+        """Full fetcher path with a synthetic page text — verifies
+        the loan-record shape, KES scaling, and the row count."""
+        settings.cbk_statistical_bulletin_url = "file:///fake.pdf"
+        with (
+            patch.object(cbk_bulletin, "_download_pdf", return_value=b"%PDF-fake"),
+            patch.object(
+                cbk_bulletin,
+                "_extract_domestic_debt_page_text",
+                return_value=_REAL_PAGE_TEXT,
+            ),
+        ):
+            loans = cbk_bulletin.fetch_domestic_debt_from_cbk_bulletin(
+                client=None, settings=settings
+            )
+        # 5 non-zero columns expected (Stocks=0 skipped; Total skipped).
+        assert len(loans) == 5
+        by_lender = {l["lender"]: l for l in loans}
+        # Treasury Bonds: 5,110,010.0 KES million → 5.11013e12 KES.
+        bonds = by_lender["Domestic Treasury Bonds"]
+        assert Decimal(bonds["outstanding"]) == Decimal("5110010000000.00")
+        assert bonds["debt_category"] == "domestic_bonds"
+        assert bonds["currency"] == "KES"
+        # All rows share the same FY-start issue_date.
+        assert all(l["issue_date"] == "2024-07-01" for l in loans)
+
+
 # ── fetcher.fetch_debt_payload (integration) ──
 
 
@@ -275,11 +475,13 @@ class TestFetchDebtPayload:
         with (
             patch.object(nd_fetcher, "load_json_resource", return_value=_baseline_payload()),
             patch.object(nd_fetcher, "fetch_external_debt_from_wb_ids", return_value=[]),
+            patch.object(nd_fetcher, "fetch_domestic_debt_from_cbk_bulletin", return_value=[]),
         ):
             payload = nd_fetcher.fetch_debt_payload(client=None, settings=settings)
         assert len(payload["loans"]) == 3
         # Marker NOT set when we couldn't overlay anything.
         assert "wb_ids_overlay_applied" not in payload.get("metadata", {})
+        assert "cbk_bulletin_overlay_applied" not in payload.get("metadata", {})
 
     def test_overlay_applied_metadata_set_on_success(self, settings):
         wb_overlay = [
@@ -300,21 +502,70 @@ class TestFetchDebtPayload:
         with (
             patch.object(nd_fetcher, "load_json_resource", return_value=_baseline_payload()),
             patch.object(nd_fetcher, "fetch_external_debt_from_wb_ids", return_value=wb_overlay),
+            patch.object(nd_fetcher, "fetch_domestic_debt_from_cbk_bulletin", return_value=[]),
         ):
             payload = nd_fetcher.fetch_debt_payload(client=None, settings=settings)
         meta = payload.get("metadata", {})
         assert meta.get("wb_ids_overlay_applied") is True
         assert meta.get("wb_ids_overlay_count") == 1
 
+    def test_cbk_overlay_applied_metadata_set_on_success(self, settings):
+        cbk_overlay = [
+            {
+                "entity_name": "National Government",
+                "entity_type": "national",
+                "lender": "Domestic Treasury Bills (91-day, 182-day, 364-day)",
+                "debt_category": "domestic_bills",
+                "principal": "1.00",
+                "outstanding": "1.00",
+                "interest_rate": None,
+                "issue_date": "2024-07-01",
+                "maturity_date": None,
+                "currency": "KES",
+                "notes": "cbk",
+            },
+            {
+                "entity_name": "National Government",
+                "entity_type": "national",
+                "lender": "Advances from Commercial Banks",
+                "debt_category": "domestic_overdraft",
+                "principal": "2.00",
+                "outstanding": "2.00",
+                "interest_rate": None,
+                "issue_date": "2024-07-01",
+                "maturity_date": None,
+                "currency": "KES",
+                "notes": "cbk",
+            },
+        ]
+        with (
+            patch.object(nd_fetcher, "load_json_resource", return_value=_baseline_payload()),
+            patch.object(nd_fetcher, "fetch_external_debt_from_wb_ids", return_value=[]),
+            patch.object(
+                nd_fetcher,
+                "fetch_domestic_debt_from_cbk_bulletin",
+                return_value=cbk_overlay,
+            ),
+        ):
+            payload = nd_fetcher.fetch_debt_payload(client=None, settings=settings)
+        meta = payload.get("metadata", {})
+        assert meta.get("cbk_bulletin_overlay_applied") is True
+        assert meta.get("cbk_bulletin_overlay_count") == 2
+
     def test_skips_overlay_when_live_fetch_disabled(self, settings):
+        """Both overlays gate behind live_pdf_fetch_enabled — neither
+        should be invoked when it's False."""
         settings.live_pdf_fetch_enabled = False
         with (
             patch.object(nd_fetcher, "load_json_resource", return_value=_baseline_payload()),
             patch.object(nd_fetcher, "fetch_external_debt_from_wb_ids") as mock_wb,
+            patch.object(nd_fetcher, "fetch_domestic_debt_from_cbk_bulletin") as mock_cbk,
         ):
             payload = nd_fetcher.fetch_debt_payload(client=None, settings=settings)
         mock_wb.assert_not_called()
+        mock_cbk.assert_not_called()
         assert "wb_ids_overlay_applied" not in payload.get("metadata", {})
+        assert "cbk_bulletin_overlay_applied" not in payload.get("metadata", {})
 
     def test_continues_when_wb_raises_unexpectedly(self, settings):
         """A bug in the WB module shouldn't take down the whole
@@ -325,8 +576,42 @@ class TestFetchDebtPayload:
                 nd_fetcher, "fetch_external_debt_from_wb_ids",
                 side_effect=RuntimeError("kaboom"),
             ),
+            patch.object(nd_fetcher, "fetch_domestic_debt_from_cbk_bulletin", return_value=[]),
         ):
             payload = nd_fetcher.fetch_debt_payload(client=None, settings=settings)
         # Same fixture, no overlay marker.
         assert len(payload["loans"]) == 3
         assert "wb_ids_overlay_applied" not in payload.get("metadata", {})
+
+    def test_continues_when_cbk_raises_unexpectedly(self, settings):
+        """Same story for the CBK side — a parser bug or PDF-layout
+        change must not take down the whole domain. WB IDS overlay
+        still applies in that case."""
+        wb_overlay = [
+            {
+                "entity_name": "National Government",
+                "entity_type": "national",
+                "lender": "Multilateral (World Bank / IDA / IBRD)",
+                "debt_category": "external_multilateral",
+                "principal": "1.00",
+                "outstanding": "1.00",
+                "interest_rate": None,
+                "issue_date": "2024-01-01",
+                "maturity_date": None,
+                "currency": "KES",
+                "notes": "wb",
+            }
+        ]
+        with (
+            patch.object(nd_fetcher, "load_json_resource", return_value=_baseline_payload()),
+            patch.object(nd_fetcher, "fetch_external_debt_from_wb_ids", return_value=wb_overlay),
+            patch.object(
+                nd_fetcher, "fetch_domestic_debt_from_cbk_bulletin",
+                side_effect=RuntimeError("pdf parse exploded"),
+            ),
+        ):
+            payload = nd_fetcher.fetch_debt_payload(client=None, settings=settings)
+        meta = payload.get("metadata", {})
+        # WB overlay still landed; CBK marker absent.
+        assert meta.get("wb_ids_overlay_applied") is True
+        assert "cbk_bulletin_overlay_applied" not in meta


### PR DESCRIPTION
## Summary

Closes the second leg of the two-source national_debt strategy started in [#75](https://github.com/Rodgers31/audit_app/pull/75). WB IDS already covers external creditors; this adds the **domestic** instruments (T-bills, T-bonds, overdraft, advances, other) by overlaying CBK Statistical Bulletin **Table 4.1.4** on top of the fixture.

- New module: [backend/seeding/domains/national_debt/cbk_bulletin.py](backend/seeding/domains/national_debt/cbk_bulletin.py) — downloads the bulletin PDF, finds Table 4.1.4 by title anchor, parses the latest month row.
- Fetcher wires the CBK overlay in after WB IDS using the same `_overlay_loans` merge ([backend/seeding/domains/national_debt/fetcher.py](backend/seeding/domains/national_debt/fetcher.py)).
- New opt-in setting `SEED_CBK_STATISTICAL_BULLETIN_URL` (default `None`) controls discovery.

Why text-mode parsing
- pdfplumber's `extract_tables()` is broken on the 4.1.4 layout — every column gets concatenated into one cell with newlines.
- `extract_text()` returns clean per-month rows that parse trivially with regex.
- Verified against the June 2025 bulletin (`sbull_jun25.pdf`):
  - Treasury Bills 1.053T · Treasury Bonds 5.110T · Overdraft 67.6B · Advances 14.8B · Other 80.6B
  - sum 6.326T matches CBK's published Total Domestic Debt exactly.

Overlay behaviour
- 3 fixture lenders are REPLACED in place (Bills, Bonds, Overdraft) — exact name match.
- 2 new lenders are APPENDED (Advances from Commercial Banks, Other Domestic Debt).
- `issue_date` pinned to fiscal-year-start so within-FY pulls UPDATE the same writer row (same convention as `wb_ids.py`); measurement month is preserved in `notes`.
- Government Stocks (always 0) and Total Domestic Debt (sum row) are skipped.

Discovery is opt-in
- Bulletin URL paths change each release, so this defaults to `None`. Production users export `SEED_CBK_STATISTICAL_BULLETIN_URL` pointing at the latest PDF.
- Auto-discovery from the CBK statistics page is a planned follow-up.

Known small over-count
- The fixture's "Domestic Infrastructure & Green Bonds" row (300B) isn't broken out by CBK and stays untouched, so the post-overlay sum overstates by ~300B (~5% of domestic). Cleanest fix is to drop that fixture row once we confirm no UI surface depends on the breakdown — flagged as a separate task.

## Test plan

- [x] `pytest tests/test_national_debt_fetcher.py` — 22 passing (10 new for CBK).
- [x] Smoke test against the real June 2025 CBK bulletin produces the expected 5 rows with correct values.
- [ ] `seed --domain national_debt` against staging with `SEED_CBK_STATISTICAL_BULLETIN_URL` set — verify metadata flag `cbk_bulletin_overlay_applied: true` and the bond/bill rows in the DB reflect CBK's June 2025 totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)