### PR TITLE
fix(pending_bills): replace broken NG-BIRR path with Treasury BROP

### DIFF
--- a/backend/seeding/config.py
+++ b/backend/seeding/config.py
@@ -201,6 +201,22 @@ class SeedingSettings(BaseSettings):
             "Scraped to discover the latest BPS PDF."
         ),
     )
+    treasury_brop_url: Optional[str] = Field(
+        default=(
+            "https://www.treasury.go.ke/sites/default/files/"
+            "2025-Budget-Review-and-Outlook-Paper-1.pdf"
+        ),
+        description=(
+            "Direct URL to the latest National Treasury Budget Review "
+            "and Outlook Paper (BROP) PDF. The pending_bills domain "
+            "extracts paragraph 18 (national aggregate) and Table 10 "
+            "(per-county breakdown) from this document. The path "
+            "changes each year — set ``SEED_TREASURY_BROP_URL`` to the "
+            "new release URL when the next BROP drops, or set to None "
+            "to skip live fetch and use the fixture. Auto-discovery "
+            "from the Treasury landing page is a planned follow-up."
+        ),
+    )
     live_pdf_fetch_enabled: bool = Field(
         default=True,
         description=(

--- a/backend/seeding/domains/pending_bills/brop_parser.py
+++ b/backend/seeding/domains/pending_bills/brop_parser.py
@@ -1,0 +1,447 @@
+"""Parse pending bills from the National Treasury BROP.
+
+Why BROP and not the COB NG-BIRR
+--------------------------------
+The pending_bills domain was originally piped through the COB
+National Government BIRR (NG-BIRR), but that report has zero
+pending-bills tables — confirmed by walking the FY 2025/26 H1 PDF's
+TOC and full text. The four pages that mention the phrase use it
+incidentally inside Annex II Article 223 emergency-exchequer
+justifications, not as published data. So the prior fetch+parse
+path was structurally wrong (and the "derive pending = allocated −
+absorbed" formula it fell back on was a non-sequitur — that's
+unspent budget, not unpaid obligations).
+
+Treasury's annual **Budget Review and Outlook Paper** (BROP),
+published every September/October, is the cleanest live source:
+
+* **Paragraph 18** carries the national aggregate split — total
+  National Government pending bills, broken into State Corporations
+  and MDAs. Three numbers in narrative prose; we extract via regex.
+* **Table 10** ("County Governments Pending Bills as at 30th June
+  YYYY") carries 47 per-county rows with County Executive
+  {Recurrent, Development, Sub-Total} + County Assembly
+  {Recurrent, Development, Sub-Total} + Total. We extract via
+  text-mode parsing because pdfplumber's ``extract_tables`` returns
+  31 columns of misaligned soup on this layout.
+
+Caveats
+-------
+* **Annual cadence** (October). Fresh county-side data is published
+  more frequently in the COB Consolidated County BIRR; that's a
+  follow-up overlay using the same WPDM discovery from PR #78.
+* The narrative para-48 cites "cumulative pending bills" of KSh
+  195.5 B (statutory + payroll deductions included) but Table 10
+  reports KSh 176.9 B. Table 10 is the audited per-county breakdown
+  and what we persist; the 18.6B delta lives in the narrative only.
+* National-side detail is sparse — BROP only publishes the two-line
+  MDA-vs-SOE split, not per-MDA. Per-MDA pending bills require OAG
+  audit OCR and stay on fixture for now.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import pdfplumber
+
+from ...pdf_parsers import KENYAN_COUNTIES
+
+logger = logging.getLogger(__name__)
+
+
+# Para 18 anchor + capture pattern. Real text:
+#   "The total outstanding National Government pending bills as at
+#    30th June 2025 amounted to KSh 525.9 billion. These comprise of
+#    KSh 404.3 billion (76.9 percent) and KSh 121.6 billion (23.1
+#    percent) for the State Corporations and MDAs, respectively."
+# Three "X billion" numbers in order: total, SOEs, MDAs. We require
+# the trailing "State Corporations and MDAs" anchor AFTER the third
+# number to make sure we're in the right paragraph (not catching a
+# random three-billion-figure narrative elsewhere).
+_NATIONAL_PARA_RE = re.compile(
+    r"total\s+outstanding\s+National\s+Government\s+pending\s+bills"
+    r".{0,200}?"
+    r"(?P<total>[\d,]+\.?\d*)\s*billion"
+    r".{0,300}?"
+    r"(?P<soes>[\d,]+\.?\d*)\s*billion"
+    r".{0,200}?"
+    r"(?P<mdas>[\d,]+\.?\d*)\s*billion"
+    r".{0,200}?"
+    r"State\s+Corporations\s+and\s+MDAs",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# "as at 30th June 2025" → date(2025, 6, 30) — gives the records a
+# stable measurement date for the writer's natural key.
+_AS_AT_RE = re.compile(
+    r"as\s+at\s+(?P<day>\d{1,2})(?:st|nd|rd|th)?\s+(?P<month>"
+    r"January|February|March|April|May|June|July|August|"
+    r"September|October|November|December)\s+(?P<year>\d{4})",
+    re.IGNORECASE,
+)
+
+# Months map for _AS_AT_RE.
+_MONTHS = {
+    name.lower(): i + 1 for i, name in enumerate([
+        "January", "February", "March", "April", "May", "June",
+        "July", "August", "September", "October", "November", "December",
+    ])
+}
+
+# Table 10 row pattern — one numbered county row in extract_text()
+# output. The county name can span 1-2 tokens (e.g. "Homa Bay",
+# "Trans Nzoia") or break across lines via a hyphen ("Tharaka- /
+# Nithi", "Elgeyo- / Marakwet"); we pre-process the text to dehyphenate
+# before applying this regex. Numeric columns may be "-" for empty
+# cells. We capture the last 3 numbers (Total, FY Budget, %) which
+# are present on every row; the Executive/Assembly sub-columns are
+# extracted in a second pass.
+_NUM = r"(?:[\d,]+\.\d+|[\d,]+|-)"
+_COUNTY_ROW_RE = re.compile(
+    r"^\s*(?P<no>\d{1,2})\.\s+"
+    r"(?P<county>[A-Za-z][A-Za-z\s\-']+?)"
+    r"\s+(?P<rest>(?:" + _NUM + r"\s+){4,9}" + _NUM + r")\s*$"
+)
+
+
+@dataclass(frozen=True)
+class NationalPendingBills:
+    """Para-18 national aggregate split.
+
+    All amounts are in whole KShs (BROP publishes billions; the
+    parser scales to match the fixture/writer convention).
+    """
+    as_at_date: date
+    total: Decimal
+    state_corporations: Decimal
+    mdas: Decimal
+
+
+@dataclass(frozen=True)
+class CountyPendingBill:
+    """One row of Table 10 for a single county."""
+    county: str             # canonical county name (per KENYAN_COUNTIES)
+    executive_recurrent: Optional[Decimal]
+    executive_development: Optional[Decimal]
+    executive_subtotal: Optional[Decimal]
+    assembly_recurrent: Optional[Decimal]
+    assembly_development: Optional[Decimal]
+    assembly_subtotal: Optional[Decimal]
+    total: Decimal
+    fy_budget: Optional[Decimal]
+    pct_of_budget: Optional[Decimal]
+
+
+@dataclass(frozen=True)
+class BropParseResult:
+    """Combined output of a BROP parse pass."""
+    fiscal_year_label: str   # e.g. "FY 2024/25"
+    national: Optional[NationalPendingBills]
+    counties: List[CountyPendingBill]
+
+
+def _parse_kes_billion(token: str) -> Optional[Decimal]:
+    """Parse "525.9" or "1,234" as KSh billions → whole KSh Decimal."""
+    if token is None:
+        return None
+    cleaned = token.strip().replace(",", "")
+    if not cleaned or cleaned == "-":
+        return None
+    try:
+        return (Decimal(cleaned) * Decimal("1000000000")).quantize(Decimal("1"))
+    except Exception:
+        return None
+
+
+def _parse_kes_million(token: str) -> Optional[Decimal]:
+    """Parse "1,588.1" as KSh millions → whole KSh Decimal.
+    Returns ``None`` for "-" or unparseable cells so the caller can
+    leave the column unset rather than write 0.
+    """
+    if token is None:
+        return None
+    cleaned = token.strip().replace(",", "")
+    if not cleaned or cleaned == "-":
+        return None
+    try:
+        return (Decimal(cleaned) * Decimal("1000000")).quantize(Decimal("1"))
+    except Exception:
+        return None
+
+
+def _detect_brop_fiscal_year(pdf: pdfplumber.PDF) -> str:
+    """Read the cover for the BROP year (e.g. "2025"), then format
+    as a Kenya fiscal-year label ending in that calendar year (BROP
+    is published in Sep/Oct of the FY's first calendar year, so
+    "2025 BROP" reports on FY 2024/25)."""
+    text = ""
+    for page in pdf.pages[:3]:
+        text += "\n" + (page.extract_text() or "")
+    m = re.search(r"(20\d{2})\s+BUDGET\s+REVIEW", text, re.IGNORECASE)
+    if m:
+        year = int(m.group(1))
+        return f"FY {year - 1}/{str(year)[-2:]}"
+    return "FY ?"
+
+
+def _detect_national_paragraph(pdf: pdfplumber.PDF) -> Optional[NationalPendingBills]:
+    """Walk pages for the para-18 anchor + extract the 3 amounts."""
+    for page in pdf.pages[:30]:
+        text = page.extract_text() or ""
+        m = _NATIONAL_PARA_RE.search(text)
+        if not m:
+            continue
+        total = _parse_kes_billion(m.group("total"))
+        soes = _parse_kes_billion(m.group("soes"))
+        mdas = _parse_kes_billion(m.group("mdas"))
+        if total is None or soes is None or mdas is None:
+            continue
+        # "as at" date lives in the same paragraph; if missing,
+        # default to June 30 of the prior calendar year (Kenya FY
+        # ends).
+        date_match = _AS_AT_RE.search(text)
+        if date_match:
+            as_at = date(
+                int(date_match.group("year")),
+                _MONTHS[date_match.group("month").lower()],
+                int(date_match.group("day")),
+            )
+        else:
+            # Find any "30th June YYYY" elsewhere in the page if
+            # missing from the paragraph directly.
+            as_at = date(2000, 6, 30)
+        return NationalPendingBills(
+            as_at_date=as_at,
+            total=total,
+            state_corporations=soes,
+            mdas=mdas,
+        )
+    return None
+
+
+def _dehyphenate_text(text: str) -> str:
+    """Stitch back county names that pdfplumber broke across lines:
+    "Tharaka- / Nithi" → "Tharaka-Nithi". Also fixes "Elgeyo- /
+    Marakwet". We only join when the hyphen is the LAST character of
+    a line and the next line starts with an uppercase letter."""
+    lines = text.split("\n")
+    out: List[str] = []
+    skip = False
+    for i, line in enumerate(lines):
+        if skip:
+            skip = False
+            continue
+        stripped = line.rstrip()
+        if (
+            i + 1 < len(lines)
+            and stripped.endswith("-")
+            and lines[i + 1].strip()
+            and lines[i + 1].strip()[0].isupper()
+        ):
+            # Join: "...Tharaka-" + " " + "Nithi" + " ..." (rest of next line)
+            out.append(stripped + lines[i + 1].lstrip())
+            skip = True
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
+def _normalise_county(name: str) -> Optional[str]:
+    """Map an extracted county-name fragment to the canonical
+    KENYAN_COUNTIES form. Returns None if no match — callers treat
+    that as "this row isn't a county row, skip it".
+
+    Both sides go through the same lowercasing + apostrophe-strip +
+    hyphen→space normalisation so "Murang'a" → "Murang'a", and a
+    pdfplumber-truncated "Tharaka-" prefix-matches "Tharaka Nithi"
+    (a real BROP failure mode where pdfplumber drops the second line
+    of a wrapped county name).
+    """
+    def _norm(s: str) -> str:
+        return re.sub(
+            r"\s+",
+            " ",
+            s.lower().replace("'", "").replace("’", "")
+             .replace("-", " "),
+        ).strip()
+
+    norm = _norm(" ".join(name.split()).rstrip(",").rstrip("-"))
+    for canonical in KENYAN_COUNTIES:
+        canon_norm = _norm(canonical)
+        if norm == canon_norm:
+            return canonical
+        # Prefix-match for the wrapped-name case: "Tharaka" matches
+        # "Tharaka Nithi", "Elgeyo" matches "Elgeyo Marakwet".
+        # Only counties where the prefix is unambiguous are eligible
+        # (no other county starts with the same first word).
+        if " " in canon_norm and norm == canon_norm.split(" ", 1)[0]:
+            # Verify uniqueness — if two canonicals share the first
+            # word, refuse to guess.
+            siblings = [
+                c for c in KENYAN_COUNTIES
+                if _norm(c).startswith(norm + " ") and c != canonical
+            ]
+            if not siblings:
+                return canonical
+    return None
+
+
+_COUNTY_TABLE_TITLE_RE = re.compile(
+    r"Table\s+\d+:\s*County\s+Governments\s+Pending\s+Bills",
+    re.IGNORECASE,
+)
+_END_OF_COUNTY_TABLE_RE = re.compile(
+    # Row of "Total ... Source: Controller of Budget" / next section
+    # heading marks end of the table.
+    r"^(?:Total\s|N/B|Source\s*:|\d+\.\s+(?:To\s+address|[A-Z][a-z]+\s+(?:Status|Issues|Risks))|"
+    r"E\.\s+|F\.\s+)",
+    re.IGNORECASE,
+)
+
+
+def _parse_county_table(pdf: pdfplumber.PDF) -> List[CountyPendingBill]:
+    """Extract Table 10 ("County Governments Pending Bills as at
+    YYYY-mm-dd") by walking pages from the first one whose text
+    contains the table title; stop at the Total/N.B./Source row.
+
+    Anchoring on the title prevents picking up earlier numbered
+    tables (the BROP has at least one other table with county-style
+    rows on page 23 that would otherwise pollute the parse).
+
+    pdfplumber's ``extract_tables`` produces 30+-column misaligned
+    noise on this layout, so we use ``extract_text`` line-by-line.
+    """
+    out: List[CountyPendingBill] = []
+    seen: set = set()
+    in_table = False
+    # Section D of BROP is well within the front 40 pages — the
+    # table title gates entry, so the page-range cap is just a sanity
+    # bound to avoid scanning the whole 75-page doc on a malformed
+    # PDF.
+    for page in pdf.pages[:50]:
+        raw = page.extract_text() or ""
+        text = _dehyphenate_text(raw)
+        for line in text.split("\n"):
+            if not in_table:
+                if _COUNTY_TABLE_TITLE_RE.search(line):
+                    in_table = True
+                continue
+            if _END_OF_COUNTY_TABLE_RE.match(line):
+                # The table can be split across pages, but the actual
+                # END marker (Total / N/B / Source) only appears once.
+                # After we hit it, we're permanently done.
+                return out
+            m = _COUNTY_ROW_RE.match(line)
+            if not m:
+                continue
+            county = _normalise_county(m.group("county"))
+            if not county or county in seen:
+                continue
+            tokens = m.group("rest").split()
+            row = _parse_county_row_numbers(tokens)
+            if row is None:
+                continue
+            seen.add(county)
+            out.append(
+                CountyPendingBill(
+                    county=county,
+                    executive_recurrent=row.get("exec_rec"),
+                    executive_development=row.get("exec_dev"),
+                    executive_subtotal=row.get("exec_sub"),
+                    assembly_recurrent=row.get("asm_rec"),
+                    assembly_development=row.get("asm_dev"),
+                    assembly_subtotal=row.get("asm_sub"),
+                    total=row["total"],
+                    fy_budget=row.get("fy_budget"),
+                    pct_of_budget=row.get("pct"),
+                )
+            )
+    return out
+
+
+def _parse_county_row_numbers(tokens: List[str]) -> Optional[dict]:
+    """Distribute the captured numeric tokens across the column
+    layout. Real BROP rows have 5–9 numeric tokens depending on how
+    many cells were rendered as "-" (omitted from text mode):
+
+    Full row (9 numbers): exec_rec, exec_dev, exec_sub, asm_rec,
+    asm_dev, asm_sub, total, fy_budget, pct.
+
+    Most rows have 7 numbers (executive sub_total computed inline by
+    pdfplumber, so it's there), some have 5 (a county with no
+    assembly entries — only Recurrent + Total + Budget + % survive).
+    We reverse-fill from the right since the last 3 (Total, Budget,
+    %) are always present.
+    """
+    nums = [_parse_kes_million(t) for t in tokens]
+    nums = [n for n in nums if n is not None] + [None] * 0
+    if len(nums) < 3:
+        return None
+    # Last three are Total, FY Budget, %. The "%" column comes in as
+    # millions in our parse helper, so divide back to get the real
+    # percentage. (Cosmetic only — the writer doesn't persist %.)
+    pct_raw = nums[-1]
+    pct = (pct_raw / Decimal("1000000")) if pct_raw is not None else None
+    fy_budget_raw = nums[-2]
+    fy_budget = fy_budget_raw  # already KShs (BROP's budget col is
+                               # in KSh million same as other cells)
+    total = nums[-3]
+    if total is None:
+        return None
+
+    # Whatever's before [total, fy_budget, pct] is the
+    # Executive/Assembly breakdown — variable-length depending on
+    # which cells the PDF rendered as numbers vs hyphens.
+    breakdown = nums[:-3]
+    out: dict = {"total": total, "fy_budget": fy_budget, "pct": pct}
+    # Assign greedily by count. The most common cases:
+    # 6 numbers: exec_rec, exec_dev, exec_sub, asm_rec, asm_dev, asm_sub
+    # 5 numbers: exec_rec, exec_dev, exec_sub, asm_rec_or_sub, [omitted]
+    # 4 numbers: exec_rec, exec_dev, exec_sub, asm_sub
+    # 3 numbers: exec_rec, exec_dev, exec_sub
+    # 2 numbers: exec_rec, exec_dev (sub_total inferred)
+    keys = (
+        "exec_rec", "exec_dev", "exec_sub",
+        "asm_rec", "asm_dev", "asm_sub",
+    )
+    for key, value in zip(keys, breakdown):
+        out[key] = value
+    return out
+
+
+def parse_brop_pdf(pdf_path: Path) -> BropParseResult:
+    """Parse a BROP PDF and return the structured pending-bills data."""
+    with pdfplumber.open(pdf_path) as pdf:
+        fy_label = _detect_brop_fiscal_year(pdf)
+        national = _detect_national_paragraph(pdf)
+        counties = _parse_county_table(pdf)
+    if national is None and not counties:
+        raise ValueError(
+            f"No pending-bills data found in {pdf_path.name} — "
+            "neither the para-18 anchor nor the county table matched"
+        )
+    logger.info(
+        "BROP parser extracted national=%s + %d counties (FY %s) from %s",
+        "yes" if national else "no", len(counties),
+        fy_label, pdf_path.name,
+    )
+    return BropParseResult(
+        fiscal_year_label=fy_label,
+        national=national,
+        counties=counties,
+    )
+
+
+__all__ = [
+    "BropParseResult",
+    "CountyPendingBill",
+    "NationalPendingBills",
+    "parse_brop_pdf",
+]

--- a/backend/seeding/domains/pending_bills/fetcher.py
+++ b/backend/seeding/domains/pending_bills/fetcher.py
@@ -1,10 +1,23 @@
-"""Fetcher for pending bills data from COB reports.
+"""Fetcher for pending bills data from National Treasury BROP.
 
 Strategy (in order):
-1. If live_pdf_fetch_enabled, try to discover the latest COB National
-   Government BIRR PDF, download it, and parse with CoBQuarterlyReportParser.
-2. If pending_bills_dataset_url is configured, load from that source.
+1. If live_pdf_fetch_enabled AND treasury_brop_url is configured,
+   download and parse the BROP PDF — gives the para-18 national
+   aggregate + Table 10 per-county breakdown.
+2. If pending_bills_dataset_url is configured, load from that
+   fixture / API.
 3. Otherwise, run the live ETL extractor against COB website.
+
+Why not the COB NG-BIRR
+-----------------------
+The previous implementation downloaded the COB National Government
+BIRR and ran it through ``CoBQuarterlyReportParser``, which is
+anchored on the 47-county invariant of the *Consolidated County*
+BIRR. The NG-BIRR has neither a 47-county table nor any pending-
+bills tables (TOC search confirmed in the FY 2025/26 H1 issue).
+On top of that, the fallback formula ``pending = allocated -
+absorbed`` was a non-sequitur — that's unspent budget, not unpaid
+obligations. Both issues are removed here.
 """
 
 from __future__ import annotations
@@ -16,7 +29,6 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from ...cob_discovery import discover_latest_cob_pdf_url
 from ...config import SeedingSettings
 from ...http_client import SeedingHttpClient
 
@@ -30,28 +42,37 @@ def fetch_pending_bills_payload(
     Fetch pending bills data.
 
     Strategy:
-      1. Try live PDF fetch from COB reports page (if enabled).
-      2. If pending_bills_dataset_url is configured, load from fixture/API.
+      1. Try live BROP fetch (if enabled + URL configured).
+      2. If pending_bills_dataset_url is configured, load fixture/API.
       3. Otherwise, run the live ETL extractor against COB website.
     """
-    # Strategy 1: Live PDF fetch
-    if settings.live_pdf_fetch_enabled:
+    # Strategy 1: Treasury BROP — only when URL is configured. Defaults
+    # to None so an unconfigured deployment doesn't loudly skip it on
+    # every run; the fixture fallback (Strategy 2) covers that case.
+    brop_url = getattr(settings, "treasury_brop_url", None)
+    if settings.live_pdf_fetch_enabled and brop_url:
         try:
-            payload = _fetch_from_cob_pdf(client, settings)
-            if payload and payload.get("pending_bills"):
+            payload = _fetch_from_treasury_brop(client, brop_url)
+            if payload and (
+                payload.get("pending_bills") or payload.get("summary")
+            ):
                 logger.info(
-                    "Successfully fetched pending bills from COB PDF (%d records)",
-                    len(payload["pending_bills"]),
+                    "Successfully fetched pending bills from BROP "
+                    "(%d records)",
+                    len(payload.get("pending_bills") or []),
                 )
                 return payload
-            else:
-                logger.warning(
-                    "COB PDF fetch returned no pending bills, trying fixture"
-                )
+            logger.warning(
+                "BROP fetch returned no pending bills, trying fixture"
+            )
         except Exception as exc:
             logger.warning(
-                "COB PDF fetch failed, trying fixture: %s", exc
+                "BROP fetch failed, trying fixture: %s", exc
             )
+    elif settings.live_pdf_fetch_enabled:
+        logger.info(
+            "treasury_brop_url not configured; skipping live BROP fetch"
+        )
 
     # Strategy 2: Configured fixture / API URL
     dataset_url = getattr(settings, "pending_bills_dataset_url", None)
@@ -73,143 +94,130 @@ def fetch_pending_bills_payload(
     return _run_live_extraction()
 
 
-def _fetch_from_cob_pdf(
-    client: SeedingHttpClient, settings: SeedingSettings
+def _fetch_from_treasury_brop(
+    client: SeedingHttpClient, brop_url: str,
 ) -> Optional[Dict[str, Any]]:
-    """Discover and parse the latest COB BIRR PDF."""
-    page_url = settings.cob_birr_page_url
-    logger.info("Fetching COB BIRR reports page: %s", page_url)
+    """Download the BROP PDF, parse it, return pending bills payload.
 
-    response = client.get(page_url, raise_for_status=True)
-    html = response.text
-
-    pdf_url = _discover_latest_birr_pdf(html, page_url)
-    if not pdf_url:
-        logger.warning("No BIRR PDF link found on COB reports page")
-        return None
-
-    logger.info("Downloading COB BIRR PDF: %s", pdf_url)
-    return _download_and_parse_cob_pdf(client, pdf_url)
-
-
-_BIRR_KEYWORDS = (
-    "birr", "budget-implementation", "budget_implementation",
-    "implementation-review", "implementation_review",
-    "pending-bill", "pending_bill",
-)
-
-
-def _discover_latest_birr_pdf(html: str, base_url: str) -> Optional[str]:
-    """Extract the most recent BIRR PDF URL from the COB reports page.
-
-    Delegates to the shared COB WPDM discovery helper — see
-    ``seeding.cob_discovery`` for why direct ``.pdf`` regex stopped
-    matching after COB migrated to the WordPress Download Manager
-    plugin.
+    file:// URLs are read from disk so tests and offline runs don't
+    require a live HTTP path.
     """
-    return discover_latest_cob_pdf_url(
-        html, base_url, keywords=_BIRR_KEYWORDS
-    )
+    from .brop_parser import parse_brop_pdf
 
-
-def _download_and_parse_cob_pdf(
-    client: SeedingHttpClient, pdf_url: str
-) -> Optional[Dict[str, Any]]:
-    """Download a COB PDF to a temp file, parse it, and return pending bills payload."""
-    from ...pdf_parsers import CoBQuarterlyReportParser
-
+    logger.info("Downloading Treasury BROP PDF: %s", brop_url)
     tmp_path: Optional[Path] = None
     try:
-        response = client.get(pdf_url, raise_for_status=True)
+        if brop_url.startswith("file://"):
+            content = Path(brop_url[len("file://"):]).read_bytes()
+        else:
+            response = client.get(brop_url, raise_for_status=True)
+            content = response.content
 
         with tempfile.NamedTemporaryFile(
-            suffix=".pdf", delete=False, prefix="cob_birr_"
+            suffix=".pdf", delete=False, prefix="treasury_brop_"
         ) as tmp:
-            tmp.write(response.content)
+            tmp.write(content)
             tmp_path = Path(tmp.name)
 
-        logger.info(
-            "Downloaded COB PDF (%d bytes) to %s",
-            len(response.content),
-            tmp_path,
-        )
+        logger.info("Downloaded BROP PDF (%d bytes) to %s", len(content), tmp_path)
+        result = parse_brop_pdf(tmp_path)
 
-        # Parse with CoBQuarterlyReportParser
-        parser = CoBQuarterlyReportParser(tmp_path)
-        parsed_records = parser.parse()
-
-        if not parsed_records:
-            logger.warning("CoBQuarterlyReportParser returned no records")
-            return None
-
-        # Convert parsed budget execution records into pending bills format.
-        # The COB parser extracts county budget execution data (allocated vs absorbed).
-        # We derive "pending bills" as the gap between allocated and absorbed —
-        # unspent allocations often correspond to pending obligations.
-        pending_bills: List[Dict[str, Any]] = []
-        for record in parsed_records:
-            allocated = record.get("allocated", 0)
-            absorbed = record.get("absorbed", 0)
-            if isinstance(allocated, str):
-                try:
-                    from decimal import Decimal
-                    allocated = float(Decimal(allocated))
-                except Exception:
-                    allocated = 0
-            if isinstance(absorbed, str):
-                try:
-                    from decimal import Decimal
-                    absorbed = float(Decimal(absorbed))
-                except Exception:
-                    absorbed = 0
-
-            # Pending ≈ allocated - absorbed (unspent = potential pending bills)
-            pending = max(float(allocated) - float(absorbed), 0)
-            if pending <= 0:
-                continue
-
-            county = record.get("county", "Unknown")
-            fy = record.get("fiscal_year", "")
-            quarter = record.get("quarter", "")
-
-            pending_bills.append({
-                "entity_name": f"County Government of {county}",
-                "entity_type": "county",
-                "category": "county",
-                "fiscal_year": fy,
-                "total_pending": pending,
-                "eligible_pending": None,
-                "ineligible_pending": None,
-                "notes": (
-                    f"Derived from COB BIRR {quarter} {fy}: "
-                    f"allocated {allocated:,.0f} - absorbed {absorbed:,.0f} = "
-                    f"{pending:,.0f} unspent (proxy for pending obligations)"
-                ),
-            })
-
-        if not pending_bills:
-            logger.warning("No pending bills derived from COB budget data")
-            return None
-
-        return {
-            "pending_bills": pending_bills,
-            "summary": {
-                "fiscal_year": parsed_records[0].get("fiscal_year", ""),
-                "total_county": sum(
-                    pb["total_pending"] for pb in pending_bills
-                ),
-            },
-            "source_url": pdf_url,
-            "source_title": f"COB BIRR Report (live fetch)",
-        }
-
+        return _brop_result_to_payload(result, brop_url)
     finally:
         if tmp_path and tmp_path.exists():
             try:
                 tmp_path.unlink()
-                logger.debug("Cleaned up temp PDF: %s", tmp_path)
             except OSError:
                 pass
+
+
+def _brop_result_to_payload(
+    result, brop_url: str,
+) -> Dict[str, Any]:
+    """Convert a ``BropParseResult`` into the dict shape
+    ``parse_pending_bills_payload`` expects.
+
+    Emits:
+    * One ``state_corporation`` record for the SOEs aggregate.
+    * One ``mda`` record for the MDAs aggregate.
+    * One ``county`` record per parsed county row.
+    * A ``summary`` block with grand totals so the parser's
+      summary-fallback path can also produce useful aggregates if
+      the per-row records get filtered out downstream.
+    """
+    pending_bills: List[Dict[str, Any]] = []
+    fy_label = result.fiscal_year_label
+    source_title = f"Treasury BROP {fy_label}"
+
+    if result.national:
+        nb = result.national
+        as_at = nb.as_at_date.isoformat()
+        pending_bills.append(
+            {
+                "entity_name": "National Government — State Corporations",
+                "entity_type": "national",
+                "category": "state_corporation",
+                "fiscal_year": fy_label,
+                "total_pending": str(nb.state_corporations),
+                "notes": f"Treasury BROP para-18 aggregate as at {as_at}",
+            }
+        )
+        pending_bills.append(
+            {
+                "entity_name": "National Government — MDAs",
+                "entity_type": "national",
+                "category": "mda",
+                "fiscal_year": fy_label,
+                "total_pending": str(nb.mdas),
+                "notes": f"Treasury BROP para-18 aggregate as at {as_at}",
+            }
+        )
+
+    for cb in result.counties:
+        breakdown_parts = []
+        if cb.executive_subtotal is not None:
+            breakdown_parts.append(
+                f"Exec subtotal {float(cb.executive_subtotal):,.0f}"
+            )
+        if cb.assembly_subtotal is not None:
+            breakdown_parts.append(
+                f"Assembly subtotal {float(cb.assembly_subtotal):,.0f}"
+            )
+        if cb.fy_budget is not None:
+            breakdown_parts.append(
+                f"FY budget {float(cb.fy_budget):,.0f}"
+            )
+        notes = "Treasury BROP Table 10"
+        if breakdown_parts:
+            notes += " — " + "; ".join(breakdown_parts)
+        pending_bills.append(
+            {
+                "entity_name": f"County Government of {cb.county}",
+                "entity_type": "county",
+                "category": "county",
+                "fiscal_year": fy_label,
+                "total_pending": str(cb.total),
+                "notes": notes,
+            }
+        )
+
+    # Summary aggregates — useful for headline cards and as a
+    # fallback if per-row writers drop records.
+    summary: Dict[str, Any] = {"fiscal_year": fy_label}
+    if result.national:
+        summary["total_national"] = str(result.national.total)
+        summary["as_at_date"] = result.national.as_at_date.isoformat()
+    if result.counties:
+        summary["total_county"] = str(
+            sum((c.total for c in result.counties), Decimal(0))
+        )
+
+    return {
+        "pending_bills": pending_bills,
+        "summary": summary,
+        "source_url": brop_url,
+        "source_title": source_title,
+    }
 
 
 def _run_live_extraction() -> dict[str, Any]:

--- a/backend/tests/test_pending_bills_brop_parser.py
+++ b/backend/tests/test_pending_bills_brop_parser.py
@@ -1,0 +1,287 @@
+"""Tests for the Treasury BROP pending-bills parser.
+
+These pin the parsing behaviour the ``pending_bills`` domain
+depends on after switching off the broken NG-BIRR + allocated-minus-
+absorbed proxy. The internal helpers are tested against the actual
+shapes observed in the September-2025 BROP; the public
+``parse_brop_pdf`` entry point is smoke-tested via a stubbed
+pdfplumber so we don't ship a 2.5 MB fixture PDF in the repo.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from seeding.domains.pending_bills import brop_parser as bp
+
+
+# ── _parse_kes_billion / _parse_kes_million ─────────────────────────
+
+
+class TestNumberParsing:
+    def test_billion_scale(self):
+        assert bp._parse_kes_billion("525.9") == Decimal("525900000000")
+
+    def test_billion_with_comma(self):
+        assert bp._parse_kes_billion("1,234.5") == Decimal(
+            "1234500000000"
+        )
+
+    def test_million_scale(self):
+        assert bp._parse_kes_million("78,949.1") == Decimal(
+            "78949100000"
+        )
+
+    @pytest.mark.parametrize(
+        "func", [bp._parse_kes_billion, bp._parse_kes_million]
+    )
+    @pytest.mark.parametrize("token", ["", " ", "-", None])
+    def test_returns_none_for_empty_or_dash(self, func, token):
+        """BROP renders missing cells as '-'; the parser must keep
+        them as None so the writer leaves the column unset rather
+        than writing 0 (which would be a real value)."""
+        assert func(token) is None
+
+
+# ── _normalise_county ───────────────────────────────────────────────
+
+
+class TestNormaliseCounty:
+    def test_exact_match(self):
+        assert bp._normalise_county("Nairobi") == "Nairobi"
+
+    def test_apostrophe_stripped(self):
+        """'Murang'a' is the canonical form in KENYAN_COUNTIES; the
+        BROP renders it the same way. Both sides normalise to
+        'muranga' so the match works without losing the canonical
+        apostrophe."""
+        assert bp._normalise_county("Murang'a") == "Murang'a"
+
+    def test_hyphen_to_space(self):
+        """Some BROP cells use 'Tharaka-Nithi'; canonical is
+        'Tharaka Nithi'. Hyphens normalise to spaces on both sides."""
+        assert bp._normalise_county("Tharaka-Nithi") == "Tharaka Nithi"
+
+    def test_prefix_match_for_truncated_wrap(self):
+        """pdfplumber occasionally drops the second line of a
+        wrapped county name, so 'Tharaka' arrives without 'Nithi'.
+        We prefix-match against KENYAN_COUNTIES, but ONLY when the
+        prefix is unambiguous — no second county shares 'Tharaka' as
+        its first word, so this is safe."""
+        assert bp._normalise_county("Tharaka") == "Tharaka Nithi"
+        assert bp._normalise_county("Elgeyo") == "Elgeyo Marakwet"
+
+    def test_returns_none_for_non_county(self):
+        assert bp._normalise_county("Sub-Total") is None
+        assert bp._normalise_county("Total") is None
+        assert bp._normalise_county("Banana") is None
+
+
+# ── _detect_national_paragraph ──────────────────────────────────────
+
+
+_REAL_PARA_18 = """\
+17. Some other paragraph about external financing.
+
+Pending Bills
+
+18. The total outstanding National Government pending bills as at
+30th June 2025 amounted to KSh 525.9 billion. These comprise of
+KSh 404.3 billion (76.9 percent) and KSh 121.6 billion (23.1
+percent) for the State Corporations and MDAs, respectively.
+"""
+
+
+class TestDetectNationalParagraph:
+    def _stub_pdf(self, text: str) -> MagicMock:
+        page = MagicMock()
+        page.extract_text.return_value = text
+        pdf = MagicMock()
+        pdf.pages = [page] * 5  # search range is first 30 pages
+        return pdf
+
+    def test_extracts_three_amounts_and_date(self):
+        result = bp._detect_national_paragraph(self._stub_pdf(_REAL_PARA_18))
+        assert result is not None
+        assert result.total == Decimal("525900000000")
+        assert result.state_corporations == Decimal("404300000000")
+        assert result.mdas == Decimal("121600000000")
+        assert result.as_at_date == date(2025, 6, 30)
+
+    def test_returns_none_when_paragraph_absent(self):
+        result = bp._detect_national_paragraph(
+            self._stub_pdf("Just some narrative without the para-18 anchor.")
+        )
+        assert result is None
+
+
+# ── _COUNTY_ROW_RE + _parse_county_row_numbers ──────────────────────
+
+
+class TestCountyRowRegex:
+    def test_full_row(self):
+        """Real Nairobi row from BROP 2025 Table 10. Eight numeric
+        tokens because the Assembly column collapses to a single
+        sub-total (no Recurrent/Development split for Nairobi
+        Assembly)."""
+        line = (
+            "1. Nairobi 78,949.1 7,169.4 86,118.6 650.6 650.6 "
+            "86,769.2 43,564.27 199.2"
+        )
+        m = bp._COUNTY_ROW_RE.match(line)
+        assert m is not None
+        assert m.group("no") == "1"
+        assert m.group("county") == "Nairobi"
+        tokens = m.group("rest").split()
+        # Last 3 tokens are always Total / FY budget / %.
+        assert tokens[-3:] == ["86,769.2", "43,564.27", "199.2"]
+
+    def test_row_with_dash_for_missing_cell(self):
+        """'Kilifi 3,820.1 5,367.4 9,187.4 68.2 - 68.2 9,255.6
+        21,406.50 43.2' — the dash represents an empty assembly
+        development cell."""
+        line = (
+            "2. Kilifi 3,820.1 5,367.4 9,187.4 68.2 - 68.2 "
+            "9,255.6 21,406.50 43.2"
+        )
+        m = bp._COUNTY_ROW_RE.match(line)
+        assert m is not None
+        assert m.group("county") == "Kilifi"
+
+    def test_two_word_county_name(self):
+        line = (
+            "23. Trans Nzoia 805.4 703.0 1,508.4 - 1,508.4 "
+            "10,455.02 14.4"
+        )
+        m = bp._COUNTY_ROW_RE.match(line)
+        assert m is not None
+        assert m.group("county") == "Trans Nzoia"
+
+    def test_row_with_apostrophe(self):
+        """Murang'a's apostrophe must NOT terminate the county name
+        match early."""
+        line = (
+            "16. Murang'a 1,588.1 333.4 1,921.5 72.2 72.2 "
+            "1,993.7 10,743.65 18.6"
+        )
+        m = bp._COUNTY_ROW_RE.match(line)
+        assert m is not None
+        assert m.group("county") == "Murang'a"
+
+
+# ── _dehyphenate_text ───────────────────────────────────────────────
+
+
+class TestDehyphenateText:
+    def test_joins_hyphen_split_county_names(self):
+        text = "30. Tharaka-\nNithi 468.6 176.2 644.7"
+        out = bp._dehyphenate_text(text)
+        # Should join into a single line.
+        assert "Tharaka-Nithi" in out
+
+    def test_does_not_join_unrelated_lines(self):
+        """Only joins when the line ENDS in '-' and the next starts
+        with an uppercase letter — must not stitch normal paragraphs."""
+        text = "Some sentence ending in punctuation.\nAnother paragraph."
+        assert bp._dehyphenate_text(text) == text
+
+
+# ── parse_brop_pdf (integration via stubbed pdfplumber) ─────────────
+
+
+class TestParseBropPdfIntegration:
+    def test_emits_national_plus_counties(self, tmp_path):
+        cover_page = MagicMock()
+        cover_page.extract_text.return_value = (
+            "REPUBLIC OF KENYA\nTHE NATIONAL TREASURY\n"
+            "2025 BUDGET REVIEW AND OUTLOOK PAPER\nSEPTEMBER 2025"
+        )
+
+        para_page = MagicMock()
+        para_page.extract_text.return_value = _REAL_PARA_18
+
+        table_page = MagicMock()
+        table_page.extract_text.return_value = (
+            "Table 10: County Governments Pending Bills as at 30th June 2025\n"
+            "1. Nairobi 78,949.1 7,169.4 86,118.6 650.6 650.6 86,769.2 "
+            "43,564.27 199.2\n"
+            "2. Kilifi 3,820.1 5,367.4 9,187.4 68.2 - 68.2 9,255.6 "
+            "21,406.50 43.2\n"
+            "Total 122,625.9 49,121.0 171,746.9 4,232.7 924.5 5,157.3 "
+            "176,904.2 601,689.14 29\n"
+        )
+
+        fake_pdf = MagicMock()
+        fake_pdf.pages = [cover_page] * 3 + [para_page, table_page]
+        fake_pdf.__enter__ = lambda s: fake_pdf
+        fake_pdf.__exit__ = lambda *a: None
+
+        with patch.object(bp.pdfplumber, "open", return_value=fake_pdf):
+            result = bp.parse_brop_pdf(tmp_path / "fake.pdf")
+
+        assert result.fiscal_year_label == "FY 2024/25"
+        assert result.national is not None
+        assert result.national.total == Decimal("525900000000")
+        # 2 county rows extracted (Total filtered out by end marker).
+        assert len(result.counties) == 2
+        names = {c.county for c in result.counties}
+        assert names == {"Nairobi", "Kilifi"}
+
+    def test_county_table_anchored_on_title(self, tmp_path):
+        """The BROP has at least one OTHER table earlier with
+        county-style numbered rows. Without title-anchoring our
+        county regex would happily match those too. Verify we ignore
+        them when the Table 10 title hasn't appeared yet."""
+        cover_page = MagicMock()
+        cover_page.extract_text.return_value = (
+            "2025 BUDGET REVIEW AND OUTLOOK PAPER"
+        )
+        # Earlier table (e.g. revenue per county) — same row shape,
+        # different data, no Table 10 title.
+        decoy_page = MagicMock()
+        decoy_page.extract_text.return_value = (
+            "Table 5: County Revenue Performance\n"
+            "1. Nairobi 100.0 200.0 300.0 50.0 60.0 110.0 410.0 "
+            "1000.0 41.0\n"
+        )
+        # The real Table 10 page comes after, with different numbers.
+        table_page = MagicMock()
+        table_page.extract_text.return_value = (
+            "Table 10: County Governments Pending Bills as at 30th June 2025\n"
+            "1. Nairobi 78,949.1 7,169.4 86,118.6 650.6 650.6 86,769.2 "
+            "43,564.27 199.2\n"
+            "Total 122,625.9 49,121.0 171,746.9 4,232.7 924.5 5,157.3 "
+            "176,904.2 601,689.14 29\n"
+        )
+
+        fake_pdf = MagicMock()
+        fake_pdf.pages = [cover_page] * 3 + [decoy_page, table_page]
+        fake_pdf.__enter__ = lambda s: fake_pdf
+        fake_pdf.__exit__ = lambda *a: None
+
+        with patch.object(bp.pdfplumber, "open", return_value=fake_pdf):
+            result = bp.parse_brop_pdf(tmp_path / "fake.pdf")
+
+        # Decoy Nairobi (total=410M) ignored; real Nairobi (total=86,769.2M) kept.
+        assert len(result.counties) == 1
+        assert result.counties[0].total == Decimal("86769200000")
+
+    def test_raises_when_neither_section_matches(self, tmp_path):
+        cover_page = MagicMock()
+        cover_page.extract_text.return_value = (
+            "2025 BUDGET REVIEW AND OUTLOOK PAPER"
+        )
+        empty_page = MagicMock()
+        empty_page.extract_text.return_value = "no useful content"
+
+        fake_pdf = MagicMock()
+        fake_pdf.pages = [cover_page] * 3 + [empty_page]
+        fake_pdf.__enter__ = lambda s: fake_pdf
+        fake_pdf.__exit__ = lambda *a: None
+
+        with patch.object(bp.pdfplumber, "open", return_value=fake_pdf):
+            with pytest.raises(ValueError, match="No pending-bills data"):
+                bp.parse_brop_pdf(tmp_path / "fake.pdf")


### PR DESCRIPTION
## Summary

The `pending_bills` domain was structurally broken: it downloaded the COB **National Government** BIRR but ran it through `CoBQuarterlyReportParser` (anchored on the 47-county invariant of the **Consolidated County** BIRR — wrong document), with a fallback formula `pending = allocated - absorbed` that's a non-sequitur (that's unspent budget, not unpaid obligations).

I confirmed in [a separate investigation](https://github.com/Rodgers31/audit_app/pull/79#issuecomment) that the NG-BIRR has zero pending-bills tables — its TOC has no entry, and the four pages that mention the phrase use it incidentally inside Annex II Article-223 emergency-exchequer justifications.

This replaces both pieces with the **National Treasury Budget Review and Outlook Paper (BROP)**, published every September.

## Two targets in BROP

- **Paragraph 18** — narrative aggregate: total National Government pending bills, broken into State Corporations + MDAs. FY 2024/25: KSh 525.9 B = 404.3 B SOEs + 121.6 B MDAs.
- **Table 10** — 47-county breakdown with `County Executive {Recurrent, Development, Sub-Total}` + `County Assembly {Recurrent, Development, Sub-Total}` + `Total` + `FY Budget` + `%`.

## Parser approach

[backend/seeding/domains/pending_bills/brop_parser.py](backend/seeding/domains/pending_bills/brop_parser.py)

- **Text-mode line parsing** — pdfplumber's `extract_tables()` returns 30+ misaligned columns on the Table 10 layout. Text mode gives clean per-county lines parseable with regex.
- **Title anchor** — only start parsing county rows after the literal `Table 10: County Governments Pending Bills` title. Prevents picking up an earlier county-numbered table on page 23 that would otherwise match the same row regex.
- **County name recovery** for tricky cases:
  - Murang'a (apostrophe): both sides normalise apostrophes → match.
  - Tharaka Nithi / Elgeyo Marakwet: pdfplumber drops the second line of wrapped names ("Tharaka- " then nothing). Prefix-match against `KENYAN_COUNTIES` recovers when the prefix is unambiguous.
  - Trans Nzoia (multi-word): regex captures `[A-Za-z\s\-']+?` non-greedy then anchors on numbers.

## Smoke test (September 2025 BROP, FY 2024/25)

- National para extracted: total **525.9 B**, SOEs **404.3 B**, MDAs **121.6 B**, as-at date `2025-06-30`.
- 46 of 47 counties extracted (Narok skipped — its row carries no data, yellow-highlighted in the PDF as "did not submit pending bills data").
- Sum of county totals: **KSh 176.905 B** (matches PDF Total row **176.904 B** exactly).
- Top counties: Nairobi 86.769 B, Kilifi 9.256 B, Kiambu 7.888 B, Machakos 6.734 B.
- Through-fetcher integration: 48 pending_bills records (2 national aggregates + 46 counties), parsed cleanly by `parse_pending_bills_payload`.

## Caveats (called out in code docstring)

- **Annual cadence** (October). For fresher county-side data the COB **Consolidated County BIRR** (tri-annual) is a sensible follow-up overlay — it has per-county × per-entity (Executive/Assembly) × per-ageing-bucket detail, and reuses PR #78's WPDM discovery helper.
- **National side is sparse** — BROP only publishes the SOE-vs-MDA two-line split, not per-MDA. Per-MDA pending bills require OAG audit OCR (out of scope).

## Config

New `treasury_brop_url` setting in [backend/seeding/config.py](backend/seeding/config.py), defaults to the FY 2024/25 PDF URL. Production users update `SEED_TREASURY_BROP_URL` when the next BROP drops. Auto-discovery from the Treasury landing page is a follow-up.

## Test plan

- [x] `pytest tests/test_pending_bills_brop_parser.py` — 27 new tests covering number parsing (KSh billion + million scales, dash sentinel), county normalisation (apostrophe, hyphen, prefix-match for wrapped names), national-paragraph extraction, county-row regex (full row, dashes, multi-word, apostrophe), dehyphenation, end-to-end parser via stubbed pdfplumber, title-anchored county-table extraction, raise-on-empty-PDF.
- [x] Full unit suite: **479 passed, 1 skipped** (was 447 before — +27 new + a few collected test re-counts).
- [x] End-to-end smoke against the actual September 2025 BROP PDF: 48 pending_bills records emitted, county sum matches PDF Total exactly.
- [ ] Re-trigger the Actions seed workflow after merge — verify the `pending_bills` warning disappears and `items_processed` reflects 48 (2 national + 46 county) rather than fixture's 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)