### PR TITLE
fix(national_debt): drop partial WB rows + consolidate zombie loans

### DIFF
--- a/backend/seeding/domains/national_debt/wb_ids.py
+++ b/backend/seeding/domains/national_debt/wb_ids.py
@@ -117,8 +117,21 @@ def fetch_external_debt_from_wb_ids(
             secondary = _fetch_latest(
                 client, creditor["combine_with"], at_year=latest_year
             )
-            if secondary:
-                kes_value += Decimal(str(secondary["value"])) * _USD_KES_RATE
+            if secondary is None:
+                # Skip the row entirely rather than write a misleading
+                # partial. For combined indicators (IBRD + IDA), the
+                # primary value alone undercounts the lender bucket by a
+                # large factor — silently writing IBRD-only as "World
+                # Bank" overwrote the fixture row with a 7x understatement
+                # in a real prod run. Better to keep the fixture in place
+                # than corrupt it; the next run will retry the secondary.
+                logger.warning(
+                    "WB IDS skipping %s: combine_with %s unavailable; "
+                    "fixture row stays in place",
+                    creditor["lender"], creditor["combine_with"],
+                )
+                continue
+            kes_value += Decimal(str(secondary["value"])) * _USD_KES_RATE
         out.append(
             {
                 "entity_name": "National Government",

--- a/backend/seeding/domains/national_debt/writer.py
+++ b/backend/seeding/domains/national_debt/writer.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 import logging
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -94,15 +92,24 @@ def _get_or_create_source_document(
     return doc
 
 
-def compute_loan_hash(record: DebtRecord, entity_id: int) -> str:
-    """Compute deterministic hash for a loan record."""
-    data = (
-        f"{entity_id}:{record.lender}:{record.principal}:"
-        f"{record.outstanding}:{record.issue_date.isoformat()}:"
-        f"{record.maturity_date.isoformat() if record.maturity_date else 'None'}:"
-        f"{record.currency}"
-    )
-    return hashlib.sha256(data.encode()).hexdigest()
+def _resolve_debt_category(value: str | None):
+    """Map a debt_category string to the DebtCategory enum, defaulting
+    to ``OTHER`` for unknown values. Returns ``None`` when the input is
+    falsy so callers can leave the column unset on existing rows."""
+    if not value:
+        return None
+    from models import DebtCategory as _DC
+
+    return {
+        "external_multilateral": _DC.EXTERNAL_MULTILATERAL,
+        "external_bilateral": _DC.EXTERNAL_BILATERAL,
+        "external_commercial": _DC.EXTERNAL_COMMERCIAL,
+        "domestic_bonds": _DC.DOMESTIC_BONDS,
+        "domestic_bills": _DC.DOMESTIC_BILLS,
+        "domestic_overdraft": _DC.DOMESTIC_OVERDRAFT,
+        "pending_bills": _DC.PENDING_BILLS,
+        "county_guaranteed": _DC.COUNTY_GUARANTEED,
+    }.get(value, _DC.OTHER)
 
 
 def write_debt_records(
@@ -110,6 +117,18 @@ def write_debt_records(
 ) -> tuple[int, int]:
     """
     Persist debt records to database.
+
+    Dedupe by ``(entity_id, lender)`` rather than the writer's older
+    ``(entity_id, lender, issue_date)`` triple. National-debt loans
+    are aggregate buckets (e.g. "Multilateral (World Bank / IDA /
+    IBRD)") with synthetic issue dates that change as live overlays
+    advance their data vintage. Keying on issue_date too caused every
+    new vintage to insert a NEW row alongside the prior one, leaving
+    a trail of stale zombies. We now find all rows for (entity,
+    lender), update one in-place to the latest values, and DELETE any
+    extras as a one-shot cleanup of pre-existing zombies. Safe because
+    the national_debt domain enforces one row per lender bucket
+    (verified against the fixture and both live overlays).
 
     Args:
         session: Database session
@@ -124,7 +143,6 @@ def write_debt_records(
     updated = 0
 
     for record in records:
-        # Get or create entity
         entity = _get_or_create_entity(session, record.entity_name, record.entity_type)
         if not entity:
             logger.warning(
@@ -132,20 +150,16 @@ def write_debt_records(
             )
             continue
 
-        # Get or create source document
         source_doc = _get_or_create_source_document(session, record)
 
-        # Check if loan already exists using hash
-        loan_hash = compute_loan_hash(record, entity.id)
-
-        existing_loan = (
+        existing_loans = (
             session.query(Loan)
             .filter(
                 Loan.entity_id == entity.id,
                 Loan.lender == record.lender,
-                Loan.issue_date == record.issue_date,
             )
-            .first()
+            .order_by(Loan.id)
+            .all()
         )
 
         provenance_entry = {
@@ -154,75 +168,70 @@ def write_debt_records(
             "ingested_at": datetime.now(timezone.utc).isoformat(),
         }
 
-        if existing_loan:
-            # Update if outstanding amount changed or debt_category missing
-            needs_update = (
-                existing_loan.outstanding != record.outstanding
-                or existing_loan.debt_category is None
-            )
-            if needs_update:
-                logger.info(
-                    f"Updating loan: {record.lender} for {record.entity_name} "
-                    f"(outstanding: {existing_loan.outstanding} → {record.outstanding})"
-                )
-                existing_loan.outstanding = record.outstanding
-                existing_loan.principal = record.principal
-                existing_loan.maturity_date = record.maturity_date
+        if existing_loans:
+            keeper = existing_loans[0]
+            zombies = existing_loans[1:]
 
-                # Update debt_category and interest_rate if provided
-                if record.debt_category:
-                    from models import DebtCategory as _DC
-
-                    _cat_map = {
-                        "external_multilateral": _DC.EXTERNAL_MULTILATERAL,
-                        "external_bilateral": _DC.EXTERNAL_BILATERAL,
-                        "external_commercial": _DC.EXTERNAL_COMMERCIAL,
-                        "domestic_bonds": _DC.DOMESTIC_BONDS,
-                        "domestic_bills": _DC.DOMESTIC_BILLS,
-                        "domestic_overdraft": _DC.DOMESTIC_OVERDRAFT,
-                        "pending_bills": _DC.PENDING_BILLS,
-                        "county_guaranteed": _DC.COUNTY_GUARANTEED,
-                    }
-                    existing_loan.debt_category = _cat_map.get(
-                        record.debt_category, _DC.OTHER
+            # Drop zombies BEFORE mutating the keeper. The Loan table
+            # carries a UniqueConstraint(entity_id, lender, issue_date),
+            # and SQLAlchemy's unit-of-work flushes UPDATEs ahead of
+            # DELETEs — so updating keeper.issue_date to a value still
+            # held by a not-yet-deleted zombie raises IntegrityError.
+            # Explicit flush after the deletes guarantees the row is
+            # gone before the keeper takes its date.
+            if zombies:
+                for zombie in zombies:
+                    logger.info(
+                        "Deleting zombie loan #%s (lender=%s, "
+                        "issue_date=%s) consolidated into #%s",
+                        zombie.id, zombie.lender, zombie.issue_date,
+                        keeper.id,
                     )
+                    session.delete(zombie)
+                session.flush()
+
+            # Counts toward `updated` only when something actually
+            # shifted, so the metric still reflects real churn rather
+            # than counting every no-op re-write.
+            changed = (
+                keeper.outstanding != record.outstanding
+                or keeper.principal != record.principal
+                or keeper.issue_date != record.issue_date
+                or keeper.maturity_date != record.maturity_date
+                or keeper.debt_category is None
+            )
+            if changed or zombies:
+                logger.info(
+                    "Updating loan: %s for %s (outstanding: %s → %s%s)",
+                    record.lender,
+                    record.entity_name,
+                    keeper.outstanding,
+                    record.outstanding,
+                    f"; consolidated {len(zombies)} zombie row(s)" if zombies else "",
+                )
+                keeper.outstanding = record.outstanding
+                keeper.principal = record.principal
+                keeper.issue_date = record.issue_date
+                keeper.maturity_date = record.maturity_date
+                resolved_cat = _resolve_debt_category(record.debt_category)
+                if resolved_cat is not None:
+                    keeper.debt_category = resolved_cat
                 if record.interest_rate is not None:
-                    existing_loan.interest_rate = record.interest_rate
+                    keeper.interest_rate = record.interest_rate
 
-                # Append to provenance
-                provenance = existing_loan.provenance or []
+                provenance = keeper.provenance or []
                 provenance.append(provenance_entry)
-                existing_loan.provenance = provenance
-
+                keeper.provenance = provenance
                 updated += 1
         else:
-            # Create new loan
             logger.info(
                 f"Creating loan: {record.lender} for {record.entity_name} "
                 f"(principal: {record.principal}, outstanding: {record.outstanding})"
             )
-
-            # Map debt_category string to DebtCategory enum
-            debt_cat = None
-            if record.debt_category:
-                from models import DebtCategory
-
-                cat_map = {
-                    "external_multilateral": DebtCategory.EXTERNAL_MULTILATERAL,
-                    "external_bilateral": DebtCategory.EXTERNAL_BILATERAL,
-                    "external_commercial": DebtCategory.EXTERNAL_COMMERCIAL,
-                    "domestic_bonds": DebtCategory.DOMESTIC_BONDS,
-                    "domestic_bills": DebtCategory.DOMESTIC_BILLS,
-                    "domestic_overdraft": DebtCategory.DOMESTIC_OVERDRAFT,
-                    "pending_bills": DebtCategory.PENDING_BILLS,
-                    "county_guaranteed": DebtCategory.COUNTY_GUARANTEED,
-                }
-                debt_cat = cat_map.get(record.debt_category, DebtCategory.OTHER)
-
             loan = Loan(
                 entity_id=entity.id,
                 lender=record.lender,
-                debt_category=debt_cat,
+                debt_category=_resolve_debt_category(record.debt_category),
                 principal=record.principal,
                 outstanding=record.outstanding,
                 interest_rate=record.interest_rate or Decimal("0"),

--- a/backend/tests/test_national_debt_fetcher.py
+++ b/backend/tests/test_national_debt_fetcher.py
@@ -188,6 +188,32 @@ class TestWbIdsFetcher:
         loans = wb_ids.fetch_external_debt_from_wb_ids(FakeClient(), settings)
         assert loans == []
 
+    def test_skips_combined_row_when_secondary_fails(self, settings):
+        """If the primary indicator (IBRD) succeeds but the
+        ``combine_with`` secondary (IDA) fails — e.g. WB API returns
+        an intermittent 400 — we MUST NOT emit the IBRD-only value as
+        the World Bank total. A real prod run silently undercounted
+        WB lending by 7x ($1.9B vs the $13.8B IBRD+IDA combined). The
+        whole row is dropped so the fixture stays in place; the next
+        run retries."""
+
+        class FakeClient:
+            def get(self, url, **_kwargs):
+                if "MIDA" in url:  # the combine_with secondary
+                    raise RuntimeError("simulated WB API 400")
+                # Both MIBR (IBRD primary) and DIMF (IMF) succeed.
+                class R:
+                    def json(self_):
+                        return _wb_response(1_000_000_000)
+                return R()
+
+        loans = wb_ids.fetch_external_debt_from_wb_ids(FakeClient(), settings)
+        lenders = {l["lender"] for l in loans}
+        # WB row dropped because IDA leg unavailable.
+        assert "Multilateral (World Bank / IDA / IBRD)" not in lenders
+        # IMF (no combine_with) is unaffected.
+        assert "Multilateral (IMF — Extended Credit & Resilience Trust)" in lenders
+
 
 # ── fetcher._overlay_loans ──
 

--- a/backend/tests/test_national_debt_writer.py
+++ b/backend/tests/test_national_debt_writer.py
@@ -1,0 +1,259 @@
+"""Tests for the national_debt writer's dedupe + zombie cleanup.
+
+The writer keys on ``(entity_id, lender)`` rather than the older
+``(entity_id, lender, issue_date)`` triple. National-debt loans are
+synthetic aggregate buckets — adding ``issue_date`` to the dedupe key
+made every new live-overlay vintage insert a fresh row alongside the
+prior one, leaving zombie rows in production. These tests pin the
+new behaviour so a future refactor can't silently regress it.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Iterator
+
+import pytest
+from models import (
+    Base,
+    Country,
+    DebtCategory,
+    DocumentType,
+    Entity,
+    EntityType,
+    Loan,
+    SourceDocument,
+)
+from seeding.domains.national_debt.parser import DebtRecord
+from seeding.domains.national_debt.writer import write_debt_records
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session, sessionmaker
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_sqlite(type_, compiler, **kw):  # pragma: no cover - dialect shim
+    return "TEXT"
+
+
+@pytest.fixture()
+def session(tmp_path) -> Iterator[Session]:
+    engine = create_engine(f"sqlite:///{tmp_path/'debt.db'}")
+    Base.metadata.create_all(engine)
+    Maker = sessionmaker(bind=engine)
+    s = Maker()
+    try:
+        yield s
+    finally:
+        s.close()
+        engine.dispose()
+
+
+@pytest.fixture()
+def national_entity(session: Session) -> Entity:
+    """Bootstrap a Country + National Government Entity, mirroring
+    what bootstrap_data.py creates in production."""
+    country = Country(
+        iso_code="KEN",
+        name="Kenya",
+        currency="KES",
+        timezone="Africa/Nairobi",
+        default_locale="en-KE",
+    )
+    session.add(country)
+    session.flush()
+    entity = Entity(
+        country_id=country.id,
+        type=EntityType.NATIONAL,
+        canonical_name="National Government",
+        slug="national-government",
+    )
+    session.add(entity)
+    session.flush()
+    return entity
+
+
+@pytest.fixture()
+def source_doc(session: Session, national_entity: Entity) -> SourceDocument:
+    """A SourceDocument the staged zombie loans can attach to. The
+    writer creates its own SourceDocument for live-record loans, so
+    this only exists to satisfy the NOT NULL FK on the seeded
+    fixture-state rows."""
+    doc = SourceDocument(
+        country_id=national_entity.country_id,
+        publisher="Test Publisher",
+        title="test bulletin",
+        doc_type=DocumentType.LOAN,
+        fetch_date=datetime(2024, 1, 1),
+    )
+    session.add(doc)
+    session.flush()
+    return doc
+
+
+def _make_record(
+    *,
+    lender: str,
+    outstanding: str,
+    issue_date_iso: str,
+    debt_category: str = "external_multilateral",
+) -> DebtRecord:
+    return DebtRecord(
+        entity_name="National Government",
+        entity_type="national",
+        lender=lender,
+        principal=Decimal(outstanding),
+        outstanding=Decimal(outstanding),
+        issue_date=datetime.fromisoformat(issue_date_iso),
+        maturity_date=None,
+        currency="KES",
+        source_url="file://test",
+        source_title="test bulletin",
+        debt_category=debt_category,
+        interest_rate=None,
+        notes=None,
+    )
+
+
+class TestZombieConsolidation:
+    def test_consolidates_two_existing_rows_into_one(
+        self, session, national_entity, source_doc
+    ):
+        """Pre-existing zombies (same entity+lender, different
+        issue_dates from earlier runs that keyed on the triple) must
+        be collapsed to a single row on the next write."""
+        # Stage two stale rows for the same lender — represents what
+        # production looks like after PR #75 ran a couple of times
+        # against an older fixture.
+        for issue_date, outstanding in [
+            (datetime(2010, 7, 1), Decimal("500000000000")),
+            (datetime(2024, 1, 1), Decimal("253000000000")),
+        ]:
+            session.add(
+                Loan(
+                    entity_id=national_entity.id,
+                    lender="Multilateral (World Bank / IDA / IBRD)",
+                    debt_category=DebtCategory.EXTERNAL_MULTILATERAL,
+                    principal=outstanding,
+                    outstanding=outstanding,
+                    interest_rate=Decimal("0"),
+                    issue_date=issue_date,
+                    currency="KES",
+                    source_document_id=source_doc.id,
+                )
+            )
+        session.flush()
+        assert session.query(Loan).count() == 2
+
+        record = _make_record(
+            lender="Multilateral (World Bank / IDA / IBRD)",
+            outstanding="1797000000000",  # the correct WB IDS combined value
+            issue_date_iso="2024-01-01",
+        )
+        created, updated = write_debt_records(
+            session, [record], dataset_id="national-debt", job_id=42
+        )
+        session.flush()
+
+        loans = session.query(Loan).all()
+        # Both zombies collapsed into the keeper row.
+        assert len(loans) == 1
+        assert created == 0
+        assert updated == 1
+        # Keeper now reflects the live value, not the partial.
+        assert loans[0].outstanding == Decimal("1797000000000")
+
+    def test_create_when_no_existing_row(self, session, national_entity):
+        """First-ever seed of a brand-new lender bucket should INSERT,
+        not error from the empty existing-loans list."""
+        record = _make_record(
+            lender="Multilateral (Brand New Lender)",
+            outstanding="1000000",
+            issue_date_iso="2024-07-01",
+        )
+        created, updated = write_debt_records(
+            session, [record], dataset_id="national-debt", job_id=1
+        )
+        session.flush()
+        assert created == 1
+        assert updated == 0
+        assert session.query(Loan).count() == 1
+
+    def test_update_in_place_when_one_existing_row(
+        self, session, national_entity, source_doc
+    ):
+        """A single existing row with a different issue_date must be
+        UPDATED in place — not joined by a sibling — so the WB IDS
+        date-vintage drift across runs doesn't fork rows."""
+        session.add(
+            Loan(
+                entity_id=national_entity.id,
+                lender="Multilateral (IMF — Extended Credit & Resilience Trust)",
+                debt_category=DebtCategory.EXTERNAL_MULTILATERAL,
+                principal=Decimal("400000000000"),
+                outstanding=Decimal("400000000000"),
+                interest_rate=Decimal("0"),
+                issue_date=datetime(2024, 1, 1),
+                currency="KES",
+                source_document_id=source_doc.id,
+            )
+        )
+        session.flush()
+
+        record = _make_record(
+            lender="Multilateral (IMF — Extended Credit & Resilience Trust)",
+            outstanding="644000000000",
+            # Different issue_date than the existing row — older writer
+            # would have inserted a sibling here.
+            issue_date_iso="2025-01-01",
+        )
+        created, updated = write_debt_records(
+            session, [record], dataset_id="national-debt", job_id=2
+        )
+        session.flush()
+
+        loans = session.query(Loan).all()
+        assert len(loans) == 1
+        assert created == 0
+        assert updated == 1
+        assert loans[0].outstanding == Decimal("644000000000")
+        assert loans[0].issue_date.date().isoformat() == "2025-01-01"
+
+    def test_no_op_when_record_unchanged(
+        self, session, national_entity, source_doc
+    ):
+        """An identical re-write (same outstanding, same date, same
+        category) shouldn't be counted as an update — ``updated``
+        tracks real churn, not row touches. Provenance is also not
+        appended, to avoid bloating the JSON column on no-op runs."""
+        session.add(
+            Loan(
+                entity_id=national_entity.id,
+                lender="Multilateral (World Bank / IDA / IBRD)",
+                debt_category=DebtCategory.EXTERNAL_MULTILATERAL,
+                principal=Decimal("1000"),
+                outstanding=Decimal("1000"),
+                interest_rate=Decimal("0"),
+                issue_date=datetime(2024, 1, 1),
+                currency="KES",
+                provenance=[{"existing": "entry"}],
+                source_document_id=source_doc.id,
+            )
+        )
+        session.flush()
+
+        record = _make_record(
+            lender="Multilateral (World Bank / IDA / IBRD)",
+            outstanding="1000",
+            issue_date_iso="2024-01-01",
+        )
+        created, updated = write_debt_records(
+            session, [record], dataset_id="national-debt", job_id=3
+        )
+        session.flush()
+
+        assert (created, updated) == (0, 0)
+        loan = session.query(Loan).one()
+        assert loan.provenance == [{"existing": "entry"}]


### PR DESCRIPTION
## Summary

Two correctness issues that surfaced in the post-merge seed run ([Actions run 24943881873](https://github.com/Rodgers31/audit_app/actions/runs/24943881873)).

### 1. WB IDS silently shipped a 7x undercount on World Bank
The IDA secondary fetch returned HTTP 400 (intermittent WB API flakiness) — but the IBRD primary succeeded. Old code happily emitted IBRD-only as the "World Bank" row:

> [WARNING] WB IDS request failed for DT.DOD.MIDA.CD: Client error '400 Bad Request' …
> [INFO] Creating loan: Multilateral (World Bank / IDA / IBRD) … outstanding: **253130280000.00**

Real IBRD+IDA combined is ~$13.8B → ~KES 1.797T. We wrote KES 253B. **7x undercount, no surface warning, fixture overwritten.**

[Fix in wb_ids.py:118-128](backend/seeding/domains/national_debt/wb_ids.py#L118-L128) — when `combine_with` secondary fails after primary succeeds, drop the entire row. Better to keep the fixture in place than corrupt it; next run retries cleanly.

### 2. Writer accumulated zombie loans across runs
The writer keyed dedupe on `(entity_id, lender, issue_date)`. WB IDS / CBK overlays advance their `issue_date` year-over-year (e.g., `2024-01-01` → `2025-01-01` when a new IDS vintage publishes), so every new vintage INSERTed a fresh row alongside the prior one. The prod loans table is at 132 rows partly from this drift.

National-debt loans are aggregate buckets (one "World Bank" row, one "Treasury Bonds" row, etc.) — verified against the fixture and both live overlays. Switch dedupe key to `(entity_id, lender)` ([writer.py:155-163](backend/seeding/domains/national_debt/writer.py#L155-L163)). When multiple rows match (existing zombies):
- Update one in-place to the latest values
- Delete the rest as **one-shot cleanup** — the next seed run vacuums historical zombies automatically

Subtle ordering bug surfaced during testing: SQLAlchemy flushes UPDATEs before DELETEs by default, so updating `keeper.issue_date` to a value still held by a not-yet-deleted zombie raises `IntegrityError` against the `UniqueConstraint(entity_id, lender, issue_date)`. Explicit flush after the deletes ([writer.py:171-184](backend/seeding/domains/national_debt/writer.py#L171-L184)).

Also drops dead code: `compute_loan_hash` was only called once and the result was discarded.

## Test plan

- [x] `pytest tests/test_national_debt_fetcher.py tests/test_national_debt_writer.py` — 27 passing (1 new for partial-row skip, 4 new writer tests for zombie consolidation / no-op / single-row update / first-insert).
- [x] Full unit suite (excluding pre-existing import errors in test_etl.py et al.): **420 passed, 1 skipped**.
- [ ] Re-trigger the Actions seed workflow after merge to confirm:
  - WB row writes the full $13.8B value (or, if WB API is flaky again, no WB row gets written at all),
  - Loan count drops as zombies get vacuumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)