### PR TITLE
fix(seeding): WPDM-aware PDF discovery for 3 COB domains

### DIFF
--- a/backend/seeding/cob_discovery.py
+++ b/backend/seeding/cob_discovery.py
@@ -1,0 +1,132 @@
+"""Shared discovery helpers for Controller of Budget (COB) PDFs.
+
+The COB website at https://cob.go.ke distributes its Budget
+Implementation Review Reports (BIRR) through the WordPress Download
+Manager (WPDM) plugin. Anchors on the publications pages no longer
+end in ``.pdf`` — they look like
+
+    <a ... href="https://cob.go.ke/download/<slug>/?wpdmdl=16349">
+
+Hitting the ``?wpdmdl=NNN`` URL streams the actual file
+(``Content-Type: application/pdf``). Higher ``wpdmdl`` IDs are newer
+uploads (WPDM's monotonic counter), so sorting by ID descending
+gives the latest report.
+
+Three seeding domains scrape the same family of pages:
+
+* ``counties_budget`` — Consolidated County BIRR
+* ``national_budget`` — National Government BIRR
+* ``pending_bills`` — same NG-BIRR page, different keyword filter
+
+Before this helper landed each fetcher inlined a ``[^"']*\\.pdf``
+regex — which matched zero links after COB migrated to WPDM — and
+silently fell back to fixture. This module centralises the
+WPDM-aware pattern with the legacy ``.pdf`` fallback so all three
+domains stay in sync the next time the page layout shifts.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Iterable, Optional
+from urllib.parse import urljoin
+
+logger = logging.getLogger("seeding.cob_discovery")
+
+
+# Match COB WPDM anchors. The href can use either "href=" or
+# "location.href=" (the legacy onclick handler form). Captures the
+# full URL plus the numeric ``wpdmdl`` ID for sort-by-recency.
+_WPDM_RE = re.compile(
+    r"""(?:location\.href=|href=)['"]"""
+    r"""(?P<url>https?://[^'"\s]+\?(?:[^'"\s]*&)?wpdmdl=(?P<id>\d+)[^'"\s]*)""",
+    re.IGNORECASE,
+)
+
+# Legacy direct ``.pdf`` href — kept as a fallback for older test
+# fixtures and any page that ever reverts to direct links.
+_PDF_RE = re.compile(r'href=["\']([^"\']*\.pdf)["\']', re.IGNORECASE)
+
+
+def discover_latest_cob_pdf_url(
+    html: str,
+    base_url: str,
+    *,
+    keywords: Iterable[str],
+) -> Optional[str]:
+    """Return the most recent COB PDF URL on a publications page.
+
+    Strategy
+    --------
+    1. Find every WPDM ``?wpdmdl=NNN`` anchor in the HTML.
+       Filter by the caller's keywords (matched case-insensitively
+       against the URL string — the slug encodes the FY/period so
+       keyword filtering on the URL is reliable). Sort by ID
+       descending (highest = newest WPDM upload). Return the top.
+    2. If no WPDM anchors are present (legacy page or test fixture),
+       fall back to a direct ``[^"']*\\.pdf`` regex with the same
+       keyword filter and pick the first match — preserves the
+       original fetcher behaviour for offline tests.
+
+    Returns ``None`` only when neither strategy yields a candidate;
+    callers treat that as "live discovery failed, fall back to
+    fixture".
+
+    Parameters
+    ----------
+    html
+        Raw HTML body of the COB publications page.
+    base_url
+        URL of the page (used to absolutise relative hrefs in the
+        legacy fallback path; WPDM URLs are always absolute).
+    keywords
+        Substrings to match (case-insensitively) against the
+        candidate URLs. Domain-specific so each fetcher keeps its own
+        editorial control over which reports it picks up.
+    """
+    keywords_lower = [k.lower() for k in keywords]
+
+    # ── Strategy 1: WPDM anchors ──────────────────────────────────
+    wpdm_matches = [
+        (int(m.group("id")), m.group("url"))
+        for m in _WPDM_RE.finditer(html)
+    ]
+    if wpdm_matches:
+        filtered = [
+            (wid, url)
+            for wid, url in wpdm_matches
+            if any(kw in url.lower() for kw in keywords_lower)
+        ]
+        # Filtered list preferred; fall back to all WPDM hits if no
+        # keyword survived (cheap insurance against slug-text drift).
+        pool = filtered if filtered else wpdm_matches
+        pool.sort(key=lambda t: t[0], reverse=True)
+        chosen = pool[0][1]
+        if not chosen.startswith(("http://", "https://")):
+            chosen = urljoin(base_url, chosen)
+        logger.debug(
+            "COB WPDM discovery picked %s (from %d WPDM anchors, "
+            "%d after keyword filter)",
+            chosen, len(wpdm_matches), len(filtered),
+        )
+        return chosen
+
+    # ── Strategy 2: legacy direct .pdf hrefs ──────────────────────
+    all_pdfs = _PDF_RE.findall(html)
+    if not all_pdfs:
+        return None
+    filtered_pdfs = [
+        url for url in all_pdfs
+        if any(kw in url.lower() for kw in keywords_lower)
+    ]
+    candidates = filtered_pdfs if filtered_pdfs else all_pdfs
+    if not candidates:
+        return None
+    chosen = candidates[0]
+    if not chosen.startswith(("http://", "https://")):
+        chosen = urljoin(base_url, chosen)
+    return chosen
+
+
+__all__ = ["discover_latest_cob_pdf_url"]

