### PR TITLE
chore(seeding): clear three known-noisy log warnings

### DIFF
--- a/backend/seeding/domains/audits/fetcher.py
+++ b/backend/seeding/domains/audits/fetcher.py
@@ -5,9 +5,31 @@ Strategy (in order):
    PDFs from the OAG (Office of the Auditor General) website.
 2. Fall back to the static fixture / configured URL.
 
-Note: OAG Kenya does not provide a structured API. Audit findings are
-published as PDF reports at https://www.oagkenya.go.ke/reports/.
-The live fetcher attempts to discover and parse the latest reports.
+Known limitation: OAG report PDFs are scanned images
+-----------------------------------------------------
+Most published OAG audit reports are scanned (raster) PDFs with no
+embedded text, so pdfplumber's ``extract_text`` returns empty and
+the live path produces zero findings. Probed 2026-04-26: the home
+page links one matching "performance-audit" PDF (32 MB, scanned)
+plus an Annual Corporate Report (text but doesn't match the audit
+keyword filter); the per-category listings
+(/national-government-audit-reports/, /county-governments-reports/,
+/financial-audit-reports/) are JS-rendered and don't expose PDFs in
+raw HTML.
+
+Two paths to actually solve this, both larger scope than this file:
+
+* Add an OCR pipeline (pytesseract + pdf2image, plus
+  apt-installed tesseract-ocr + poppler-utils in CI). Heavy on
+  runtime — OCR is ~2-5 sec/page and an OAG report is 100+ pages.
+* JS-render the per-category listing pages with Playwright to find
+  text-based PDFs — assumes any exist; we haven't confirmed.
+
+Until one of those lands, the live path here will keep returning
+None and the fixture is authoritative. The "no extractable text"
+log used to fire as WARNING; it's INFO now because the fallback
+works correctly and a real warning would be misleading on every
+nightly run.
 """
 
 from __future__ import annotations
@@ -41,7 +63,13 @@ def fetch_audit_payload(
     1. Try live PDF fetch from OAG reports page (if enabled).
     2. Fall back to configured fixture/API URL.
     """
-    # Strategy 1: Live PDF fetch from OAG
+    # Strategy 1: Live PDF fetch from OAG.
+    # Empty results are EXPECTED on the live path while OAG continues
+    # to publish scanned-image PDFs (see module docstring) — the
+    # "fall back to fixture" log is INFO not WARNING so we don't
+    # noise up every nightly run. Real exceptions still WARN because
+    # they signal a NEW failure (e.g. OAG site reorganisation,
+    # network outage, pdfplumber regression).
     if settings.live_pdf_fetch_enabled:
         try:
             payload = _fetch_from_oag(client, settings)
@@ -52,8 +80,9 @@ def fetch_audit_payload(
                 )
                 return payload
             else:
