### PR TITLE
fix(pending_bills): match DB entity_name format for counties

### DIFF
--- a/backend/seeding/domains/pending_bills/fetcher.py
+++ b/backend/seeding/domains/pending_bills/fetcher.py
@@ -194,9 +194,16 @@ def _brop_result_to_payload(
         notes = "Treasury BROP Table 10"
         if breakdown_parts:
             notes += " — " + "; ".join(breakdown_parts)
+        # Match the fixture's "{County} County" entity-name format —
+        # the writer's _get_or_create_entity does an exact
+        # canonical_name match first, and that's the format the
+        # bootstrap-seeded county entities use. Earlier seed run
+        # 24966698677 had this code emitting "County Government of
+        # X" which fell through to the ILIKE fallback and failed for
+        # all 46 counties.
         pending_bills.append(
             {
-                "entity_name": f"County Government of {cb.county}",
+                "entity_name": f"{cb.county} County",
                 "entity_type": "county",
                 "category": "county",
                 "fiscal_year": fy_label,


### PR DESCRIPTION
## Summary

The post-#83 seed run ([Actions 24966698677](https://github.com/Rodgers31/audit_app/actions/runs/24966698677)) succeeded overall (all 14 domains green, including `national_budget` writing 20 fresh records), but **46 of 48** `pending_bills` records were silently dropped:

> [WARNING] seeding.pending_bills.writer: Entity not found: County Government of Nairobi (county)…  
> [WARNING] seeding.pending_bills.writer: Could not resolve entity: County Government of Nairobi (county). Skipping.  
> *(× 46 — every county row from the BROP Table 10 parse)*

The 2 national-side records (MDA + State Corporation aggregates) landed correctly because they resolve to the existing "National Government" entity. Only the per-county BROP rows failed.

## Root cause

The BROP fetcher emitted `entity_name="County Government of Nairobi"` but the bootstrap-seeded county entities use `"Nairobi County"` as their `canonical_name` (matching the existing pending_bills fixture's format). The writer's `_get_or_create_entity` tries an exact `canonical_name` match first, then falls through to an `ILIKE` substring match — but `%County Government of Nairobi%` doesn't substring-match `"Nairobi County"` either, so all 46 county rows hit the warning-and-skip branch.

## Fix

Switch the fetcher to emit `f"{cb.county} County"` (matches the fixture's working format and the DB canonical name), so the writer's first-path exact lookup hits.

## Why this slipped through #80/#81 testing

Same pattern as the `normalize_fiscal_label` gap fixed in #83. My smoke tests confirmed:
- The PARSER produces correct values (totals match PDF)
- The FETCHER passes those through `parse_pending_bills_payload` cleanly

But they didn't run the writer (which requires a DB session and bootstrapped county entities). One direct assertion on `entity_name` against the fixture's working shape (`"Nairobi County"`) would have caught it. The fetcher→writer contract is the recurring weak point — there's a simple fix worth considering as a follow-up: a smoke test that round-trips one county record through `_get_or_create_entity` against an in-memory DB pre-populated with the bootstrap entities.

## Test plan

- [x] Smoke-tested locally: BROP fetcher now emits `entity_name=['Nairobi County', 'Kilifi County', 'Machakos County', …]` for all 46 counties.
- [x] `pytest tests/test_pending_bills_brop_parser.py` — 33 passing (no regression; tests don't cover the entity-name shape directly so no test changes needed).
- [ ] Re-trigger the Actions seed workflow after merge — verify `pending_bills: items_processed=48 created=46 updated=2` (or `created=48` on first post-merge run since the 46 county rows are new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)