--- a/backend/seeding/domains/counties_budget/fetcher.py
+++ b/backend/seeding/domains/counties_budget/fetcher.py
@@ -20,8 +20,8 @@ import tempfile
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import urljoin
 
+from ...cob_discovery import discover_latest_cob_pdf_url
 from ...config import SeedingSettings
 from ...http_client import SeedingHttpClient
 from ...utils import load_json_resource, slugify_entity
@@ -371,80 +371,25 @@ def _discover_latest_county_birr_via_html(
     return pdf_url
 
 
+_COUNTY_BIRR_KEYWORDS = (
+    "county", "c-birr", "cbirr", "county-government",
+    "county_government", "county-budget", "counties",
+    "consolidated-county",
+)
+
+
 def _discover_latest_county_birr_pdf(
     html: str, base_url: str
 ) -> Optional[str]:
     """Extract the most recent county BIRR PDF URL from the COB page.
 
-    COB wraps their PDFs in the WordPress Download Manager plugin, so the
-    anchors look like
-
-        <a ... onclick="location.href='https://cob.go.ke/download/
-        county-governments-budget-implementation-review-report-
-        first-half-of-fy-2025-26/?wpdmdl=16349';return false;">
-
-    not raw `.pdf` hrefs. Hitting the `?wpdmdl=NNN` URL with
-    ``Accept: application/pdf`` streams the file directly
-    (Content-Type: application/pdf). Higher ``wpdmdl`` IDs correspond to
-    newer uploads (WPDM's monotonic internal counter), so we sort by ID
-    descending and pick the highest county-slug match.
-
-    We also keep the original `.pdf` href scan as a fallback for:
-      * Legacy pages still hosting direct PDF links.
-      * Test fixtures / mocks written before WPDM was on the scene.
+    Delegates to the shared COB WPDM discovery helper. See
+    ``seeding.cob_discovery`` for the WPDM anchor + legacy ``.pdf``
+    fallback strategy.
     """
-    county_keywords = [
-        "county", "c-birr", "cbirr", "county-government",
-        "county_government", "county-budget", "counties",
-        "consolidated-county",
-    ]
-
-    # Strategy 1: WordPress Download Manager `wpdmdl=NNN` links.
-    wpdm_pattern = re.compile(
-        r"""(?P<prefix>location\.href=['"]|href=['"])"""
-        r"""(?P<url>https?://[^'"\s]+\?(?:[^'"\s]*&)?wpdmdl=(?P<id>\d+)[^'"\s]*)""",
-        re.IGNORECASE,
+    return discover_latest_cob_pdf_url(
+        html, base_url, keywords=_COUNTY_BIRR_KEYWORDS
     )
-    wpdm_matches = [
-        (int(m.group("id")), m.group("url")) for m in wpdm_pattern.finditer(html)
-    ]
-    if wpdm_matches:
-        county_wpdm = [
-            (wid, url)
-            for wid, url in wpdm_matches
-            if any(kw in url.lower() for kw in county_keywords)
-        ]
-        pool = county_wpdm if county_wpdm else wpdm_matches
-        # Highest ID = most recent upload per WPDM's monotonic counter.
-        pool.sort(key=lambda t: t[0], reverse=True)
-        chosen_url = pool[0][1]
-        if not chosen_url.startswith(("http://", "https://")):
-            chosen_url = urljoin(base_url, chosen_url)
-        return chosen_url
-
-    # Strategy 2: direct `.pdf` hrefs (legacy pages, test fixtures).
-    pdf_pattern = re.compile(
-        r'href=["\']([^"\']*\.pdf)["\']',
-        re.IGNORECASE,
-    )
-    all_pdfs = pdf_pattern.findall(html)
-    if not all_pdfs:
-        return None
-
-    county_pdfs = [
-        url for url in all_pdfs
-        if any(kw in url.lower() for kw in county_keywords)
-    ]
-
-    candidates = county_pdfs if county_pdfs else all_pdfs
-    if not candidates:
-        return None
-
-    chosen = candidates[0]
-    if not chosen.startswith(("http://", "https://")):
-        chosen = urljoin(base_url, chosen)
-
-    return chosen
 
 
 def _download_and_parse_county_pdf(

--- a/backend/seeding/domains/national_budget/fetcher.py
+++ b/backend/seeding/domains/national_budget/fetcher.py
@@ -12,12 +12,11 @@ quarterly NG-BIRR reports.
 from __future__ import annotations
 
 import logging
-import re
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-from urllib.parse import urljoin
 
+from ...cob_discovery import discover_latest_cob_pdf_url
 from ...config import SeedingSettings
 from ...http_client import SeedingHttpClient
 from ...utils import load_json_resource
@@ -90,37 +89,26 @@ def _fetch_from_cob_ng_pdf(
     return _download_and_parse_ng_pdf(client, pdf_url)
 
 
+_NG_BIRR_KEYWORDS = (
+    "ng-birr", "national-government-budget",
+    "national_government_budget", "birr",
+    "budget-implementation", "budget_implementation",
+)
+
+
 def _discover_latest_ng_birr_pdf(
     html: str, base_url: str
 ) -> Optional[str]:
-    """Extract the most recent NG-BIRR PDF URL from the COB page."""
-    pdf_pattern = re.compile(
-        r'href=["\']([^"\']*\.pdf)["\']',
-        re.IGNORECASE,
+    """Extract the most recent NG-BIRR PDF URL from the COB page.
+
+    Delegates to the shared COB WPDM discovery helper — see
+    ``seeding.cob_discovery`` for why direct ``.pdf`` regex stopped
+    matching after COB migrated to the WordPress Download Manager
+    plugin.
+    """
+    return discover_latest_cob_pdf_url(
+        html, base_url, keywords=_NG_BIRR_KEYWORDS
     )
-    all_pdfs = pdf_pattern.findall(html)
-    if not all_pdfs:
-        return None
-
-    birr_keywords = [
-        "ng-birr", "national-government-budget",
-        "national_government_budget", "birr",
-        "budget-implementation", "budget_implementation",
-    ]
-    birr_pdfs = [
-        url for url in all_pdfs
-        if any(kw in url.lower() for kw in birr_keywords)
-    ]
-
-    candidates = birr_pdfs if birr_pdfs else all_pdfs
-    if not candidates:
-        return None
-
-    chosen = candidates[0]
-    if not chosen.startswith(("http://", "https://")):
-        chosen = urljoin(base_url, chosen)
-
-    return chosen
 
 
 def _download_and_parse_ng_pdf(

--- a/backend/seeding/domains/pending_bills/fetcher.py
+++ b/backend/seeding/domains/pending_bills/fetcher.py
@@ -11,13 +11,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 import tempfile
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-from urllib.parse import urljoin
 
+from ...cob_discovery import discover_latest_cob_pdf_url
 from ...config import SeedingSettings
 from ...http_client import SeedingHttpClient
 
@@ -93,47 +92,24 @@ def _fetch_from_cob_pdf(
     return _download_and_parse_cob_pdf(client, pdf_url)
 
 
+_BIRR_KEYWORDS = (
+    "birr", "budget-implementation", "budget_implementation",
+    "implementation-review", "implementation_review",
+    "pending-bill", "pending_bill",
+)
+
+
 def _discover_latest_birr_pdf(html: str, base_url: str) -> Optional[str]:
     """Extract the most recent BIRR PDF URL from the COB reports page.
 
-    Looks for links matching common COB BIRR naming patterns like:
-    - BIRR-*.pdf
-    - Budget-Implementation-Review-*.pdf
-    - NG-BIRR-*.pdf
-    - national-government-budget-implementation*.pdf
+    Delegates to the shared COB WPDM discovery helper — see
+    ``seeding.cob_discovery`` for why direct ``.pdf`` regex stopped
+    matching after COB migrated to the WordPress Download Manager
+    plugin.
     """
-    pdf_pattern = re.compile(
-        r'href=["\']([^"\']*\.pdf)["\']',
-        re.IGNORECASE,
+    return discover_latest_cob_pdf_url(
+        html, base_url, keywords=_BIRR_KEYWORDS
     )
-    all_pdfs = pdf_pattern.findall(html)
-
-    if not all_pdfs:
-        return None
-
-    # Filter for BIRR-related PDFs
-    birr_keywords = [
-        "birr", "budget-implementation", "budget_implementation",
-        "implementation-review", "implementation_review",
-        "pending-bill", "pending_bill",
-    ]
-    birr_pdfs = [
-        url for url in all_pdfs
-        if any(kw in url.lower() for kw in birr_keywords)
-    ]
-
-    candidates = birr_pdfs if birr_pdfs else all_pdfs
-
-    if not candidates:
-        return None
-
-    # Pick the first match (usually the most recent)
-    chosen = candidates[0]
-
-    if not chosen.startswith(("http://", "https://")):
-        chosen = urljoin(base_url, chosen)
-
-    return chosen
 
 
 def _download_and_parse_cob_pdf(

--- a/backend/tests/test_cob_discovery.py
+++ b/backend/tests/test_cob_discovery.py
@@ -1,0 +1,128 @@
+"""Tests for the shared COB WPDM PDF-discovery helper.
+
+These pin the behaviour the three caller domains (counties_budget,
+national_budget, pending_bills) depend on:
+
+* WPDM ``?wpdmdl=NNN`` anchors are preferred and sorted by ID
+  descending so the latest upload wins.
+* Direct ``.pdf`` hrefs still work as a fallback (legacy pages /
+  test fixtures predating the WPDM migration).
+* Keyword filtering is permissive — it falls back to the unfiltered
+  pool when no candidate matches, instead of returning ``None``.
+
+The motivating bug: COB migrated all PDF distribution to WPDM, the
+direct-``.pdf`` regex matched zero links, three domains silently
+shipped fixture data on every nightly run.
+"""
+
+from __future__ import annotations
+
+import pytest
+from seeding.cob_discovery import discover_latest_cob_pdf_url
+
+
+# A trimmed, real-shape page snippet covering both anchor styles
+# COB has used. WPDM IDs are intentionally non-monotonic in source
+# order so the test verifies sort-by-ID, not sort-by-position.
+_WPDM_HTML = """
+<html><body>
+<a href="https://cob.go.ke/download/county-governments-birr-fy-2024-25/?wpdmdl=16263">FY 2024/25</a>
+<a href="https://cob.go.ke/download/county-governments-birr-first-half-of-fy-2025-26/?wpdmdl=16349">H1 FY 2025/26</a>
+<a href="https://cob.go.ke/download/county-governments-birr-first-quarter-of-fy-2025-26/?wpdmdl=16323">Q1 FY 2025/26</a>
+<a href="https://cob.go.ke/download/some-other-publication/?wpdmdl=16400">Unrelated newer doc</a>
+</body></html>
+"""
+
+
+class TestWpdmStrategy:
+    def test_picks_highest_wpdmdl_id_among_keyword_matches(self):
+        """Highest ``wpdmdl`` ID = newest WPDM upload. Among
+        county-keyword matches, 16349 wins over 16263 / 16323."""
+        chosen = discover_latest_cob_pdf_url(
+            _WPDM_HTML,
+            base_url="https://cob.go.ke/publications/foo/",
+            keywords=["county", "c-birr"],
+        )
+        assert chosen == (
+            "https://cob.go.ke/download/county-governments-birr-"
+            "first-half-of-fy-2025-26/?wpdmdl=16349"
+        )
+
+    def test_keyword_filter_is_case_insensitive(self):
+        """Caller keywords might be canonical-cased; the helper
+        lowers both sides so an upper-case slug fragment still
+        matches."""
+        chosen = discover_latest_cob_pdf_url(
+            _WPDM_HTML,
+            base_url="https://cob.go.ke/",
+            keywords=["COUNTY"],
+        )
+        assert chosen is not None and "county-governments" in chosen
+
+    def test_falls_back_to_unfiltered_pool_when_no_keyword_match(self):
+        """If filtering eliminates every candidate (e.g. caller's
+        keyword list drifted away from current slugs), still return
+        the latest WPDM hit rather than None — better than silently
+        failing back to fixture for a slug-text typo."""
+        chosen = discover_latest_cob_pdf_url(
+            _WPDM_HTML,
+            base_url="https://cob.go.ke/",
+            keywords=["kazakhstan"],  # matches nothing
+        )
+        # Highest ID across ALL wpdm matches is 16400.
+        assert chosen.endswith("?wpdmdl=16400")
+
+    def test_handles_location_href_form(self):
+        """Some legacy COB pages used the JS onclick handler:
+        ``onclick="location.href='...'"`` rather than ``href=``."""
+        html = """
+        <a onclick="location.href='https://cob.go.ke/download/foo/?wpdmdl=999';return false;">x</a>
+        """
+        chosen = discover_latest_cob_pdf_url(
+            html, base_url="https://cob.go.ke/", keywords=["foo"]
+        )
+        assert chosen == "https://cob.go.ke/download/foo/?wpdmdl=999"
+
+
+class TestLegacyPdfFallback:
+    def test_picks_first_pdf_when_no_wpdm(self):
+        """Pages that still use direct ``.pdf`` hrefs (or test
+        fixtures predating WPDM) fall through to the legacy pattern.
+        First match wins — preserves the prior behaviour callers
+        relied on."""
+        html = """
+        <a href="https://cob.go.ke/files/national-government-birr-q1.pdf">Q1</a>
+        <a href="https://cob.go.ke/files/national-government-birr-q2.pdf">Q2</a>
+        """
+        chosen = discover_latest_cob_pdf_url(
+            html,
+            base_url="https://cob.go.ke/",
+            keywords=["national-government", "birr"],
+        )
+        assert chosen.endswith("national-government-birr-q1.pdf")
+
+    def test_resolves_relative_pdf_urls_against_base(self):
+        """Relative hrefs in the legacy fallback get absolutised
+        with ``urljoin`` against the page URL — WPDM URLs are always
+        absolute so this only matters for the ``.pdf`` path."""
+        html = '<a href="/files/birr-q1.pdf">x</a>'
+        chosen = discover_latest_cob_pdf_url(
+            html,
+            base_url="https://cob.go.ke/publications/",
+            keywords=["birr"],
+        )
+        assert chosen == "https://cob.go.ke/files/birr-q1.pdf"
+
+
+class TestEmptyResults:
+    def test_returns_none_when_no_pdf_links(self):
+        """A page with neither WPDM nor ``.pdf`` anchors should
+        return None — the caller treats that as 'live discovery
+        failed, fall back to fixture'."""
+        html = "<html><body>nothing useful here</body></html>"
+        assert (
+            discover_latest_cob_pdf_url(
+                html, base_url="https://cob.go.ke/", keywords=["birr"]
+            )
+            is None
+        )


### PR DESCRIPTION
## Summary

The seed run [Actions 24943881873](https://github.com/Rodgers31/audit_app/actions/runs/24943881873) showed two domains silently falling back to fixtures because their COB PDF discovery returned zero matches:

> [WARNING] seeding.national_budget.fetcher: No NG-BIRR PDF link found on COB reports page  
> [WARNING] seeding.pending_bills.fetcher:   No BIRR PDF link found on COB reports page

## Root cause

COB migrated all PDF distribution from direct `wp-content/uploads/.../foo.pdf` URLs to the WordPress Download Manager (WPDM) plugin. Anchors on the publications pages now look like:

```html
<a href="https://cob.go.ke/download/national-government-budget-implementation-review-report-for-first-six-months-fy-2025-26/?wpdmdl=16344">…</a>
```

Both fetchers used a `[^"']*\.pdf` regex which matches **zero** of these. counties_budget had a domain-local WPDM handler so its HTML fallback worked — but national_budget and pending_bills had no equivalent, so every nightly run shipped stale fixture data.

(Side note: the WP REST API counties_budget tries first now returns 4 unrelated items because BIRR uploads no longer surface in `/wp/v2/media`. The HEAD-probe path catches this and falls through to HTML — non-fatal noise, untouched here.)

## Fix

New shared helper `seeding/cob_discovery.py:discover_latest_cob_pdf_url(html, base_url, keywords)`:
- Strategy 1: match WPDM `?wpdmdl=NNN` anchors, sort by ID descending (WPDM's monotonic counter ≡ upload recency), filter by caller-supplied keywords against the slug
- Strategy 2: legacy direct `.pdf` regex as fallback (preserves test fixtures and any page that ever reverts to direct links)
- Missing-keyword candidates fall through to the unfiltered pool — slug-text drift can't silently drop us back to fixture

All three fetchers now delegate to the helper:
- [counties_budget/fetcher.py](backend/seeding/domains/counties_budget/fetcher.py) loses ~70 lines of inlined WPDM logic (refactor only — unchanged behaviour).
- [national_budget/fetcher.py](backend/seeding/domains/national_budget/fetcher.py) goes from broken to live.
- [pending_bills/fetcher.py](backend/seeding/domains/pending_bills/fetcher.py) goes from broken to live.

## Smoke test (live, 2026-04-26)

```
counties_budget   -> https://cob.go.ke/download/county-governments-…-first-half-of-fy-2025-26/?wpdmdl=16349
national_budget   -> https://cob.go.ke/download/national-government-…-first-six-months-fy-2025-26/?wpdmdl=16344
pending_bills     -> https://cob.go.ke/download/national-government-…-first-six-months-fy-2025-26/?wpdmdl=16344
```

## Test plan

- [x] `pytest tests/test_cob_discovery.py` — 7 new tests covering WPDM sort-by-ID, case-insensitive keyword filter, slug-drift fallback, `location.href=` legacy form, direct-`.pdf` fallback, relative-URL absolutisation, empty-result None.
- [x] `pytest tests/test_counties_budget_fetcher.py tests/test_counties_budget_domain.py` — 23/23 passing (refactor preserved behaviour).
- [x] Full unit suite (excluding pre-existing import errors): **422 passed, 1 skipped**.
- [ ] Re-trigger the Actions seed workflow after merge — verify `national_budget` and `pending_bills` warnings disappear and items_processed > 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)