### PR TITLE
fix(auth): surface password-update errors in reset-password form

### DIFF
--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -36,7 +36,12 @@ function ResetPasswordForm() {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
-  const [error, setError] = useState(linkError || '');
+  // Form-submit error only — the URL `?error=` param flows through
+  // its own UI branch below (see `linkError && !isAuthenticated`
+  // ternary). Don't seed this from linkError or the in-form error
+  // panel will show the URL leftover instead of the actual submit
+  // failure once the user starts interacting.
+  const [error, setError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
 
@@ -63,6 +68,13 @@ function ResetPasswordForm() {
         await updatePassword(password);
         setSuccess(true);
       } catch (err: any) {
+        // Surface the Supabase error verbatim when present — e.g.
+        // "New password should be different from the old password."
+        // for the same_password code. Console-log the full object so
+        // a future "spinner stuck, no message" report is debuggable
+        // from DevTools without round-tripping back to this fix.
+        // eslint-disable-next-line no-console
+        console.error('[reset-password] updatePassword failed', err);
         setError(
           err?.message ||
             'Failed to update password. The link may have expired — please request a new one.'
@@ -237,9 +249,18 @@ function ResetPasswordForm() {
                   )}
                 </div>
 
-                {/* Error */}
+                {/* Error — show whenever an in-form submit fails.
+                    Pre-fix this was gated on `!linkError`, which
+                    silently hid the actual same_password / weak-
+                    password error from Supabase whenever the URL
+                    still carried the original ``?error=`` token-
+                    exchange parameter. linkError gets its own
+                    dedicated UI branch above (the
+                    ``linkError && !isAuthenticated`` ternary), so
+                    once we're rendering the form, in-form errors
+                    are always meaningful. */}
                 <AnimatePresence>
-                  {error && !linkError && (
+                  {error && (
                     <motion.div
                       initial={{ opacity: 0, y: -8 }}
                       animate={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
## Summary

User reported a stuck-spinner UX bug on `/reset-password`:

> Entered a new password → Supabase returns 422 with `{"code":"same_password","message":"New password should be different from the old password."}` → button stays on the Loader2 spinner forever, no error message appears in the UI.

The submit handler's try/catch/finally chain in `page.tsx:52-87` was actually correct — the spinner does clear via `finally { setIsSubmitting(false) }`. The bug is **purely on the rendering side**: the error message was being suppressed by a stale UI gate, leaving the button apparently frozen because nothing visible changes.

## Two bugs

**1. Error display gate** ([page.tsx:242](frontend/app/reset-password/page.tsx#L242)):

```tsx
{error && !linkError && <error UI/>}   // ← !linkError suppresses it
```

The `linkError` reads from URL `?error=` (line 33). When set, the dedicated "expired link" UI branch at line 128-145 handles it. But that branch only fires when `!isAuthenticated`. If a user was authenticated AND landed with `?error=` in the URL (any redirect leftover), the form rendered — but every in-form submit error after that was hidden because `linkError` was still truthy.

Fix: drop the `!linkError` clause. The dedicated link-error branch above handles URL-passed errors; once we're rendering the form, in-form errors are unconditionally meaningful.

**2. Error state seeded from linkError** ([page.tsx:39](frontend/app/reset-password/page.tsx#L39)):

```ts
const [error, setError] = useState(linkError || '');
```

That meant the in-form error panel could briefly display the URL-leftover token-exchange message before the user typed anything. Initialise to empty string instead.

## Plus instrumentation

Added `console.error('[reset-password] updatePassword failed', err)` in the catch block, so any future "spinner stuck, no message" report is debuggable from DevTools without re-investigating from scratch.

## Test plan

- [x] TypeScript check (`tsc --noEmit`) — clean.
- [ ] Manual verification on Vercel preview: enter the same password as current → expect "New password should be different from the old password." in the red error panel (instead of stuck spinner).
- [ ] Manual verification: enter a weak password (<8 chars) → existing client-side validation still fires.
- [ ] Manual verification: enter a valid new password → existing success path still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)