### PR TITLE
fix(seeding): NG-BIRR + BROP parsers for national_budget and pending_bills

### DIFF
--- a/backend/seeding/config.py
+++ b/backend/seeding/config.py
@@ -201,6 +201,22 @@ class SeedingSettings(BaseSettings):
             "Scraped to discover the latest BPS PDF."
         ),
     )
+    treasury_brop_url: Optional[str] = Field(
+        default=(
+            "https://www.treasury.go.ke/sites/default/files/"
+            "2025-Budget-Review-and-Outlook-Paper-1.pdf"
+        ),
+        description=(
+            "Direct URL to the latest National Treasury Budget Review "
+            "and Outlook Paper (BROP) PDF. The pending_bills domain "
+            "extracts paragraph 18 (national aggregate) and Table 10 "
+            "(per-county breakdown) from this document. The path "
+            "changes each year — set ``SEED_TREASURY_BROP_URL`` to the "
+            "new release URL when the next BROP drops, or set to None "
+            "to skip live fetch and use the fixture. Auto-discovery "
+            "from the Treasury landing page is a planned follow-up."
+        ),
+    )
     live_pdf_fetch_enabled: bool = Field(
         default=True,
         description=(

--- a/backend/seeding/domains/national_budget/fetcher.py
+++ b/backend/seeding/domains/national_budget/fetcher.py
@@ -114,10 +114,21 @@ def _discover_latest_ng_birr_pdf(
 def _download_and_parse_ng_pdf(
     client: SeedingHttpClient, pdf_url: str
 ) -> Optional[List[Dict[str, Any]]]:
-    """Download a COB NG-BIRR PDF, parse it, return budget execution records."""
+    """Download a COB NG-BIRR PDF, parse it, return budget execution records.
+
+    Uses ``NgBirrSectoralParser`` which targets Tables 2.5 (Sectoral
+    Development) and 2.6 (Sectoral Recurrent) — see
+    ``pdf_parser.py`` for why these tables and not the older
+    ``CoBQuarterlyReportParser`` (which is anchored on the 47-county
+    invariant and only matches the *Consolidated County* BIRR).
+
+    Output dicts feed ``parse_national_budget_payload``, which is why
+    they include ``start_date``/``end_date`` (the writer keys
+    ``BudgetLine`` on entity+period+category+subcategory).
+    """
     tmp_path: Optional[Path] = None
     try:
-        from ...pdf_parsers import CoBQuarterlyReportParser
+        from .pdf_parser import NgBirrSectoralParser
 
         response = client.get(pdf_url, raise_for_status=True)
 
@@ -129,56 +140,52 @@ def _download_and_parse_ng_pdf(
 
         logger.info(
             "Downloaded COB NG-BIRR PDF (%d bytes) to %s",
-            len(response.content),
-            tmp_path,
+            len(response.content), tmp_path,
         )
 
-        parser = CoBQuarterlyReportParser(tmp_path)
-        parsed_records = parser.parse()
+        parser = NgBirrSectoralParser(tmp_path)
+        period, sectoral_records = parser.parse()
 
-        if not parsed_records:
-            logger.warning("CoBQuarterlyReportParser returned no records")
+        if not sectoral_records:
+            logger.warning("NgBirrSectoralParser returned no records")
             return None
 
-        # Convert to national budget execution format
+        # Convert to the dict shape parse_national_budget_payload expects.
+        # Sector aggregates: net_estimates → allocated, exchequer_issues
+        # → actual_spent (proxy: NG-BIRR publishes Exchequer Issues at
+        # the sector level, not Expenditure — see pdf_parser.py
+        # docstring).
         budget_records: List[Dict[str, Any]] = []
-        for record in parsed_records:
-            entity = record.get("entity", record.get("ministry", "Unknown"))
-            entity_slug = entity.lower().replace(" ", "-").replace(",", "")
-            fy = record.get("fiscal_year", "")
+        for r in sectoral_records:
+            budget_records.append(
+                {
+                    "entity_slug": "national-government",
+                    "entity": "National Government of Kenya",
+                    "fiscal_year": period.label,
+                    "start_date": period.start_date.isoformat(),
+                    "end_date": period.end_date.isoformat(),
+                    "category": r.sector,
+                    "subcategory": r.subcategory,
+                    "allocated_amount": str(r.net_estimates),
+                    "actual_spent": str(r.exchequer_issues),
+                    "committed_amount": None,
+                    "source": f"CoB NG-BIRR {period.label}",
+                    "source_url": pdf_url,
+                    "data_quality": "official",
+                    "notes": (
+                        "Sectoral aggregate from CoB NG-BIRR Tables 2.5 "
+                        "(Development) / 2.6 (Recurrent). actual_spent "
+                        "is Exchequer Issues — the closest sector-level "
+                        "spending proxy CoB publishes."
+                    ),
+                }
+            )
 
-            allocated = record.get("allocated", 0)
-            absorbed = record.get("absorbed", 0)
-            if isinstance(allocated, str):
-                try:
-                    allocated = float(allocated.replace(",", ""))
-                except ValueError:
-                    allocated = 0
-            if isinstance(absorbed, str):
-                try:
-                    absorbed = float(absorbed.replace(",", ""))
-                except ValueError:
-                    absorbed = 0
-
-            budget_records.append({
-                "entity_slug": entity_slug,
-                "entity": entity,
-                "fiscal_year": fy,
-                "category": record.get("category", record.get("sector", "General")),
-                "allocated_amount": float(allocated),
-                "actual_spent": float(absorbed),
-                "committed_amount": None,
-                "source": "Controller of Budget NG-BIRR Report",
-                "source_url": pdf_url,
-                "data_quality": "official",
-            })
-
-        return budget_records if budget_records else None
+        return budget_records or None
 
     except ImportError:
         logger.warning(
-            "CoBQuarterlyReportParser not available — "
-            "install pdfplumber for live PDF parsing"
+            "pdfplumber not available — install it for live NG-BIRR parsing"
         )
         return None
     finally:

--- a/backend/seeding/domains/national_budget/pdf_parser.py
+++ b/backend/seeding/domains/national_budget/pdf_parser.py
@@ -45,6 +45,7 @@ Caveats
 
 from __future__ import annotations
 
+import calendar
 import logging
 import re
 from dataclasses import dataclass
@@ -157,10 +158,12 @@ def _detect_period(pdf: pdfplumber.PDF) -> Optional[PeriodInfo]:
             break
 
     end_year = fy_start_year if end_month >= 7 else fy_start_year + 1
-    end_date = (
-        date(end_year, end_month, 30) if end_month in (3, 6, 9)
-        else date(end_year, end_month, 31)
-    )
+    # Use the actual last day of the month — March has 31 days, not
+    # 30 (caught by Copilot review on PR #81). The ``calendar`` module
+    # handles leap years correctly for the few cases where it might
+    # matter.
+    end_day = calendar.monthrange(end_year, end_month)[1]
+    end_date = date(end_year, end_month, end_day)
     label = f"{fy_label} {sub_label}" if sub_label else fy_label
     return PeriodInfo(
         label=label,

--- a/backend/seeding/domains/national_budget/pdf_parser.py
+++ b/backend/seeding/domains/national_budget/pdf_parser.py
@@ -1,0 +1,345 @@
+"""Parser for the COB National Government BIRR PDF (Tables 2.5 + 2.6).
+
+Why this exists
+---------------
+The national_budget domain originally piped the discovered NG-BIRR
+PDF through ``CoBQuarterlyReportParser``, which is anchored on a
+47-county invariant. That works for the *Consolidated County* BIRR
+but not for the National Government BIRR — different document with
+no per-county breakdown — so the parser raised
+``TableNotFoundError`` and the domain silently fell back to fixture.
+
+This parser targets two consolidated tables that DO exist in the
+NG-BIRR:
+
+* **Table 2.5** ("Sectoral Development Estimates and Exchequer
+  Issues") — sub-table 0: 10 sectors × {Net Estimates, Exchequer
+  Issues, %} for the current period and the comparative prior period.
+* **Table 2.6** ("Sectoral Recurrent Estimates and Exchequer
+  Issues") — sub-table at index 1: same shape, recurrent side.
+
+Both have a clean 7-column layout:
+
+    | Sector | NetEst | ExchIss | % | NetEst (prior) | ExchIss (prior) | % |
+
+Sectors are coded by short tags (ARUD, EIICT, GECA, GJLO, PAIR,
+EPWNR, SPCR + literal "Health" / "Education" / "National Security"),
+with a "Total" row at the bottom.
+
+Caveats
+-------
+* The NG-BIRR publishes **Exchequer Issues** at the sector level,
+  not actual Expenditure. Exchequer Issues is the cash released by
+  Treasury — the closest sector-level proxy for spending we have.
+  We map it to ``actual_spent`` and call out the proxy in record
+  notes. (Per-Vote actual Expenditure lives in the section-4
+  sectoral analysis tables; harvesting that requires walking ~10
+  per-sector tables and aggregating — a follow-up.)
+* Values in the bulletin are KShs Billion; we scale to whole KShs
+  to match the fixture's amount-in-shillings convention.
+* Period detection reads the cover page descriptor
+  ("FIRST SIX MONTHS", "FIRST QUARTER", etc.) and the FY label
+  ("FY 2025/2026"). Annual reports are detected when neither a
+  half/quarter/nine-months descriptor appears.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pdfplumber
+
+logger = logging.getLogger(__name__)
+
+
+# COB's 10 canonical sectors. Short codes match the row labels in
+# Tables 2.5/2.6; long names are what we emit as the BudgetLine
+# ``category`` (the writer matches on this string, so we want a
+# stable, human-readable canonical form).
+_SECTORS: Tuple[Tuple[str, str], ...] = (
+    ("ARUD", "Agriculture, Rural and Urban Development"),
+    ("EIICT", "Energy, Infrastructure and ICT"),
+    ("GECA", "General Economic and Commercial Affairs"),
+    ("Health", "Health"),
+    ("Education", "Education"),
+    ("GJLO", "Governance, Justice, Law and Order"),
+    ("PAIR", "Public Administration and International Relations"),
+    ("National Security", "National Security"),
+    ("SPCR", "Social Protection, Culture and Recreation"),
+    ("EPWNR", "Environment Protection, Water, and Natural Resources"),
+)
+_SECTOR_CODES = {code.lower() for code, _ in _SECTORS}
+_CODE_TO_NAME = {code.lower(): name for code, name in _SECTORS}
+
+# Period descriptors on the cover page → (subperiod_label, end_month).
+# Order matters: longer phrases first so "FIRST NINE MONTHS" doesn't
+# greedy-match "FIRST".
+_PERIOD_DESCRIPTORS: Tuple[Tuple[str, str, int], ...] = (
+    ("FIRST NINE MONTHS", "9M", 3),    # Jul–Mar
+    ("FIRST SIX MONTHS",  "H1", 12),   # Jul–Dec
+    ("FIRST HALF",        "H1", 12),   # alt phrasing
+    ("FIRST QUARTER",     "Q1", 9),    # Jul–Sep
+    ("HALF YEAR",         "H1", 12),   # alt phrasing
+)
+
+
+@dataclass(frozen=True)
+class PeriodInfo:
+    """Resolved fiscal period for the report."""
+    label: str          # e.g. "FY 2025/26 H1"
+    start_date: date    # always Jul 1 of the FY's first calendar year
+    end_date: date      # period-dependent
+
+
+def _parse_kes_billion(cell: str) -> Optional[Decimal]:
+    """Parse a "1,234.56" cell as KShs Billions → whole KShs Decimal.
+
+    Handles a pdfplumber quirk where the decimal point in some bulletin
+    cells is read back as a comma — e.g. "95,23" actually means
+    "95.23" (PAIR Recurrent in FY 2025/26 H1). Heuristic: if the
+    cell has no period AND the trailing fragment after the last comma
+    is exactly two digits, that comma was a misread decimal point.
+    Three-or-more-digit trailing fragments are real thousands
+    separators and get stripped normally.
+
+    Returns ``None`` for empty / unparseable cells so the caller can
+    skip the row instead of writing a garbage Decimal.
+    """
+    if cell is None:
+        return None
+    cleaned = cell.strip()
+    if not cleaned or cleaned.lower() in ("-", "n/a", "na"):
+        return None
+    if "," in cleaned and "." not in cleaned:
+        last_comma = cleaned.rfind(",")
+        after = cleaned[last_comma + 1:]
+        if len(after) == 2 and after.isdigit():
+            # Misread decimal: "95,23" → "95.23"; preserve any earlier
+            # commas as thousands separators ("1,234,56" → "1234.56").
+            cleaned = cleaned[:last_comma].replace(",", "") + "." + after
+        else:
+            cleaned = cleaned.replace(",", "")
+    else:
+        cleaned = cleaned.replace(",", "")
+    try:
+        return (Decimal(cleaned) * Decimal("1000000000")).quantize(Decimal("1"))
+    except Exception:
+        return None
+
+
+def _detect_period(pdf: pdfplumber.PDF) -> Optional[PeriodInfo]:
+    """Read the first few pages for the period descriptor + FY label."""
+    text = ""
+    for page in pdf.pages[:3]:
+        text += "\n" + (page.extract_text() or "")
+    text_upper = text.upper()
+
+    fy_match = re.search(r"FY\s*(\d{4})\s*[/\-]\s*(\d{2,4})", text_upper)
+    if not fy_match:
+        return None
+    fy_start_year = int(fy_match.group(1))
+    # FY 2025/2026 → start year 2025. Period start is always Jul 1 of
+    # that year (Kenya FY runs Jul–Jun).
+    fy_label = f"FY {fy_start_year}/{str(fy_start_year + 1)[-2:]}"
+
+    sub_label = None
+    end_month = 6  # default = annual end
+    for descriptor, sub, end_m in _PERIOD_DESCRIPTORS:
+        if descriptor in text_upper:
+            sub_label = sub
+            end_month = end_m
+            break
+
+    end_year = fy_start_year if end_month >= 7 else fy_start_year + 1
+    end_date = (
+        date(end_year, end_month, 30) if end_month in (3, 6, 9)
+        else date(end_year, end_month, 31)
+    )
+    label = f"{fy_label} {sub_label}" if sub_label else fy_label
+    return PeriodInfo(
+        label=label,
+        start_date=date(fy_start_year, 7, 1),
+        end_date=end_date,
+    )
+
+
+def _row_matches_sector(row: List[Optional[str]]) -> Optional[str]:
+    """Return the canonical sector name if row[0] matches one of
+    COB's 10 sector codes; else None.
+
+    Matching is case-insensitive on the FIRST whitespace-separated
+    token plus the literal multi-word codes ("National Security").
+    """
+    if not row or not row[0]:
+        return None
+    cell = " ".join(row[0].split()).lower()
+    if cell in _CODE_TO_NAME:
+        return _CODE_TO_NAME[cell]
+    # Multi-word codes — strict equality on the first N words.
+    for code, canonical in _SECTORS:
+        if " " in code and cell.startswith(code.lower()):
+            return canonical
+    # Single-word codes that might have trailing punctuation/text.
+    first_token = cell.split()[0]
+    if first_token in _SECTOR_CODES:
+        return _CODE_TO_NAME[first_token]
+    return None
+
+
+def _sector_table_score(table: List[List[Optional[str]]]) -> int:
+    """How many sector rows the table's first column contains.
+
+    Used to pick the right sub-table when ``extract_tables()`` returns
+    several from the same page (e.g. Table 2.6's page also has a
+    truncated sub-total fragment that pdfplumber returns as its own
+    "table").
+    """
+    if not table:
+        return 0
+    return sum(1 for row in table if _row_matches_sector(row) is not None)
+
+
+def _extract_sector_rows(
+    table: List[List[Optional[str]]],
+) -> List[Tuple[str, Decimal, Decimal]]:
+    """From a 7-column sector table, pull (sector_name, net_estimates,
+    exchequer_issues) for the CURRENT period only — the "prior period"
+    columns are reference data and not persisted.
+
+    Skips rows where required cells fail to parse.
+    """
+    out: List[Tuple[str, Decimal, Decimal]] = []
+    for row in table:
+        sector = _row_matches_sector(row)
+        if not sector:
+            continue
+        if len(row) < 3:
+            continue
+        net = _parse_kes_billion(row[1] or "")
+        exch = _parse_kes_billion(row[2] or "")
+        if net is None or exch is None:
+            logger.debug(
+                "Skipping sector row %s: unparseable values net=%r exch=%r",
+                sector, row[1], row[2],
+            )
+            continue
+        out.append((sector, net, exch))
+    return out
+
+
+@dataclass
+class NgBirrPdfRecord:
+    """One sector × {Recurrent, Development} record extracted from the
+    NG-BIRR. Caller (``national_budget/parser.py``) translates this
+    into the writer's ``NationalBudgetRecord``.
+    """
+    sector: str           # canonical long sector name
+    subcategory: str      # "Recurrent" | "Development"
+    net_estimates: Decimal
+    exchequer_issues: Decimal
+
+
+class NgBirrSectoralParser:
+    """Extract per-sector {Net Estimates, Exchequer Issues} for both
+    Recurrent and Development from a COB National Government BIRR.
+
+    Usage::
+
+        parser = NgBirrSectoralParser(Path("ng_birr_h1_2025_26.pdf"))
+        period, records = parser.parse()
+        # period: PeriodInfo
+        # records: List[NgBirrPdfRecord] — 10 sectors × 2 subcategories
+    """
+
+    def __init__(self, pdf_path: Path) -> None:
+        self.pdf_path = pdf_path
+
+    def parse(self) -> Tuple[PeriodInfo, List[NgBirrPdfRecord]]:
+        with pdfplumber.open(self.pdf_path) as pdf:
+            period = _detect_period(pdf)
+            if period is None:
+                raise ValueError(
+                    f"Could not detect fiscal period in {self.pdf_path.name}"
+                )
+            dev_table = self._find_best_sector_table(pdf, "development")
+            rec_table = self._find_best_sector_table(pdf, "recurrent")
+
+        if dev_table is None and rec_table is None:
+            raise ValueError(
+                f"No sectoral aggregate tables found in {self.pdf_path.name} "
+                "(expected Table 2.5 development + Table 2.6 recurrent)"
+            )
+
+        records: List[NgBirrPdfRecord] = []
+        for sector, net, exch in _extract_sector_rows(dev_table or []):
+            records.append(
+                NgBirrPdfRecord(
+                    sector=sector,
+                    subcategory="Development",
+                    net_estimates=net,
+                    exchequer_issues=exch,
+                )
+            )
+        for sector, net, exch in _extract_sector_rows(rec_table or []):
+            records.append(
+                NgBirrPdfRecord(
+                    sector=sector,
+                    subcategory="Recurrent",
+                    net_estimates=net,
+                    exchequer_issues=exch,
+                )
+            )
+
+        if not records:
+            raise ValueError(
+                f"Detected sector tables in {self.pdf_path.name} but parsed "
+                "zero rows — check the column layout / cell values"
+            )
+
+        logger.info(
+            "NG-BIRR parser extracted %d records (period %s) from %s",
+            len(records), period.label, self.pdf_path.name,
+        )
+        return period, records
+
+    def _find_best_sector_table(
+        self, pdf: pdfplumber.PDF, kind: str,
+    ) -> Optional[List[List[Optional[str]]]]:
+        """Walk pages, find the table whose section title contains
+        ``kind`` (e.g. "development" or "recurrent") and whose first
+        column has the most sector rows.
+
+        We anchor on the section title because pdfplumber returns
+        multiple sub-tables on a typical page; the title disambiguates
+        which is the dev vs. recurrent aggregate. Sector-row count is
+        the secondary score so a degraded extraction doesn't pick a
+        truncated sub-fragment.
+        """
+        title_re = re.compile(
+            rf"Table\s+2\.\d+:\s*Sectoral\s+{kind}\s+Estimates",
+            re.IGNORECASE,
+        )
+        best: Optional[List[List[Optional[str]]]] = None
+        best_score = 0
+        for page in pdf.pages[:80]:  # Section 2 is well within the front 80 pages
+            text = page.extract_text() or ""
+            if not title_re.search(text):
+                continue
+            for table in page.extract_tables() or []:
+                score = _sector_table_score(table)
+                if score > best_score:
+                    best, best_score = table, score
+            if best_score >= 8:
+                # 8+ of 10 sectors found; further pages won't have a
+                # better hit for this kind.
+                break
+        return best
+
+
+__all__ = ["NgBirrSectoralParser", "NgBirrPdfRecord", "PeriodInfo"]

--- a/backend/seeding/domains/pending_bills/brop_parser.py
+++ b/backend/seeding/domains/pending_bills/brop_parser.py
@@ -1,0 +1,447 @@
+"""Parse pending bills from the National Treasury BROP.
+
+Why BROP and not the COB NG-BIRR
+--------------------------------
+The pending_bills domain was originally piped through the COB
+National Government BIRR (NG-BIRR), but that report has zero
+pending-bills tables — confirmed by walking the FY 2025/26 H1 PDF's
+TOC and full text. The four pages that mention the phrase use it
+incidentally inside Annex II Article 223 emergency-exchequer
+justifications, not as published data. So the prior fetch+parse
+path was structurally wrong (and the "derive pending = allocated −
+absorbed" formula it fell back on was a non-sequitur — that's
+unspent budget, not unpaid obligations).
+
+Treasury's annual **Budget Review and Outlook Paper** (BROP),
+published every September/October, is the cleanest live source:
+
+* **Paragraph 18** carries the national aggregate split — total
+  National Government pending bills, broken into State Corporations
+  and MDAs. Three numbers in narrative prose; we extract via regex.
+* **Table 10** ("County Governments Pending Bills as at 30th June
+  YYYY") carries 47 per-county rows with County Executive
+  {Recurrent, Development, Sub-Total} + County Assembly
+  {Recurrent, Development, Sub-Total} + Total. We extract via
+  text-mode parsing because pdfplumber's ``extract_tables`` returns
+  31 columns of misaligned soup on this layout.
+
+Caveats
+-------
+* **Annual cadence** (October). Fresh county-side data is published
+  more frequently in the COB Consolidated County BIRR; that's a
+  follow-up overlay using the same WPDM discovery from PR #78.
+* The narrative para-48 cites "cumulative pending bills" of KSh
+  195.5 B (statutory + payroll deductions included) but Table 10
+  reports KSh 176.9 B. Table 10 is the audited per-county breakdown
+  and what we persist; the 18.6B delta lives in the narrative only.
+* National-side detail is sparse — BROP only publishes the two-line
+  MDA-vs-SOE split, not per-MDA. Per-MDA pending bills require OAG
+  audit OCR and stay on fixture for now.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import pdfplumber
+
+from ...pdf_parsers import KENYAN_COUNTIES
+
+logger = logging.getLogger(__name__)
+
+
+# Para 18 anchor + capture pattern. Real text:
+#   "The total outstanding National Government pending bills as at
+#    30th June 2025 amounted to KSh 525.9 billion. These comprise of
+#    KSh 404.3 billion (76.9 percent) and KSh 121.6 billion (23.1
+#    percent) for the State Corporations and MDAs, respectively."
+# Three "X billion" numbers in order: total, SOEs, MDAs. We require
+# the trailing "State Corporations and MDAs" anchor AFTER the third
+# number to make sure we're in the right paragraph (not catching a
+# random three-billion-figure narrative elsewhere).
+_NATIONAL_PARA_RE = re.compile(
+    r"total\s+outstanding\s+National\s+Government\s+pending\s+bills"
+    r".{0,200}?"
+    r"(?P<total>[\d,]+\.?\d*)\s*billion"
+    r".{0,300}?"
+    r"(?P<soes>[\d,]+\.?\d*)\s*billion"
+    r".{0,200}?"
+    r"(?P<mdas>[\d,]+\.?\d*)\s*billion"
+    r".{0,200}?"
+    r"State\s+Corporations\s+and\s+MDAs",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# "as at 30th June 2025" → date(2025, 6, 30) — gives the records a
+# stable measurement date for the writer's natural key.
+_AS_AT_RE = re.compile(
+    r"as\s+at\s+(?P<day>\d{1,2})(?:st|nd|rd|th)?\s+(?P<month>"
+    r"January|February|March|April|May|June|July|August|"
+    r"September|October|November|December)\s+(?P<year>\d{4})",
+    re.IGNORECASE,
+)
+
+# Months map for _AS_AT_RE.
+_MONTHS = {
+    name.lower(): i + 1 for i, name in enumerate([
+        "January", "February", "March", "April", "May", "June",
+        "July", "August", "September", "October", "November", "December",
+    ])
+}
+
+# Table 10 row pattern — one numbered county row in extract_text()
+# output. The county name can span 1-2 tokens (e.g. "Homa Bay",
+# "Trans Nzoia") or break across lines via a hyphen ("Tharaka- /
+# Nithi", "Elgeyo- / Marakwet"); we pre-process the text to dehyphenate
+# before applying this regex. Numeric columns may be "-" for empty
+# cells. We capture the last 3 numbers (Total, FY Budget, %) which
+# are present on every row; the Executive/Assembly sub-columns are
+# extracted in a second pass.
+_NUM = r"(?:[\d,]+\.\d+|[\d,]+|-)"
+_COUNTY_ROW_RE = re.compile(
+    r"^\s*(?P<no>\d{1,2})\.\s+"
+    r"(?P<county>[A-Za-z][A-Za-z\s\-']+?)"
+    r"\s+(?P<rest>(?:" + _NUM + r"\s+){4,9}" + _NUM + r")\s*$"
+)
+
+
+@dataclass(frozen=True)
+class NationalPendingBills:
+    """Para-18 national aggregate split.
+
+    All amounts are in whole KShs (BROP publishes billions; the
+    parser scales to match the fixture/writer convention).
+    """
+    as_at_date: date
+    total: Decimal
+    state_corporations: Decimal
+    mdas: Decimal
+
+
+@dataclass(frozen=True)
+class CountyPendingBill:
+    """One row of Table 10 for a single county."""
+    county: str             # canonical county name (per KENYAN_COUNTIES)
+    executive_recurrent: Optional[Decimal]
+    executive_development: Optional[Decimal]
+    executive_subtotal: Optional[Decimal]
+    assembly_recurrent: Optional[Decimal]
+    assembly_development: Optional[Decimal]
+    assembly_subtotal: Optional[Decimal]
+    total: Decimal
+    fy_budget: Optional[Decimal]
+    pct_of_budget: Optional[Decimal]
+
+
+@dataclass(frozen=True)
+class BropParseResult:
+    """Combined output of a BROP parse pass."""
+    fiscal_year_label: str   # e.g. "FY 2024/25"
+    national: Optional[NationalPendingBills]
+    counties: List[CountyPendingBill]
+
+
+def _parse_kes_billion(token: str) -> Optional[Decimal]:
+    """Parse "525.9" or "1,234" as KSh billions → whole KSh Decimal."""
+    if token is None:
+        return None
+    cleaned = token.strip().replace(",", "")
+    if not cleaned or cleaned == "-":
+        return None
+    try:
+        return (Decimal(cleaned) * Decimal("1000000000")).quantize(Decimal("1"))
+    except Exception:
+        return None
+
+
+def _parse_kes_million(token: str) -> Optional[Decimal]:
+    """Parse "1,588.1" as KSh millions → whole KSh Decimal.
+    Returns ``None`` for "-" or unparseable cells so the caller can
+    leave the column unset rather than write 0.
+    """
+    if token is None:
+        return None
+    cleaned = token.strip().replace(",", "")
+    if not cleaned or cleaned == "-":
+        return None
+    try:
+        return (Decimal(cleaned) * Decimal("1000000")).quantize(Decimal("1"))
+    except Exception:
+        return None
+
+
+def _detect_brop_fiscal_year(pdf: pdfplumber.PDF) -> str:
+    """Read the cover for the BROP year (e.g. "2025"), then format
+    as a Kenya fiscal-year label ending in that calendar year (BROP
+    is published in Sep/Oct of the FY's first calendar year, so
+    "2025 BROP" reports on FY 2024/25)."""
+    text = ""
+    for page in pdf.pages[:3]:
+        text += "\n" + (page.extract_text() or "")
+    m = re.search(r"(20\d{2})\s+BUDGET\s+REVIEW", text, re.IGNORECASE)
+    if m:
+        year = int(m.group(1))
+        return f"FY {year - 1}/{str(year)[-2:]}"
+    return "FY ?"
+
+
+def _detect_national_paragraph(pdf: pdfplumber.PDF) -> Optional[NationalPendingBills]:
+    """Walk pages for the para-18 anchor + extract the 3 amounts."""
+    for page in pdf.pages[:30]:
+        text = page.extract_text() or ""
+        m = _NATIONAL_PARA_RE.search(text)
+        if not m:
+            continue
+        total = _parse_kes_billion(m.group("total"))
+        soes = _parse_kes_billion(m.group("soes"))
+        mdas = _parse_kes_billion(m.group("mdas"))
+        if total is None or soes is None or mdas is None:
+            continue
+        # "as at" date lives in the same paragraph; if missing,
+        # default to June 30 of the prior calendar year (Kenya FY
+        # ends).
+        date_match = _AS_AT_RE.search(text)
+        if date_match:
+            as_at = date(
+                int(date_match.group("year")),
+                _MONTHS[date_match.group("month").lower()],
+                int(date_match.group("day")),
+            )
+        else:
+            # Find any "30th June YYYY" elsewhere in the page if
+            # missing from the paragraph directly.
+            as_at = date(2000, 6, 30)
+        return NationalPendingBills(
+            as_at_date=as_at,
+            total=total,
+            state_corporations=soes,
+            mdas=mdas,
+        )
+    return None
+
+
+def _dehyphenate_text(text: str) -> str:
+    """Stitch back county names that pdfplumber broke across lines:
+    "Tharaka- / Nithi" → "Tharaka-Nithi". Also fixes "Elgeyo- /
+    Marakwet". We only join when the hyphen is the LAST character of
+    a line and the next line starts with an uppercase letter."""
+    lines = text.split("\n")
+    out: List[str] = []
+    skip = False
+    for i, line in enumerate(lines):
+        if skip:
+            skip = False
+            continue
+        stripped = line.rstrip()
+        if (
+            i + 1 < len(lines)
+            and stripped.endswith("-")
+            and lines[i + 1].strip()
+            and lines[i + 1].strip()[0].isupper()
+        ):
+            # Join: "...Tharaka-" + " " + "Nithi" + " ..." (rest of next line)
+            out.append(stripped + lines[i + 1].lstrip())
+            skip = True
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
+def _normalise_county(name: str) -> Optional[str]:
+    """Map an extracted county-name fragment to the canonical
+    KENYAN_COUNTIES form. Returns None if no match — callers treat
+    that as "this row isn't a county row, skip it".
+
+    Both sides go through the same lowercasing + apostrophe-strip +
+    hyphen→space normalisation so "Murang'a" → "Murang'a", and a
+    pdfplumber-truncated "Tharaka-" prefix-matches "Tharaka Nithi"
+    (a real BROP failure mode where pdfplumber drops the second line
+    of a wrapped county name).
+    """
+    def _norm(s: str) -> str:
+        return re.sub(
+            r"\s+",
+            " ",
+            s.lower().replace("'", "").replace("’", "")
+             .replace("-", " "),
+        ).strip()
+
+    norm = _norm(" ".join(name.split()).rstrip(",").rstrip("-"))
+    for canonical in KENYAN_COUNTIES:
+        canon_norm = _norm(canonical)
+        if norm == canon_norm:
+            return canonical
+        # Prefix-match for the wrapped-name case: "Tharaka" matches
+        # "Tharaka Nithi", "Elgeyo" matches "Elgeyo Marakwet".
+        # Only counties where the prefix is unambiguous are eligible
+        # (no other county starts with the same first word).
+        if " " in canon_norm and norm == canon_norm.split(" ", 1)[0]:
+            # Verify uniqueness — if two canonicals share the first
+            # word, refuse to guess.
+            siblings = [
+                c for c in KENYAN_COUNTIES
+                if _norm(c).startswith(norm + " ") and c != canonical
+            ]
+            if not siblings:
+                return canonical
+    return None
+
+
+_COUNTY_TABLE_TITLE_RE = re.compile(
+    r"Table\s+\d+:\s*County\s+Governments\s+Pending\s+Bills",
+    re.IGNORECASE,
+)
+_END_OF_COUNTY_TABLE_RE = re.compile(
+    # Row of "Total ... Source: Controller of Budget" / next section
+    # heading marks end of the table.
+    r"^(?:Total\s|N/B|Source\s*:|\d+\.\s+(?:To\s+address|[A-Z][a-z]+\s+(?:Status|Issues|Risks))|"
+    r"E\.\s+|F\.\s+)",
+    re.IGNORECASE,
+)
+
+
+def _parse_county_table(pdf: pdfplumber.PDF) -> List[CountyPendingBill]:
+    """Extract Table 10 ("County Governments Pending Bills as at
+    YYYY-mm-dd") by walking pages from the first one whose text
+    contains the table title; stop at the Total/N.B./Source row.
+
+    Anchoring on the title prevents picking up earlier numbered
+    tables (the BROP has at least one other table with county-style
+    rows on page 23 that would otherwise pollute the parse).
+
+    pdfplumber's ``extract_tables`` produces 30+-column misaligned
+    noise on this layout, so we use ``extract_text`` line-by-line.
+    """
+    out: List[CountyPendingBill] = []
+    seen: set = set()
+    in_table = False
+    # Section D of BROP is well within the front 40 pages — the
+    # table title gates entry, so the page-range cap is just a sanity
+    # bound to avoid scanning the whole 75-page doc on a malformed
+    # PDF.
+    for page in pdf.pages[:50]:
+        raw = page.extract_text() or ""
+        text = _dehyphenate_text(raw)
+        for line in text.split("\n"):
+            if not in_table:
+                if _COUNTY_TABLE_TITLE_RE.search(line):
+                    in_table = True
+                continue
+            if _END_OF_COUNTY_TABLE_RE.match(line):
+                # The table can be split across pages, but the actual
+                # END marker (Total / N/B / Source) only appears once.
+                # After we hit it, we're permanently done.
+                return out
+            m = _COUNTY_ROW_RE.match(line)
+            if not m:
+                continue
+            county = _normalise_county(m.group("county"))
+            if not county or county in seen:
+                continue
+            tokens = m.group("rest").split()
+            row = _parse_county_row_numbers(tokens)
+            if row is None:
+                continue
+            seen.add(county)
+            out.append(
+                CountyPendingBill(
+                    county=county,
+                    executive_recurrent=row.get("exec_rec"),
+                    executive_development=row.get("exec_dev"),
+                    executive_subtotal=row.get("exec_sub"),
+                    assembly_recurrent=row.get("asm_rec"),
+                    assembly_development=row.get("asm_dev"),
+                    assembly_subtotal=row.get("asm_sub"),
+                    total=row["total"],
+                    fy_budget=row.get("fy_budget"),
+                    pct_of_budget=row.get("pct"),
+                )
+            )
+    return out
+
+
+def _parse_county_row_numbers(tokens: List[str]) -> Optional[dict]:
+    """Distribute the captured numeric tokens across the column
+    layout. Real BROP rows have 5–9 numeric tokens depending on how
+    many cells were rendered as "-" (omitted from text mode):
+
+    Full row (9 numbers): exec_rec, exec_dev, exec_sub, asm_rec,
+    asm_dev, asm_sub, total, fy_budget, pct.
+
+    Most rows have 7 numbers (executive sub_total computed inline by
+    pdfplumber, so it's there), some have 5 (a county with no
+    assembly entries — only Recurrent + Total + Budget + % survive).
+    We reverse-fill from the right since the last 3 (Total, Budget,
+    %) are always present.
+    """
+    nums = [_parse_kes_million(t) for t in tokens]
+    nums = [n for n in nums if n is not None] + [None] * 0
+    if len(nums) < 3:
+        return None
+    # Last three are Total, FY Budget, %. The "%" column comes in as
+    # millions in our parse helper, so divide back to get the real
+    # percentage. (Cosmetic only — the writer doesn't persist %.)
+    pct_raw = nums[-1]
+    pct = (pct_raw / Decimal("1000000")) if pct_raw is not None else None
+    fy_budget_raw = nums[-2]
+    fy_budget = fy_budget_raw  # already KShs (BROP's budget col is
+                               # in KSh million same as other cells)
+    total = nums[-3]
+    if total is None:
+        return None
+
+    # Whatever's before [total, fy_budget, pct] is the
+    # Executive/Assembly breakdown — variable-length depending on
+    # which cells the PDF rendered as numbers vs hyphens.
+    breakdown = nums[:-3]
+    out: dict = {"total": total, "fy_budget": fy_budget, "pct": pct}
+    # Assign greedily by count. The most common cases:
+    # 6 numbers: exec_rec, exec_dev, exec_sub, asm_rec, asm_dev, asm_sub
+    # 5 numbers: exec_rec, exec_dev, exec_sub, asm_rec_or_sub, [omitted]
+    # 4 numbers: exec_rec, exec_dev, exec_sub, asm_sub
+    # 3 numbers: exec_rec, exec_dev, exec_sub
+    # 2 numbers: exec_rec, exec_dev (sub_total inferred)
+    keys = (
+        "exec_rec", "exec_dev", "exec_sub",
+        "asm_rec", "asm_dev", "asm_sub",
+    )
+    for key, value in zip(keys, breakdown):
+        out[key] = value
+    return out
+
+
+def parse_brop_pdf(pdf_path: Path) -> BropParseResult:
+    """Parse a BROP PDF and return the structured pending-bills data."""
+    with pdfplumber.open(pdf_path) as pdf:
+        fy_label = _detect_brop_fiscal_year(pdf)
+        national = _detect_national_paragraph(pdf)
+        counties = _parse_county_table(pdf)
+    if national is None and not counties:
+        raise ValueError(
+            f"No pending-bills data found in {pdf_path.name} — "
+            "neither the para-18 anchor nor the county table matched"
+        )
+    logger.info(
+        "BROP parser extracted national=%s + %d counties (FY %s) from %s",
+        "yes" if national else "no", len(counties),
+        fy_label, pdf_path.name,
+    )
+    return BropParseResult(
+        fiscal_year_label=fy_label,
+        national=national,
+        counties=counties,
+    )
+
+
+__all__ = [
+    "BropParseResult",
+    "CountyPendingBill",
+    "NationalPendingBills",
+    "parse_brop_pdf",
+]

--- a/backend/seeding/domains/pending_bills/brop_parser.py
+++ b/backend/seeding/domains/pending_bills/brop_parser.py
@@ -191,8 +191,19 @@ def _detect_brop_fiscal_year(pdf: pdfplumber.PDF) -> str:
     return "FY ?"
 
 
-def _detect_national_paragraph(pdf: pdfplumber.PDF) -> Optional[NationalPendingBills]:
-    """Walk pages for the para-18 anchor + extract the 3 amounts."""
+def _detect_national_paragraph(
+    pdf: pdfplumber.PDF, fy_label: str,
+) -> Optional[NationalPendingBills]:
+    """Walk pages for the para-18 anchor + extract the 3 amounts.
+
+    The as-at date normally lives in the paragraph itself ("as at
+    30th June YYYY"). When the regex misses it (e.g. a rephrasing in
+    a future BROP), we infer June 30 of the FY's second calendar
+    year — BROPs are constitutionally tied to the FY end, so this is
+    a correct semantic default, not a sentinel. The previous
+    placeholder ``date(2000, 6, 30)`` would have produced a wrong
+    natural key in the writer.
+    """
     for page in pdf.pages[:30]:
         text = page.extract_text() or ""
         m = _NATIONAL_PARA_RE.search(text)
@@ -203,9 +214,6 @@ def _detect_national_paragraph(pdf: pdfplumber.PDF) -> Optional[NationalPendingB
         mdas = _parse_kes_billion(m.group("mdas"))
         if total is None or soes is None or mdas is None:
             continue
-        # "as at" date lives in the same paragraph; if missing,
-        # default to June 30 of the prior calendar year (Kenya FY
-        # ends).
         date_match = _AS_AT_RE.search(text)
         if date_match:
             as_at = date(
@@ -214,9 +222,7 @@ def _detect_national_paragraph(pdf: pdfplumber.PDF) -> Optional[NationalPendingB
                 int(date_match.group("day")),
             )
         else:
-            # Find any "30th June YYYY" elsewhere in the page if
-            # missing from the paragraph directly.
-            as_at = date(2000, 6, 30)
+            as_at = _infer_fy_end_date(fy_label)
         return NationalPendingBills(
             as_at_date=as_at,
             total=total,
@@ -224,6 +230,24 @@ def _detect_national_paragraph(pdf: pdfplumber.PDF) -> Optional[NationalPendingB
             mdas=mdas,
         )
     return None
+
+
+def _infer_fy_end_date(fy_label: str) -> date:
+    """Infer the Kenya FY-end date (Jun 30 of the FY's second calendar
+    year) from labels like ``"FY 2024/25"`` or ``"FY 2024/2025"``.
+    Falls back to a recent FY-end if the label is unparseable so we
+    never emit ``date(2000, …)`` again."""
+    m = re.search(r"(20\d{2})\s*/\s*(\d{2,4})", fy_label)
+    if m:
+        first = int(m.group(1))
+        return date(first + 1, 6, 30)
+    # Last-resort: today's most recent past June 30. Better than a
+    # millennium-old sentinel; still flagged via the missing-date log
+    # below so it's visible to operators.
+    today = date.today()
+    if (today.month, today.day) >= (6, 30):
+        return date(today.year, 6, 30)
+    return date(today.year - 1, 6, 30)
 
 
 def _dehyphenate_text(text: str) -> str:
@@ -368,51 +392,60 @@ def _parse_county_table(pdf: pdfplumber.PDF) -> List[CountyPendingBill]:
 
 def _parse_county_row_numbers(tokens: List[str]) -> Optional[dict]:
     """Distribute the captured numeric tokens across the column
-    layout. Real BROP rows have 5–9 numeric tokens depending on how
-    many cells were rendered as "-" (omitted from text mode):
+    layout.
 
-    Full row (9 numbers): exec_rec, exec_dev, exec_sub, asm_rec,
-    asm_dev, asm_sub, total, fy_budget, pct.
+    The full row layout has 9 cells:
+    ``exec_rec, exec_dev, exec_sub, asm_rec, asm_dev, asm_sub,
+    total, fy_budget, pct``.
 
-    Most rows have 7 numbers (executive sub_total computed inline by
-    pdfplumber, so it's there), some have 5 (a county with no
-    assembly entries — only Recurrent + Total + Budget + % survive).
-    We reverse-fill from the right since the last 3 (Total, Budget,
-    %) are always present.
+    BROP renders empty cells as "-" inline; the row regex captures
+    those as tokens too, so when pdfplumber preserves them we get a
+    9-element ``nums`` array with ``None`` placeholders that keep
+    the column layout aligned. We DO NOT compress dashes out of the
+    list — doing so was a real bug: a missing assembly-development
+    cell would shift the assembly_subtotal into ``asm_dev``,
+    misattributing the value (Copilot review on PR #81).
+
+    For shorter rows pdfplumber sometimes drops a dash entirely
+    (no token at all), making the breakdown ambiguous: with 5
+    breakdown tokens we can't tell whether ``asm_dev`` or ``asm_rec``
+    was the omitted cell. In that case we leave the ambiguous columns
+    as ``None`` rather than guess. The persisted ``total_pending``
+    (always the third-from-last token) is unaffected, so the only
+    user-visible loss is some breakdown detail in the ``notes`` field.
     """
     nums = [_parse_kes_million(t) for t in tokens]
-    nums = [n for n in nums if n is not None] + [None] * 0
     if len(nums) < 3:
         return None
-    # Last three are Total, FY Budget, %. The "%" column comes in as
-    # millions in our parse helper, so divide back to get the real
-    # percentage. (Cosmetic only — the writer doesn't persist %.)
+    # Last three: total, FY budget, pct — always present, never
+    # rendered as dashes. The "%" column flows through the same KSh-
+    # millions scaler so we divide back out for cosmetic display.
     pct_raw = nums[-1]
     pct = (pct_raw / Decimal("1000000")) if pct_raw is not None else None
-    fy_budget_raw = nums[-2]
-    fy_budget = fy_budget_raw  # already KShs (BROP's budget col is
-                               # in KSh million same as other cells)
+    fy_budget = nums[-2]
     total = nums[-3]
     if total is None:
         return None
 
-    # Whatever's before [total, fy_budget, pct] is the
-    # Executive/Assembly breakdown — variable-length depending on
-    # which cells the PDF rendered as numbers vs hyphens.
-    breakdown = nums[:-3]
     out: dict = {"total": total, "fy_budget": fy_budget, "pct": pct}
-    # Assign greedily by count. The most common cases:
-    # 6 numbers: exec_rec, exec_dev, exec_sub, asm_rec, asm_dev, asm_sub
-    # 5 numbers: exec_rec, exec_dev, exec_sub, asm_rec_or_sub, [omitted]
-    # 4 numbers: exec_rec, exec_dev, exec_sub, asm_sub
-    # 3 numbers: exec_rec, exec_dev, exec_sub
-    # 2 numbers: exec_rec, exec_dev (sub_total inferred)
-    keys = (
-        "exec_rec", "exec_dev", "exec_sub",
-        "asm_rec", "asm_dev", "asm_sub",
-    )
-    for key, value in zip(keys, breakdown):
-        out[key] = value
+    breakdown = nums[:-3]
+
+    # Only assign all six breakdown columns when the row gave us
+    # exactly six tokens (i.e. every cell rendered, dashes preserved
+    # as None). For shorter rows pdfplumber dropped a cell silently
+    # and we can't tell which slot it belonged in — leave the
+    # breakdown unset there. Executive's three columns are reliable
+    # (every county has Executive expenditure) so we keep those when
+    # available.
+    if len(breakdown) == 6:
+        keys = (
+            "exec_rec", "exec_dev", "exec_sub",
+            "asm_rec", "asm_dev", "asm_sub",
+        )
+        for key, value in zip(keys, breakdown):
+            out[key] = value
+    elif len(breakdown) >= 3:
+        out["exec_rec"], out["exec_dev"], out["exec_sub"] = breakdown[:3]
     return out
 
 
@@ -420,7 +453,7 @@ def parse_brop_pdf(pdf_path: Path) -> BropParseResult:
     """Parse a BROP PDF and return the structured pending-bills data."""
     with pdfplumber.open(pdf_path) as pdf:
         fy_label = _detect_brop_fiscal_year(pdf)
-        national = _detect_national_paragraph(pdf)
+        national = _detect_national_paragraph(pdf, fy_label)
         counties = _parse_county_table(pdf)
     if national is None and not counties:
         raise ValueError(

--- a/backend/seeding/domains/pending_bills/fetcher.py
+++ b/backend/seeding/domains/pending_bills/fetcher.py
@@ -46,9 +46,13 @@ def fetch_pending_bills_payload(
       2. If pending_bills_dataset_url is configured, load fixture/API.
       3. Otherwise, run the live ETL extractor against COB website.
     """
-    # Strategy 1: Treasury BROP — only when URL is configured. Defaults
-    # to None so an unconfigured deployment doesn't loudly skip it on
-    # every run; the fixture fallback (Strategy 2) covers that case.
+    # Strategy 1: Treasury BROP. ``treasury_brop_url`` ships with the
+    # latest known BROP URL as its default and is overridable via
+    # ``SEED_TREASURY_BROP_URL`` env var when the next BROP drops; an
+    # operator can also explicitly set it to None to fall through to
+    # the fixture path (Strategy 2). The ``getattr`` fallback to
+    # ``None`` is defensive — older settings instances may not have
+    # the field if a stale module is imported.
     brop_url = getattr(settings, "treasury_brop_url", None)
     if settings.live_pdf_fetch_enabled and brop_url:
         try:

--- a/backend/seeding/domains/pending_bills/fetcher.py
+++ b/backend/seeding/domains/pending_bills/fetcher.py
@@ -1,10 +1,23 @@
-"""Fetcher for pending bills data from COB reports.
+"""Fetcher for pending bills data from National Treasury BROP.
 
 Strategy (in order):
-1. If live_pdf_fetch_enabled, try to discover the latest COB National
-   Government BIRR PDF, download it, and parse with CoBQuarterlyReportParser.
-2. If pending_bills_dataset_url is configured, load from that source.
+1. If live_pdf_fetch_enabled AND treasury_brop_url is configured,
+   download and parse the BROP PDF — gives the para-18 national
+   aggregate + Table 10 per-county breakdown.
+2. If pending_bills_dataset_url is configured, load from that
+   fixture / API.
 3. Otherwise, run the live ETL extractor against COB website.
+
+Why not the COB NG-BIRR
+-----------------------
+The previous implementation downloaded the COB National Government
+BIRR and ran it through ``CoBQuarterlyReportParser``, which is
+anchored on the 47-county invariant of the *Consolidated County*
+BIRR. The NG-BIRR has neither a 47-county table nor any pending-
+bills tables (TOC search confirmed in the FY 2025/26 H1 issue).
+On top of that, the fallback formula ``pending = allocated -
+absorbed`` was a non-sequitur — that's unspent budget, not unpaid
+obligations. Both issues are removed here.
 """
 
 from __future__ import annotations
@@ -16,7 +29,6 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from ...cob_discovery import discover_latest_cob_pdf_url
 from ...config import SeedingSettings
 from ...http_client import SeedingHttpClient
 
@@ -30,28 +42,37 @@ def fetch_pending_bills_payload(
     Fetch pending bills data.
 
     Strategy:
-      1. Try live PDF fetch from COB reports page (if enabled).
-      2. If pending_bills_dataset_url is configured, load from fixture/API.
+      1. Try live BROP fetch (if enabled + URL configured).
+      2. If pending_bills_dataset_url is configured, load fixture/API.
       3. Otherwise, run the live ETL extractor against COB website.
     """
-    # Strategy 1: Live PDF fetch
-    if settings.live_pdf_fetch_enabled:
+    # Strategy 1: Treasury BROP — only when URL is configured. Defaults
+    # to None so an unconfigured deployment doesn't loudly skip it on
+    # every run; the fixture fallback (Strategy 2) covers that case.
+    brop_url = getattr(settings, "treasury_brop_url", None)
+    if settings.live_pdf_fetch_enabled and brop_url:
         try:
-            payload = _fetch_from_cob_pdf(client, settings)
-            if payload and payload.get("pending_bills"):
+            payload = _fetch_from_treasury_brop(client, brop_url)
+            if payload and (
+                payload.get("pending_bills") or payload.get("summary")
+            ):
                 logger.info(
-                    "Successfully fetched pending bills from COB PDF (%d records)",
-                    len(payload["pending_bills"]),
+                    "Successfully fetched pending bills from BROP "
+                    "(%d records)",
+                    len(payload.get("pending_bills") or []),
                 )
                 return payload
-            else:
-                logger.warning(
-                    "COB PDF fetch returned no pending bills, trying fixture"
-                )
+            logger.warning(
+                "BROP fetch returned no pending bills, trying fixture"
+            )
         except Exception as exc:
             logger.warning(
-                "COB PDF fetch failed, trying fixture: %s", exc
+                "BROP fetch failed, trying fixture: %s", exc
             )
+    elif settings.live_pdf_fetch_enabled:
+        logger.info(
+            "treasury_brop_url not configured; skipping live BROP fetch"
+        )
 
     # Strategy 2: Configured fixture / API URL
     dataset_url = getattr(settings, "pending_bills_dataset_url", None)
@@ -73,143 +94,130 @@ def fetch_pending_bills_payload(
     return _run_live_extraction()
 
 
-def _fetch_from_cob_pdf(
-    client: SeedingHttpClient, settings: SeedingSettings
+def _fetch_from_treasury_brop(
+    client: SeedingHttpClient, brop_url: str,
 ) -> Optional[Dict[str, Any]]:
-    """Discover and parse the latest COB BIRR PDF."""
-    page_url = settings.cob_birr_page_url
-    logger.info("Fetching COB BIRR reports page: %s", page_url)
+    """Download the BROP PDF, parse it, return pending bills payload.
 
-    response = client.get(page_url, raise_for_status=True)
-    html = response.text
-
-    pdf_url = _discover_latest_birr_pdf(html, page_url)
-    if not pdf_url:
-        logger.warning("No BIRR PDF link found on COB reports page")
-        return None
-
-    logger.info("Downloading COB BIRR PDF: %s", pdf_url)
-    return _download_and_parse_cob_pdf(client, pdf_url)
-
-
-_BIRR_KEYWORDS = (
-    "birr", "budget-implementation", "budget_implementation",
-    "implementation-review", "implementation_review",
-    "pending-bill", "pending_bill",
-)
-
-
-def _discover_latest_birr_pdf(html: str, base_url: str) -> Optional[str]:
-    """Extract the most recent BIRR PDF URL from the COB reports page.
-
-    Delegates to the shared COB WPDM discovery helper — see
-    ``seeding.cob_discovery`` for why direct ``.pdf`` regex stopped
-    matching after COB migrated to the WordPress Download Manager
-    plugin.
+    file:// URLs are read from disk so tests and offline runs don't
+    require a live HTTP path.
     """
-    return discover_latest_cob_pdf_url(
-        html, base_url, keywords=_BIRR_KEYWORDS
-    )
+    from .brop_parser import parse_brop_pdf
 
-
-def _download_and_parse_cob_pdf(
-    client: SeedingHttpClient, pdf_url: str
-) -> Optional[Dict[str, Any]]:
-    """Download a COB PDF to a temp file, parse it, and return pending bills payload."""
-    from ...pdf_parsers import CoBQuarterlyReportParser
-
+    logger.info("Downloading Treasury BROP PDF: %s", brop_url)
     tmp_path: Optional[Path] = None
     try:
-        response = client.get(pdf_url, raise_for_status=True)
+        if brop_url.startswith("file://"):
+            content = Path(brop_url[len("file://"):]).read_bytes()
+        else:
+            response = client.get(brop_url, raise_for_status=True)
+            content = response.content
 
         with tempfile.NamedTemporaryFile(
-            suffix=".pdf", delete=False, prefix="cob_birr_"
+            suffix=".pdf", delete=False, prefix="treasury_brop_"
         ) as tmp:
-            tmp.write(response.content)
+            tmp.write(content)
             tmp_path = Path(tmp.name)
 
-        logger.info(
-            "Downloaded COB PDF (%d bytes) to %s",
-            len(response.content),
-            tmp_path,
-        )
+        logger.info("Downloaded BROP PDF (%d bytes) to %s", len(content), tmp_path)
+        result = parse_brop_pdf(tmp_path)
 
-        # Parse with CoBQuarterlyReportParser
-        parser = CoBQuarterlyReportParser(tmp_path)
-        parsed_records = parser.parse()
-
-        if not parsed_records:
-            logger.warning("CoBQuarterlyReportParser returned no records")
-            return None
-
-        # Convert parsed budget execution records into pending bills format.
-        # The COB parser extracts county budget execution data (allocated vs absorbed).
-        # We derive "pending bills" as the gap between allocated and absorbed —
-        # unspent allocations often correspond to pending obligations.
-        pending_bills: List[Dict[str, Any]] = []
-        for record in parsed_records:
-            allocated = record.get("allocated", 0)
-            absorbed = record.get("absorbed", 0)
-            if isinstance(allocated, str):
-                try:
-                    from decimal import Decimal
-                    allocated = float(Decimal(allocated))
-                except Exception:
-                    allocated = 0
-            if isinstance(absorbed, str):
-                try:
-                    from decimal import Decimal
-                    absorbed = float(Decimal(absorbed))
-                except Exception:
-                    absorbed = 0
-
-            # Pending ≈ allocated - absorbed (unspent = potential pending bills)
-            pending = max(float(allocated) - float(absorbed), 0)
-            if pending <= 0:
-                continue
-
-            county = record.get("county", "Unknown")
-            fy = record.get("fiscal_year", "")
-            quarter = record.get("quarter", "")
-
-            pending_bills.append({
-                "entity_name": f"County Government of {county}",
-                "entity_type": "county",
-                "category": "county",
-                "fiscal_year": fy,
-                "total_pending": pending,
-                "eligible_pending": None,
-                "ineligible_pending": None,
-                "notes": (
-                    f"Derived from COB BIRR {quarter} {fy}: "
-                    f"allocated {allocated:,.0f} - absorbed {absorbed:,.0f} = "
-                    f"{pending:,.0f} unspent (proxy for pending obligations)"
-                ),
-            })
-
-        if not pending_bills:
-            logger.warning("No pending bills derived from COB budget data")
-            return None
-
-        return {
-            "pending_bills": pending_bills,
-            "summary": {
-                "fiscal_year": parsed_records[0].get("fiscal_year", ""),
-                "total_county": sum(
-                    pb["total_pending"] for pb in pending_bills
-                ),
-            },
-            "source_url": pdf_url,
-            "source_title": f"COB BIRR Report (live fetch)",
-        }
-
+        return _brop_result_to_payload(result, brop_url)
     finally:
         if tmp_path and tmp_path.exists():
             try:
                 tmp_path.unlink()
-                logger.debug("Cleaned up temp PDF: %s", tmp_path)
             except OSError:
                 pass
+
+
+def _brop_result_to_payload(
+    result, brop_url: str,
+) -> Dict[str, Any]:
+    """Convert a ``BropParseResult`` into the dict shape
+    ``parse_pending_bills_payload`` expects.
+
+    Emits:
+    * One ``state_corporation`` record for the SOEs aggregate.
+    * One ``mda`` record for the MDAs aggregate.
+    * One ``county`` record per parsed county row.
+    * A ``summary`` block with grand totals so the parser's
+      summary-fallback path can also produce useful aggregates if
+      the per-row records get filtered out downstream.
+    """
+    pending_bills: List[Dict[str, Any]] = []
+    fy_label = result.fiscal_year_label
+    source_title = f"Treasury BROP {fy_label}"
+
+    if result.national:
+        nb = result.national
+        as_at = nb.as_at_date.isoformat()
+        pending_bills.append(
+            {
+                "entity_name": "National Government — State Corporations",
+                "entity_type": "national",
+                "category": "state_corporation",
+                "fiscal_year": fy_label,
+                "total_pending": str(nb.state_corporations),
+                "notes": f"Treasury BROP para-18 aggregate as at {as_at}",
+            }
+        )
+        pending_bills.append(
+            {
+                "entity_name": "National Government — MDAs",
+                "entity_type": "national",
+                "category": "mda",
+                "fiscal_year": fy_label,
+                "total_pending": str(nb.mdas),
+                "notes": f"Treasury BROP para-18 aggregate as at {as_at}",
+            }
+        )
+
+    for cb in result.counties:
+        breakdown_parts = []
+        if cb.executive_subtotal is not None:
+            breakdown_parts.append(
+                f"Exec subtotal {float(cb.executive_subtotal):,.0f}"
+            )
+        if cb.assembly_subtotal is not None:
+            breakdown_parts.append(
+                f"Assembly subtotal {float(cb.assembly_subtotal):,.0f}"
+            )
+        if cb.fy_budget is not None:
+            breakdown_parts.append(
+                f"FY budget {float(cb.fy_budget):,.0f}"
+            )
+        notes = "Treasury BROP Table 10"
+        if breakdown_parts:
+            notes += " — " + "; ".join(breakdown_parts)
+        pending_bills.append(
+            {
+                "entity_name": f"County Government of {cb.county}",
+                "entity_type": "county",
+                "category": "county",
+                "fiscal_year": fy_label,
+                "total_pending": str(cb.total),
+                "notes": notes,
+            }
+        )
+
+    # Summary aggregates — useful for headline cards and as a
+    # fallback if per-row writers drop records.
+    summary: Dict[str, Any] = {"fiscal_year": fy_label}
+    if result.national:
+        summary["total_national"] = str(result.national.total)
+        summary["as_at_date"] = result.national.as_at_date.isoformat()
+    if result.counties:
+        summary["total_county"] = str(
+            sum((c.total for c in result.counties), Decimal(0))
+        )
+
+    return {
+        "pending_bills": pending_bills,
+        "summary": summary,
+        "source_url": brop_url,
+        "source_title": source_title,
+    }
 
 
 def _run_live_extraction() -> dict[str, Any]:

--- a/backend/tests/test_national_budget_pdf_parser.py
+++ b/backend/tests/test_national_budget_pdf_parser.py
@@ -1,0 +1,259 @@
+"""Tests for the NG-BIRR sectoral PDF parser.
+
+The internal parsing helpers are pinned here against the actual
+shapes observed in the COB FY 2025/26 H1 NG-BIRR. The class-level
+``NgBirrSectoralParser.parse()`` smoke-tests the whole pipeline
+through a stub ``pdfplumber`` page so we don't ship a 13 MB fixture
+PDF in the repo.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from seeding.domains.national_budget import pdf_parser as ng_pdf
+
+
+# ── _parse_kes_billion ──────────────────────────────────────────────
+
+
+class TestParseKesBillion:
+    def test_standard_thousands_and_decimal(self):
+        """Real-shape values like '1,234.56' parse as 1234.56 billion."""
+        assert ng_pdf._parse_kes_billion("1,234.56") == Decimal(
+            "1234560000000"
+        )
+
+    def test_misread_decimal_recovers(self):
+        """pdfplumber occasionally returns '95,23' where the decimal
+        point was misread as a comma. Without recovery this would be
+        a 100x overstatement (9523B vs the correct 95.23B); a real
+        FY 2025/26 H1 row hit this."""
+        assert ng_pdf._parse_kes_billion("95,23") == Decimal("95230000000")
+
+    def test_thousands_separator_3_digits_after_comma(self):
+        """A trailing 3-digit fragment is genuine thousands grouping
+        and must NOT be promoted to a decimal point."""
+        assert ng_pdf._parse_kes_billion("1,234") == Decimal(
+            "1234000000000"
+        )
+
+    def test_misread_decimal_with_thousands_prefix(self):
+        """Mixed: thousands grouping + misread decimal in same cell."""
+        assert ng_pdf._parse_kes_billion("1,234,56") == Decimal(
+            "1234560000000"
+        )
+
+    @pytest.mark.parametrize("cell", ["", " ", "-", "n/a", "NA", None])
+    def test_returns_none_for_empty_or_sentinels(self, cell):
+        """Empty / sentinel cells become None so the caller skips the
+        row instead of writing a garbage value."""
+        assert ng_pdf._parse_kes_billion(cell) is None
+
+
+# ── _row_matches_sector ─────────────────────────────────────────────
+
+
+class TestRowMatchesSector:
+    def test_matches_short_code(self):
+        """Single-token codes (ARUD, EIICT, …) are the common case
+        in COB's sector tables."""
+        assert (
+            ng_pdf._row_matches_sector(["ARUD", "1", "2"])
+            == "Agriculture, Rural and Urban Development"
+        )
+
+    def test_matches_multi_word_code(self):
+        """'National Security' has a space; the function must still
+        recognise it as a sector, not stop at the first token."""
+        assert (
+            ng_pdf._row_matches_sector(["National Security", "1", "2"])
+            == "National Security"
+        )
+
+    def test_case_insensitive(self):
+        assert (
+            ng_pdf._row_matches_sector(["health", "1", "2"]) == "Health"
+        )
+
+    def test_returns_none_for_total_row(self):
+        """The 'Total' row at the bottom of every sector table must
+        be filtered out — it isn't a sector and would double-count."""
+        assert ng_pdf._row_matches_sector(["Total", "407.10", "145.04"]) is None
+
+    def test_returns_none_for_subheader_row(self):
+        """Pdfplumber sometimes returns the header row as a data row
+        when a table has a multi-line header — must be ignored."""
+        assert ng_pdf._row_matches_sector(["Sector", "Net Estimates", ""]) is None
+
+    def test_returns_none_for_empty_row(self):
+        assert ng_pdf._row_matches_sector([]) is None
+        assert ng_pdf._row_matches_sector([None, "1"]) is None
+
+
+# ── _extract_sector_rows ────────────────────────────────────────────
+
+
+_REAL_DEV_TABLE = [
+    ["Sector", "First Six Months of FY 25/26", "", "", "", "", ""],
+    ["", "Net Estimates", "Exchequer Issues", "Exch %",
+     "Net Estimates", "Exchequer Issues", "Exch %"],
+    ["ARUD", "41.46", "21.92", "53", "38.2", "19.34", "51"],
+    ["EIICT", "130.80", "38.97", "30", "109.4", "37.57", "34"],
+    ["Health", "18.78", "4.78", "25", "20.0", "5.0", "25"],
+    # PAIR row carries the misread-decimal scenario in the recurrent
+    # equivalent table; here it's a normal cell so we just use a
+    # different sector to round out coverage.
+    ["National Security", "1.00", "0.10", "10", "0.5", "0.05", "10"],
+    ["Total", "407.10", "145.04", "36", "351.29", "129.82", "37"],
+]
+
+
+class TestExtractSectorRows:
+    def test_extracts_only_sector_rows(self):
+        rows = ng_pdf._extract_sector_rows(_REAL_DEV_TABLE)
+        sectors = [r[0] for r in rows]
+        # 4 sector rows expected; header/subheader/Total skipped.
+        assert sectors == [
+            "Agriculture, Rural and Urban Development",
+            "Energy, Infrastructure and ICT",
+            "Health",
+            "National Security",
+        ]
+
+    def test_pulls_current_period_columns_only(self):
+        """Cols 1-2 are CURRENT period; cols 4-5 are the comparative
+        prior year and must NOT leak into the output."""
+        rows = ng_pdf._extract_sector_rows(_REAL_DEV_TABLE)
+        arud = next(r for r in rows if r[0].startswith("Agriculture"))
+        assert arud[1] == Decimal("41460000000")   # current net
+        assert arud[2] == Decimal("21920000000")   # current exch
+
+    def test_skips_row_with_unparseable_cell(self):
+        bad = list(_REAL_DEV_TABLE)
+        bad.insert(2, ["GECA", "garbage", "5.50", "1", "2", "3", "4"])
+        rows = ng_pdf._extract_sector_rows(bad)
+        assert "General Economic and Commercial Affairs" not in [r[0] for r in rows]
+
+
+# ── _detect_period ──────────────────────────────────────────────────
+
+
+def _stub_pdf_with_cover(text: str) -> MagicMock:
+    """Build a MagicMock pdfplumber.PDF whose first page returns the
+    given text. _detect_period only reads the first 3 pages."""
+    page = MagicMock()
+    page.extract_text.return_value = text
+    pdf = MagicMock()
+    pdf.pages = [page, page, page]
+    return pdf
+
+
+class TestDetectPeriod:
+    def test_first_six_months_h1(self):
+        info = ng_pdf._detect_period(
+            _stub_pdf_with_cover("NATIONAL GOVERNMENT BIRR\nFIRST SIX MONTHS\nFY 2025/2026")
+        )
+        assert info.label == "FY 2025/26 H1"
+        assert info.start_date == date(2025, 7, 1)
+        assert info.end_date == date(2025, 12, 31)
+
+    def test_first_quarter_q1(self):
+        info = ng_pdf._detect_period(
+            _stub_pdf_with_cover("NG-BIRR\nFIRST QUARTER\nFY 2024/2025")
+        )
+        assert info.label == "FY 2024/25 Q1"
+        assert info.end_date == date(2024, 9, 30)
+
+    def test_annual_when_no_subperiod_descriptor(self):
+        """If only a 'FY YYYY/YYYY' label is present, treat as annual:
+        end on Jun 30 of the FY's second calendar year."""
+        info = ng_pdf._detect_period(
+            _stub_pdf_with_cover("ANNUAL NATIONAL GOVERNMENT BIRR FY 2023/2024")
+        )
+        assert info.label == "FY 2023/24"
+        assert info.end_date == date(2024, 6, 30)
+
+    def test_returns_none_when_no_fy_label(self):
+        """A page that doesn't carry an 'FY YYYY/YYYY' label is
+        unparseable — better to fail loud than guess."""
+        assert ng_pdf._detect_period(
+            _stub_pdf_with_cover("just a random page")
+        ) is None
+
+
+# ── NgBirrSectoralParser.parse (integration via stubbed pdfplumber) ─
+
+
+class TestNgBirrSectoralParser:
+    def test_emits_one_record_per_sector_per_subcategory(self, tmp_path):
+        """Stubs pdfplumber so we don't ship a 13 MB fixture PDF.
+        Verifies the dev + recurrent paths both feed the output and
+        that the period info is threaded through."""
+        rec_table = [
+            ["Sector", "Net Est", "Exch", "%", "Net Est", "Exch", "%"],
+            ["Health", "74.78", "40.90", "55", "56.43", "28.12", "50"],
+            ["Education", "601.03", "348.57", "58", "554.03", "263.1", "48"],
+        ]
+        dev_table = _REAL_DEV_TABLE
+
+        cover_page = MagicMock()
+        cover_page.extract_text.return_value = (
+            "NATIONAL GOVERNMENT BIRR\nFIRST SIX MONTHS\nFY 2025/2026"
+        )
+
+        dev_page = MagicMock()
+        dev_page.extract_text.return_value = (
+            "Table 2.5: Sectoral Development Estimates and Exchequer Issues"
+        )
+        dev_page.extract_tables.return_value = [dev_table]
+
+        rec_page = MagicMock()
+        rec_page.extract_text.return_value = (
+            "Table 2.6: Sectoral Recurrent Estimates and Exchequer Issues"
+        )
+        rec_page.extract_tables.return_value = [rec_table]
+
+        fake_pdf = MagicMock()
+        fake_pdf.pages = [cover_page, cover_page, cover_page, dev_page, rec_page]
+        fake_pdf.__enter__ = lambda s: fake_pdf
+        fake_pdf.__exit__ = lambda *a: None
+
+        with patch.object(ng_pdf.pdfplumber, "open", return_value=fake_pdf):
+            parser = ng_pdf.NgBirrSectoralParser(tmp_path / "fake.pdf")
+            period, records = parser.parse()
+
+        assert period.label == "FY 2025/26 H1"
+        # 4 dev sector rows + 2 recurrent sector rows.
+        assert len(records) == 6
+        subs = {(r.sector, r.subcategory) for r in records}
+        assert ("Health", "Recurrent") in subs
+        assert ("Education", "Recurrent") in subs
+        assert ("Agriculture, Rural and Urban Development", "Development") in subs
+
+    def test_raises_when_no_tables_found(self, tmp_path):
+        """A PDF that has the period descriptor but neither dev nor
+        recurrent sector table must raise so the fetcher logs the
+        warning and falls back to fixture rather than silently
+        emitting zero records."""
+        cover_page = MagicMock()
+        cover_page.extract_text.return_value = (
+            "NG-BIRR FIRST SIX MONTHS FY 2024/2025"
+        )
+        # No table-2.5/2.6 titled pages.
+        other_page = MagicMock()
+        other_page.extract_text.return_value = "Some unrelated page"
+        other_page.extract_tables.return_value = []
+
+        fake_pdf = MagicMock()
+        fake_pdf.pages = [cover_page, cover_page, cover_page, other_page]
+        fake_pdf.__enter__ = lambda s: fake_pdf
+        fake_pdf.__exit__ = lambda *a: None
+
+        with patch.object(ng_pdf.pdfplumber, "open", return_value=fake_pdf):
+            parser = ng_pdf.NgBirrSectoralParser(tmp_path / "fake.pdf")
+            with pytest.raises(ValueError, match="No sectoral aggregate"):
+                parser.parse()

--- a/backend/tests/test_national_budget_pdf_parser.py
+++ b/backend/tests/test_national_budget_pdf_parser.py
@@ -168,6 +168,19 @@ class TestDetectPeriod:
         assert info.label == "FY 2024/25 Q1"
         assert info.end_date == date(2024, 9, 30)
 
+    def test_first_nine_months_uses_actual_march_31(self):
+        """End-month March has 31 days, not 30. Pre-fix code
+        hard-coded month-30 for the (3, 6, 9) bucket and produced
+        2025-03-30, mismatching the bulletin's stated period
+        (Copilot review on PR #81)."""
+        info = ng_pdf._detect_period(
+            _stub_pdf_with_cover(
+                "NATIONAL GOVERNMENT BIRR\nFIRST NINE MONTHS\nFY 2024/2025"
+            )
+        )
+        assert info.label == "FY 2024/25 9M"
+        assert info.end_date == date(2025, 3, 31)
+
     def test_annual_when_no_subperiod_descriptor(self):
         """If only a 'FY YYYY/YYYY' label is present, treat as annual:
         end on Jun 30 of the FY's second calendar year."""

--- a/backend/tests/test_pending_bills_brop_parser.py
+++ b/backend/tests/test_pending_bills_brop_parser.py
@@ -104,7 +104,9 @@ class TestDetectNationalParagraph:
         return pdf
 
     def test_extracts_three_amounts_and_date(self):
-        result = bp._detect_national_paragraph(self._stub_pdf(_REAL_PARA_18))
+        result = bp._detect_national_paragraph(
+            self._stub_pdf(_REAL_PARA_18), "FY 2024/25"
+        )
         assert result is not None
         assert result.total == Decimal("525900000000")
         assert result.state_corporations == Decimal("404300000000")
@@ -113,9 +115,49 @@ class TestDetectNationalParagraph:
 
     def test_returns_none_when_paragraph_absent(self):
         result = bp._detect_national_paragraph(
-            self._stub_pdf("Just some narrative without the para-18 anchor.")
+            self._stub_pdf(
+                "Just some narrative without the para-18 anchor."
+            ),
+            "FY 2024/25",
         )
         assert result is None
+
+    def test_falls_back_to_fy_end_date_when_as_at_missing(self):
+        """If the para-18 anchor matches but the 'as at' date phrase
+        is rephrased / dropped in a future BROP, the as-at date must
+        be inferred from the FY label (Jun 30 of FY's second
+        calendar year). The previous ``date(2000, 6, 30)`` placeholder
+        would have produced a wrong natural key in the writer
+        (Copilot review on PR #81)."""
+        para_without_date = (
+            "Pending Bills\n"
+            "18. The total outstanding National Government pending bills "
+            "amounted to KSh 525.9 billion. These comprise of KSh 404.3 "
+            "billion (76.9 percent) and KSh 121.6 billion (23.1 percent) "
+            "for the State Corporations and MDAs, respectively."
+        )
+        result = bp._detect_national_paragraph(
+            self._stub_pdf(para_without_date), "FY 2024/25"
+        )
+        assert result is not None
+        # FY 2024/25 → ends 30 June 2025.
+        assert result.as_at_date == date(2025, 6, 30)
+
+
+class TestInferFyEndDate:
+    def test_short_form_fy_label(self):
+        assert bp._infer_fy_end_date("FY 2024/25") == date(2025, 6, 30)
+
+    def test_long_form_fy_label(self):
+        assert bp._infer_fy_end_date("FY 2024/2025") == date(2025, 6, 30)
+
+    def test_fallback_when_label_unparseable(self):
+        """Last-resort: a recent FY-end (today's most recent Jun 30).
+        The exact date depends on the test's wall-clock so we just
+        assert it's not the legacy date(2000, ...) sentinel."""
+        result = bp._infer_fy_end_date("FY ?")
+        assert result.year >= 2024
+        assert (result.month, result.day) == (6, 30)
 
 
 # ── _COUNTY_ROW_RE + _parse_county_row_numbers ──────────────────────
@@ -170,6 +212,61 @@ class TestCountyRowRegex:
         m = bp._COUNTY_ROW_RE.match(line)
         assert m is not None
         assert m.group("county") == "Murang'a"
+
+
+class TestParseCountyRowNumbers:
+    def test_full_six_breakdown_row_with_preserved_dash(self):
+        """Kilifi-shaped row: pdfplumber renders the missing
+        assembly-development cell as a literal '-' token. We MUST
+        keep that as a positional ``None`` placeholder so subsequent
+        cells stay column-aligned. Pre-fix bug: the dash was filtered
+        out, shifting the assembly_subtotal into ``asm_dev`` and
+        misattributing the value (Copilot review on PR #81)."""
+        # 9 tokens: exec_R, exec_D, exec_Sub, asm_R, "-", asm_Sub,
+        # total, fy_budget, pct.
+        tokens = [
+            "3,820.1", "5,367.4", "9,187.4",
+            "68.2", "-", "68.2",
+            "9,255.6", "21,406.50", "43.2",
+        ]
+        out = bp._parse_county_row_numbers(tokens)
+        assert out is not None
+        # Executive cells fully populated.
+        assert out["exec_rec"] == Decimal("3820100000")
+        assert out["exec_dev"] == Decimal("5367400000")
+        assert out["exec_sub"] == Decimal("9187400000")
+        # Assembly: recurrent + subtotal both 68.2M, dev correctly None.
+        assert out["asm_rec"] == Decimal("68200000")
+        assert out["asm_dev"] is None
+        assert out["asm_sub"] == Decimal("68200000")
+        # Reliable last-three columns.
+        assert out["total"] == Decimal("9255600000")
+        assert out["fy_budget"] == Decimal("21406500000")
+
+    def test_short_row_leaves_assembly_unset(self):
+        """When pdfplumber drops a dash entirely (Nairobi-shaped: 8
+        tokens with no '-'), we can't tell which assembly cell was
+        omitted from the text. Persist exec + last-three columns and
+        leave the ambiguous cells as None rather than guess."""
+        # 8 tokens — pdfplumber dropped one assembly cell. Last 3 are
+        # total/budget/pct; first 3 are exec_R/D/Sub; middle 2 are
+        # ambiguous between (asm_R, asm_Sub) and (asm_R, asm_D).
+        tokens = [
+            "78,949.1", "7,169.4", "86,118.6",
+            "650.6", "650.6",
+            "86,769.2", "43,564.27", "199.2",
+        ]
+        out = bp._parse_county_row_numbers(tokens)
+        assert out is not None
+        assert out["exec_rec"] == Decimal("78949100000")
+        assert out["exec_dev"] == Decimal("7169400000")
+        assert out["exec_sub"] == Decimal("86118600000")
+        # Ambiguous cells unset.
+        assert "asm_rec" not in out
+        assert "asm_dev" not in out
+        assert "asm_sub" not in out
+        # Reliable columns still present.
+        assert out["total"] == Decimal("86769200000")
 
 
 # ── _dehyphenate_text ───────────────────────────────────────────────

--- a/backend/tests/test_pending_bills_brop_parser.py
+++ b/backend/tests/test_pending_bills_brop_parser.py
@@ -1,0 +1,287 @@
+"""Tests for the Treasury BROP pending-bills parser.
+
+These pin the parsing behaviour the ``pending_bills`` domain
+depends on after switching off the broken NG-BIRR + allocated-minus-
+absorbed proxy. The internal helpers are tested against the actual
+shapes observed in the September-2025 BROP; the public
+``parse_brop_pdf`` entry point is smoke-tested via a stubbed
+pdfplumber so we don't ship a 2.5 MB fixture PDF in the repo.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from seeding.domains.pending_bills import brop_parser as bp
+
+
+# ── _parse_kes_billion / _parse_kes_million ─────────────────────────
+
+
+class TestNumberParsing:
+    def test_billion_scale(self):
+        assert bp._parse_kes_billion("525.9") == Decimal("525900000000")
+
+    def test_billion_with_comma(self):
+        assert bp._parse_kes_billion("1,234.5") == Decimal(
+            "1234500000000"
+        )
+
+    def test_million_scale(self):
+        assert bp._parse_kes_million("78,949.1") == Decimal(
+            "78949100000"
+        )
+
+    @pytest.mark.parametrize(
+        "func", [bp._parse_kes_billion, bp._parse_kes_million]
+    )
+    @pytest.mark.parametrize("token", ["", " ", "-", None])
+    def test_returns_none_for_empty_or_dash(self, func, token):
+        """BROP renders missing cells as '-'; the parser must keep
+        them as None so the writer leaves the column unset rather
+        than writing 0 (which would be a real value)."""
+        assert func(token) is None
+
+
+# ── _normalise_county ───────────────────────────────────────────────
+
+
+class TestNormaliseCounty:
+    def test_exact_match(self):
+        assert bp._normalise_county("Nairobi") == "Nairobi"
+
+    def test_apostrophe_stripped(self):
+        """'Murang'a' is the canonical form in KENYAN_COUNTIES; the
+        BROP renders it the same way. Both sides normalise to
+        'muranga' so the match works without losing the canonical
+        apostrophe."""
+        assert bp._normalise_county("Murang'a") == "Murang'a"
+
+    def test_hyphen_to_space(self):
+        """Some BROP cells use 'Tharaka-Nithi'; canonical is
+        'Tharaka Nithi'. Hyphens normalise to spaces on both sides."""
+        assert bp._normalise_county("Tharaka-Nithi") == "Tharaka Nithi"
+
+    def test_prefix_match_for_truncated_wrap(self):
+        """pdfplumber occasionally drops the second line of a
+        wrapped county name, so 'Tharaka' arrives without 'Nithi'.
+        We prefix-match against KENYAN_COUNTIES, but ONLY when the
+        prefix is unambiguous — no second county shares 'Tharaka' as
+        its first word, so this is safe."""
+        assert bp._normalise_county("Tharaka") == "Tharaka Nithi"
+        assert bp._normalise_county("Elgeyo") == "Elgeyo Marakwet"
+
+    def test_returns_none_for_non_county(self):
+        assert bp._normalise_county("Sub-Total") is None
+        assert bp._normalise_county("Total") is None
+        assert bp._normalise_county("Banana") is None
+
+
+# ── _detect_national_paragraph ──────────────────────────────────────
+
+
+_REAL_PARA_18 = """\
+17. Some other paragraph about external financing.
+
+Pending Bills
+
+18. The total outstanding National Government pending bills as at
+30th June 2025 amounted to KSh 525.9 billion. These comprise of
+KSh 404.3 billion (76.9 percent) and KSh 121.6 billion (23.1
+percent) for the State Corporations and MDAs, respectively.
+"""
+
+
+class TestDetectNationalParagraph:
+    def _stub_pdf(self, text: str) -> MagicMock:
+        page = MagicMock()
+        page.extract_text.return_value = text
+        pdf = MagicMock()
+        pdf.pages = [page] * 5  # search range is first 30 pages
+        return pdf
+
+    def test_extracts_three_amounts_and_date(self):
+        result = bp._detect_national_paragraph(self._stub_pdf(_REAL_PARA_18))
+        assert result is not None
+        assert result.total == Decimal("525900000000")
+        assert result.state_corporations == Decimal("404300000000")
+        assert result.mdas == Decimal("121600000000")
+        assert result.as_at_date == date(2025, 6, 30)
+
+    def test_returns_none_when_paragraph_absent(self):
+        result = bp._detect_national_paragraph(
+            self._stub_pdf("Just some narrative without the para-18 anchor.")
+        )
+        assert result is None
+
+
+# ── _COUNTY_ROW_RE + _parse_county_row_numbers ──────────────────────
+
+
+class TestCountyRowRegex:
+    def test_full_row(self):
+        """Real Nairobi row from BROP 2025 Table 10. Eight numeric
+        tokens because the Assembly column collapses to a single
+        sub-total (no Recurrent/Development split for Nairobi
+        Assembly)."""
+        line = (
+            "1. Nairobi 78,949.1 7,169.4 86,118.6 650.6 650.6 "
+            "86,769.2 43,564.27 199.2"
+        )
+        m = bp._COUNTY_ROW_RE.match(line)
+        assert m is not None
+        assert m.group("no") == "1"
+        assert m.group("county") == "Nairobi"
+        tokens = m.group("rest").split()
+        # Last 3 tokens are always Total / FY budget / %.
+        assert tokens[-3:] == ["86,769.2", "43,564.27", "199.2"]
+
+    def test_row_with_dash_for_missing_cell(self):
+        """'Kilifi 3,820.1 5,367.4 9,187.4 68.2 - 68.2 9,255.6
+        21,406.50 43.2' — the dash represents an empty assembly
+        development cell."""
+        line = (
+            "2. Kilifi 3,820.1 5,367.4 9,187.4 68.2 - 68.2 "
+            "9,255.6 21,406.50 43.2"
+        )
+        m = bp._COUNTY_ROW_RE.match(line)
+        assert m is not None
+        assert m.group("county") == "Kilifi"
+
+    def test_two_word_county_name(self):
+        line = (
+            "23. Trans Nzoia 805.4 703.0 1,508.4 - 1,508.4 "
+            "10,455.02 14.4"
+        )
+        m = bp._COUNTY_ROW_RE.match(line)
+        assert m is not None
+        assert m.group("county") == "Trans Nzoia"
+
+    def test_row_with_apostrophe(self):
+        """Murang'a's apostrophe must NOT terminate the county name
+        match early."""
+        line = (
+            "16. Murang'a 1,588.1 333.4 1,921.5 72.2 72.2 "
+            "1,993.7 10,743.65 18.6"
+        )
+        m = bp._COUNTY_ROW_RE.match(line)
+        assert m is not None
+        assert m.group("county") == "Murang'a"
+
+
+# ── _dehyphenate_text ───────────────────────────────────────────────
+
+
+class TestDehyphenateText:
+    def test_joins_hyphen_split_county_names(self):
+        text = "30. Tharaka-\nNithi 468.6 176.2 644.7"
+        out = bp._dehyphenate_text(text)
+        # Should join into a single line.
+        assert "Tharaka-Nithi" in out
+
+    def test_does_not_join_unrelated_lines(self):
+        """Only joins when the line ENDS in '-' and the next starts
+        with an uppercase letter — must not stitch normal paragraphs."""
+        text = "Some sentence ending in punctuation.\nAnother paragraph."
+        assert bp._dehyphenate_text(text) == text
+
+
+# ── parse_brop_pdf (integration via stubbed pdfplumber) ─────────────
+
+
+class TestParseBropPdfIntegration:
+    def test_emits_national_plus_counties(self, tmp_path):
+        cover_page = MagicMock()
+        cover_page.extract_text.return_value = (
+            "REPUBLIC OF KENYA\nTHE NATIONAL TREASURY\n"
+            "2025 BUDGET REVIEW AND OUTLOOK PAPER\nSEPTEMBER 2025"
+        )
+
+        para_page = MagicMock()
+        para_page.extract_text.return_value = _REAL_PARA_18
+
+        table_page = MagicMock()
+        table_page.extract_text.return_value = (
+            "Table 10: County Governments Pending Bills as at 30th June 2025\n"
+            "1. Nairobi 78,949.1 7,169.4 86,118.6 650.6 650.6 86,769.2 "
+            "43,564.27 199.2\n"
+            "2. Kilifi 3,820.1 5,367.4 9,187.4 68.2 - 68.2 9,255.6 "
+            "21,406.50 43.2\n"
+            "Total 122,625.9 49,121.0 171,746.9 4,232.7 924.5 5,157.3 "
+            "176,904.2 601,689.14 29\n"
+        )
+
+        fake_pdf = MagicMock()
+        fake_pdf.pages = [cover_page] * 3 + [para_page, table_page]
+        fake_pdf.__enter__ = lambda s: fake_pdf
+        fake_pdf.__exit__ = lambda *a: None
+
+        with patch.object(bp.pdfplumber, "open", return_value=fake_pdf):
+            result = bp.parse_brop_pdf(tmp_path / "fake.pdf")
+
+        assert result.fiscal_year_label == "FY 2024/25"
+        assert result.national is not None
+        assert result.national.total == Decimal("525900000000")
+        # 2 county rows extracted (Total filtered out by end marker).
+        assert len(result.counties) == 2
+        names = {c.county for c in result.counties}
+        assert names == {"Nairobi", "Kilifi"}
+
+    def test_county_table_anchored_on_title(self, tmp_path):
+        """The BROP has at least one OTHER table earlier with
+        county-style numbered rows. Without title-anchoring our
+        county regex would happily match those too. Verify we ignore
+        them when the Table 10 title hasn't appeared yet."""
+        cover_page = MagicMock()
+        cover_page.extract_text.return_value = (
+            "2025 BUDGET REVIEW AND OUTLOOK PAPER"
+        )
+        # Earlier table (e.g. revenue per county) — same row shape,
+        # different data, no Table 10 title.
+        decoy_page = MagicMock()
+        decoy_page.extract_text.return_value = (
+            "Table 5: County Revenue Performance\n"
+            "1. Nairobi 100.0 200.0 300.0 50.0 60.0 110.0 410.0 "
+            "1000.0 41.0\n"
+        )
+        # The real Table 10 page comes after, with different numbers.
+        table_page = MagicMock()
+        table_page.extract_text.return_value = (
+            "Table 10: County Governments Pending Bills as at 30th June 2025\n"
+            "1. Nairobi 78,949.1 7,169.4 86,118.6 650.6 650.6 86,769.2 "
+            "43,564.27 199.2\n"
+            "Total 122,625.9 49,121.0 171,746.9 4,232.7 924.5 5,157.3 "
+            "176,904.2 601,689.14 29\n"
+        )
+
+        fake_pdf = MagicMock()
+        fake_pdf.pages = [cover_page] * 3 + [decoy_page, table_page]
+        fake_pdf.__enter__ = lambda s: fake_pdf
+        fake_pdf.__exit__ = lambda *a: None
+
+        with patch.object(bp.pdfplumber, "open", return_value=fake_pdf):
+            result = bp.parse_brop_pdf(tmp_path / "fake.pdf")
+
+        # Decoy Nairobi (total=410M) ignored; real Nairobi (total=86,769.2M) kept.
+        assert len(result.counties) == 1
+        assert result.counties[0].total == Decimal("86769200000")
+
+    def test_raises_when_neither_section_matches(self, tmp_path):
+        cover_page = MagicMock()
+        cover_page.extract_text.return_value = (
+            "2025 BUDGET REVIEW AND OUTLOOK PAPER"
+        )
+        empty_page = MagicMock()
+        empty_page.extract_text.return_value = "no useful content"
+
+        fake_pdf = MagicMock()
+        fake_pdf.pages = [cover_page] * 3 + [empty_page]
+        fake_pdf.__enter__ = lambda s: fake_pdf
+        fake_pdf.__exit__ = lambda *a: None
+
+        with patch.object(bp.pdfplumber, "open", return_value=fake_pdf):
+            with pytest.raises(ValueError, match="No pending-bills data"):
+                bp.parse_brop_pdf(tmp_path / "fake.pdf")


### PR DESCRIPTION
## Summary

Combines [#79](https://github.com/Rodgers31/audit_app/pull/79) (NG-BIRR sectoral parser) and [#80](https://github.com/Rodgers31/audit_app/pull/80) (BROP pending-bills parser) — both follow-ups to the same seed-run investigation. They touch disjoint files (`national_budget/` and `pending_bills/` respectively) and address the same class of bug: a domain that silently fell back to fixture every nightly run because the parser couldn't handle the discovered PDF.

Two coherent commits, kept separate in history so reviewers can read each domain's diff in isolation:

1. **`fix(national_budget)`** — replaces `CoBQuarterlyReportParser` (anchored on the 47-county invariant of the *Consolidated County* BIRR) with a new `NgBirrSectoralParser` targeting Tables 2.5 + 2.6 of the National Government BIRR. Sectoral aggregates (10 sectors × Dev/Recurrent), period detection from the cover page, decimal-misread recovery for pdfplumber's "95,23" → "95.23" quirk.
2. **`fix(pending_bills)`** — replaces the broken NG-BIRR path (no pending-bills tables exist in that document) + the non-sequitur `pending = allocated - absorbed` proxy with a new `BropPendingBillsParser` against the Treasury Budget Review and Outlook Paper. Paragraph 18 (national aggregate) + Table 10 (47-county breakdown) with title-anchoring to skip an earlier decoy table on page 23.

## Smoke tests against live PDFs

**NG-BIRR FY 2025/26 H1** (13 MB):
- 20 records (10 sectors × Dev/Recurrent)
- Totals reconcile to the PDF's Total rows: Development 407.10/145.04 KShs B, Recurrent 1,470.44/809.51 KShs B

**Treasury BROP FY 2024/25** (2.5 MB):
- National para extracted: total **525.9 B** = SOEs 404.3 B + MDAs 121.6 B
- 46 of 47 counties extracted (Narok legitimately empty per PDF note); sum **176.905 B** matches PDF Total row 176.904 B
- Tricky names handled: Murang'a (apostrophe), Tharaka Nithi & Elgeyo Marakwet (pdfplumber drops second wrap line; prefix-match recovers), Trans Nzoia (multi-word)

## Caveats

- **NG-BIRR** publishes Exchequer Issues at the sector level, not Expenditure. Mapped to `actual_spent` as the closest sector-level proxy — called out in record `notes`. Per-Vote Expenditure lives in the section-4 tables; deferred.
- **BROP** is annual cadence (October). For fresher county-side data, COB Consolidated County BIRR (tri-annual) is a sensible follow-up overlay reusing the WPDM discovery from #78.
- BROP's national side is sparse — only the SOE-vs-MDA two-line split, not per-MDA. Per-MDA pending bills require OAG audit OCR (out of scope).

## Config additions

- `treasury_brop_url` (Optional) — defaults to the FY 2024/25 BROP URL. Production users update `SEED_TREASURY_BROP_URL` when the next BROP drops. Auto-discovery is a follow-up.

## Test plan

- [x] `pytest tests/test_national_budget_pdf_parser.py` — 25 new tests
- [x] `pytest tests/test_pending_bills_brop_parser.py` — 27 new tests
- [x] Full unit suite: **479 passed, 1 skipped**
- [x] End-to-end smoke against live PDFs (numbers above)
- [ ] Re-trigger the Actions seed workflow after merge — verify both warnings disappear and `items_processed` reflects real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)