-                logger.warning(
-                    "OAG fetch returned no findings, falling back to fixture"
+                logger.info(
+                    "OAG live fetch produced no findings (expected: "
+                    "OAG PDFs are scanned images); falling back to fixture"
                 )
         except Exception as exc:
             logger.warning(
@@ -204,7 +233,14 @@ def _download_and_parse_audit_pdf(
                     full_text += text + "\n"
 
             if not full_text.strip():
-                logger.warning("PDF appears to contain no extractable text")
+                # OAG publishes scanned-image PDFs — see module docstring
+                # for the full context and the OCR / Playwright paths
+                # required to actually fix this. INFO not WARNING so the
+                # log doesn't suggest a new fault on every nightly run.
+                logger.info(
+                    "PDF appears to contain no extractable text "
+                    "(scanned image; OCR not configured)"
+                )
                 return None
 
             # Extract audit findings using pattern matching

--- a/backend/seeding/domains/counties_budget/fetcher.py
+++ b/backend/seeding/domains/counties_budget/fetcher.py
@@ -318,8 +318,17 @@ def _discover_latest_county_birr_via_wp_api(
         )
         return source_url
 
-    logger.warning(
-        "COB WP REST API: %d scored candidates but none passed HEAD probe",
+    # All scored candidates failed HEAD probes — this is the
+    # expected state since COB migrated BIRR distribution to the
+    # WordPress Download Manager plugin (~Q4 2025), which doesn't
+    # surface in /wp/v2/media. The endpoint now returns ~4 unrelated
+    # stale image PDFs that score above the threshold but 404 on
+    # fetch. The HTML fallback handles this correctly, so demote to
+    # INFO — operators only need a real warning if both strategies
+    # fail (the orchestrator logs that case at the caller level).
+    logger.info(
+        "COB WP REST API: %d scored candidates but none passed HEAD "
+        "probe (expected post-WPDM-migration; HTML fallback in use)",
         len(scored),
     )
     return None

--- a/backend/seeding/domains/economic_indicators/fetcher.py
+++ b/backend/seeding/domains/economic_indicators/fetcher.py
@@ -62,13 +62,23 @@ _WB_INDICATORS = {
         "round_digits": 1,
         "description": "Consumer price index (2010 = 100)",
     },
-    # Government revenue as % of GDP
-    "GC.REV.TOTL.GD.ZS": {
+    # Government revenue as % of GDP. The older code was
+    # "GC.REV.TOTL.GD.ZS" ("Revenue and grants %"), which the World
+    # Bank deprecated and now returns HTTP 200 with
+    # ``"Invalid value: The provided parameter value is not valid"``
+    # for any country query — that's what produced the
+    # "World Bank API returned no data for GC.REV.TOTL.GD.ZS"
+    # warning on every nightly run. The replacement
+    # ``GC.REV.XGRT.GD.ZS`` ("Revenue, excluding grants, % of GDP")
+    # is what fiscal analysts now use as the canonical
+    # revenue-to-GDP ratio. Returns valid Kenya data through 2023:
+    # 17.35%, 17.88%, 18.64% for 2021/2022/2023.
+    "GC.REV.XGRT.GD.ZS": {
         "indicator_type": "govt_revenue_pct_gdp",
         "unit": "percent",
         "divisor": 1,
         "round_digits": 1,
-        "description": "Government revenue % of GDP",
+        "description": "Government revenue (excl. grants) % of GDP",
     },
     # Government expenditure as % of GDP
     "GC.XPN.TOTL.GD.ZS": {


### PR DESCRIPTION
## Summary

The post-#84 seed run ([Actions 24969450865](https://github.com/Rodgers31/audit_app/actions/runs/24969450865)) is fully green but emits three WARNINGs that don't represent real failures. This PR quiets each — two with a real fix, one with a deliberate log-level demotion plus documentation.

### 1. `economic_indicators`: deprecated WB indicator → real fix

`GC.REV.TOTL.GD.ZS` ("Revenue and grants %") was deprecated by the World Bank and now returns HTTP 200 with `"Invalid value: The provided parameter value is not valid"` for any country query — that's what produced the *"World Bank API returned no data for GC.REV.TOTL.GD.ZS"* warning on every nightly run. Replace with `GC.REV.XGRT.GD.ZS` ("Revenue, excluding grants, % of GDP"), the modern canonical revenue-to-GDP series.

Verified: returns valid Kenya data through 2023 — 17.35% / 17.88% / 18.64% for FY 2021/22/23.

### 2. `counties_budget`: WP REST API HEAD-probe noise → log demotion

The WP REST API path returns 4 stale image PDFs that score above the keyword threshold but 404 on HEAD probe — the BIRR PDFs migrated to the WordPress Download Manager plugin in ~Q4 2025 (this is the same migration PR #78 addressed for HTML scraping) and no longer surface in `/wp/v2/media`. The HTML fallback handles this correctly so the WARNING was misleading. Demoted to INFO with an explanatory note.

### 3. `audits`: scanned-PDF OCR limitation → log demotion + documentation

OAG publishes its audit reports as scanned-image PDFs, so pdfplumber returns empty text and the live path produces zero findings. Two paths to actually fix this (both larger scope than this PR):

- **OCR pipeline** (pytesseract + pdf2image; needs `tesseract-ocr` + `poppler-utils` in CI). Significant runtime cost: OCR is ~2-5 s/page and an OAG report is 100+ pages.
- **JS-render per-category listings** with Playwright to find text-based PDFs in the `/national-government-audit-reports/` etc. pages — assumes any exist; not yet confirmed.

Both paths are documented in the module docstring as TODOs. For now the fixture is authoritative, so the "no findings" + "no extractable text" log lines drop from WARNING to INFO. Real exceptions (network, parsing) still WARN so a NEW failure mode (e.g. OAG site reorganisation) stays visible.

## Test plan

- [x] Full unit suite: **502 passed, 1 skipped** (no test changes).
- [x] Live probe of `GC.REV.XGRT.GD.ZS`: returns valid Kenya 2021-2023 percentages.
- [ ] Re-trigger the Actions seed workflow after merge — verify the three warnings are gone (only the "OAG fetch returned no findings" line remains, now at INFO level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)