### PR TITLE
fix(api): include NULL debt_category in debt-total filters

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -333,11 +333,27 @@ def _debt_loans_query(db, entity_filter):
     rows for any other purpose. Pass ``entity_filter`` as a SQL
     expression — single entity (``DBLoan.entity_id == eid``) or a set
     (``DBLoan.entity_id.in_(eids)``).
+
+    NULL handling matters here: ``loans.debt_category`` is nullable
+    (the model has a Python-side default of ``OTHER`` but the writer
+    can pass ``debt_category=None`` which overrides the default, and
+    older rows seeded before that default existed may also be NULL).
+    A naive ``debt_category != PENDING_BILLS`` filter silently drops
+    those rows — SQL's three-valued logic makes ``NULL != value``
+    evaluate to ``UNKNOWN``, treated as ``FALSE`` in WHERE. Mirror
+    :func:`_is_debt_loan`'s "NULL counts as debt" rule by explicitly
+    OR-ing in the ``IS NULL`` branch (Copilot review on PR #90
+    flagged this on the inline filter sites; baking it into the
+    helper keeps every future caller correct by default).
     """
     from models import DebtCategory as _DC
 
     return db.query(DBLoan).filter(
-        entity_filter, DBLoan.debt_category != _DC.PENDING_BILLS
+        entity_filter,
+        or_(
+            DBLoan.debt_category.is_(None),
+            DBLoan.debt_category != _DC.PENDING_BILLS,
+        ),
     )
 
 
@@ -1783,13 +1799,20 @@ async def get_country_summary(country_id: int):
                 _nat = db.query(DBEntity).filter(DBEntity.type == _ET.NATIONAL).first()
                 if _nat:
                     # Exclude PENDING_BILLS — see ``_is_debt_loan``.
+                    # NULL ``debt_category`` rows must still count as
+                    # debt (predicate's contract); see _debt_loans_query
+                    # for why a naive ``!=`` would silently drop them.
                     from models import DebtCategory as _DC
 
+                    _debt_category_filter = or_(
+                        DBLoan.debt_category.is_(None),
+                        DBLoan.debt_category != _DC.PENDING_BILLS,
+                    )
                     total_debt_result = (
                         db.query(func.sum(DBLoan.outstanding))
                         .filter(
                             DBLoan.entity_id == _nat.id,
-                            DBLoan.debt_category != _DC.PENDING_BILLS,
+                            _debt_category_filter,
                         )
                         .scalar()
                     )
@@ -1799,7 +1822,7 @@ async def get_country_summary(country_id: int):
                             db.query(func.sum(DBLoan.principal))
                             .filter(
                                 DBLoan.entity_id == _nat.id,
-                                DBLoan.debt_category != _DC.PENDING_BILLS,
+                                _debt_category_filter,
                             )
                             .scalar()
                             or 0
@@ -7040,15 +7063,20 @@ async def get_debt_timeline(db: Session = Depends(get_db)):
             )
             if national_entity:
                 # Reconcile against /debt/national, which excludes
-                # PENDING_BILLS — match that filter so the diff_pct
-                # below isn't dominated by a category mismatch.
+                # PENDING_BILLS — match that filter (including the
+                # NULL-counts-as-debt rule from ``_is_debt_loan``) so
+                # the diff_pct below isn't dominated by a category
+                # mismatch.
                 from models import DebtCategory as _DC
 
                 loan_sum = (
                     db.query(func.sum(DBLoan.outstanding))
                     .filter(
                         DBLoan.entity_id == national_entity.id,
-                        DBLoan.debt_category != _DC.PENDING_BILLS,
+                        or_(
+                            DBLoan.debt_category.is_(None),
+                            DBLoan.debt_category != _DC.PENDING_BILLS,
+                        ),
                     )
                     .scalar()
                     or 0
@@ -7256,12 +7284,18 @@ async def get_top_loans(limit: int = 10, db: Session = Depends(get_db)):
                 "source": "No national entity found — run seeder",
             }
 
-        # Query loans excluding pending bills, sorted by outstanding desc
+        # Query loans excluding pending bills, sorted by outstanding desc.
+        # NULL ``debt_category`` rows still count as debt (matches the
+        # ``_is_debt_loan`` predicate); a bare ``!=`` would silently
+        # drop them via SQL three-valued logic.
         loans = (
             db.query(DBLoan)
             .filter(
                 DBLoan.entity_id == national_entity.id,
-                DBLoan.debt_category != DebtCategory.PENDING_BILLS,
+                or_(
+                    DBLoan.debt_category.is_(None),
+                    DBLoan.debt_category != DebtCategory.PENDING_BILLS,
+                ),
             )
             .order_by(DBLoan.outstanding.desc())
             .all()
@@ -7367,12 +7401,18 @@ async def get_national_loans(db: Session = Depends(get_db)):
                 "last_updated": "",
             }
 
-        # Query all national loans (excluding pending bills)
+        # Query all national loans (excluding pending bills). NULL
+        # ``debt_category`` rows still count as debt — see the
+        # ``_is_debt_loan`` predicate; a bare ``!=`` would silently
+        # drop them via SQL three-valued logic.
         loans = (
             db.query(DBLoan)
             .filter(
                 DBLoan.entity_id == national_entity.id,
-                DBLoan.debt_category != DebtCategory.PENDING_BILLS,
+                or_(
+                    DBLoan.debt_category.is_(None),
+                    DBLoan.debt_category != DebtCategory.PENDING_BILLS,
+                ),
             )
             .order_by(DBLoan.outstanding.desc())
             .all()

--- a/backend/tests/test_budget_debt_fiscal.py
+++ b/backend/tests/test_budget_debt_fiscal.py
@@ -191,6 +191,97 @@ class TestDebtNational:
         response = client.get("/api/v1/debt/national")
         assert response.status_code == 200
 
+    def test_total_excludes_pending_bills_but_breakdown_reports_them(
+        self, client, db_session, seed_country, seed_source_doc
+    ):
+        """Headline totals must NOT include PENDING_BILLS rows, but the
+        per-category ``summary.pending_bills`` line must still report
+        them. PR #84 made the seeding writer actually persist 48
+        pending-bills rows into the ``loans`` table for the first
+        time, which exposed a latent bug at this aggregator: it was
+        summing every loan as debt and the displayed Total Debt KPI
+        jumped 11.8T → 13.59T (+702B = the per-row pending bills the
+        user confirmed via screen recording). This test pins the
+        post-fix behaviour so a future endpoint touching this code
+        path can't silently re-inflate the headline.
+        """
+        entity = Entity(
+            id=4090,
+            country_id=seed_country.id,
+            type=EntityType.NATIONAL,
+            canonical_name="National Government 4090",
+            slug="national-government-4090",
+        )
+        db_session.add(entity)
+        db_session.flush()
+
+        # Two real-debt loans + one pending-bills row + one NULL-
+        # category row. The NULL row is the second half of Copilot's
+        # review feedback on PR #90: SQL ``debt_category != X``
+        # silently drops NULL rows because of three-valued logic, so
+        # the helper now wraps the filter in
+        # ``or_(is_(None), != PENDING_BILLS)`` to keep NULLs in the
+        # debt total. Test would pass even with the broken filter if
+        # we omitted this row.
+        db_session.add_all(
+            [
+                Loan(
+                    entity_id=entity.id,
+                    lender="Test World Bank",
+                    debt_category=DebtCategory.EXTERNAL_MULTILATERAL,
+                    principal=1_000_000_000_000,
+                    outstanding=900_000_000_000,
+                    currency="KES",
+                    source_document_id=seed_source_doc.id,
+                    issue_date=datetime(2024, 1, 1),
+                ),
+                Loan(
+                    entity_id=entity.id,
+                    lender="Test Treasury Bonds",
+                    debt_category=DebtCategory.DOMESTIC_BONDS,
+                    principal=500_000_000_000,
+                    outstanding=480_000_000_000,
+                    currency="KES",
+                    source_document_id=seed_source_doc.id,
+                    issue_date=datetime(2023, 7, 1),
+                ),
+                Loan(
+                    entity_id=entity.id,
+                    lender="Test Pending Bills",
+                    debt_category=DebtCategory.PENDING_BILLS,
+                    principal=200_000_000_000,
+                    outstanding=200_000_000_000,
+                    currency="KES",
+                    source_document_id=seed_source_doc.id,
+                    issue_date=datetime(2024, 6, 30),
+                ),
+                Loan(
+                    entity_id=entity.id,
+                    lender="Test Legacy Untagged",
+                    debt_category=None,  # NULL — must still count as debt
+                    principal=50_000_000_000,
+                    outstanding=50_000_000_000,
+                    currency="KES",
+                    source_document_id=seed_source_doc.id,
+                    issue_date=datetime(2022, 1, 1),
+                ),
+            ]
+        )
+        db_session.commit()
+
+        body = client.get("/api/v1/debt/national").json()
+        data = body.get("data", body)
+
+        # Headline excludes the 200B pending-bills row; includes the
+        # 50B NULL-category row → total_outstanding = 900 + 480 + 50.
+        assert data["total_outstanding"] == 1_430_000_000_000
+        # Same shape on the ``total_debt`` (principal sum) field.
+        assert data["total_debt"] == 1_550_000_000_000  # 1000 + 500 + 50
+
+        # Per-category breakdown still reports the pending bills.
+        summary = data.get("summary", {})
+        assert summary.get("pending_bills") == 200_000_000_000
+
 
 class TestFiscalSummary:
     """Tests for GET /api/v1/fiscal/summary."""


### PR DESCRIPTION
## Summary

Follow-up to merged [#90](https://github.com/Rodgers31/audit_app/pull/90). Copilot review surfaced a real SQL three-valued-logic bug across all six ``debt_category != PENDING_BILLS`` filter sites in `main.py` — the fix landed on PR #90's branch as commit `f37695c` AFTER #90 was merged, so it's now branched off cleanly here.

## The bug

`loans.debt_category` is `nullable=True`. The model has a Python-side default of `OTHER`, but the writer can pass `debt_category=None` (which overrides the default) and older rows seeded before the default existed may also be NULL.

A bare `debt_category != PENDING_BILLS` filter silently drops those NULL rows because `NULL != value` evaluates to `UNKNOWN`, which is treated as `FALSE` in SQL `WHERE` clauses. That contradicts the [`_is_debt_loan` predicate](backend/main.py) which explicitly returns `True` for NULL — Python iteration totals and SQL aggregate totals would slowly drift apart.

## Fix

Wrap every SQL site in `or_(is_(None), != PENDING_BILLS)` to match the predicate's contract:

| Site | Note |
|---|---|
| `_debt_loans_query` helper | Bakes the convention into the helper so future callers can't drop it |
| `func.sum(DBLoan.outstanding)` aggregate (health-stat path) | New from PR #90 |
| `func.sum(DBLoan.principal)` fallback (same path) | New from PR #90 |
| Reconciliation `loan_sum` | New from PR #90 |
| `/api/v1/debt/loans` filter | **Pre-existing** site with same NULL bug — fixed for consistency |
| `/api/v1/debt/national-loans` filter | **Pre-existing** site with same NULL bug — fixed for consistency |

## Plus regression test (Copilot's #5)

New test in `tests/test_budget_debt_fiscal.py::TestDebtNational` seeds 4 loans:
- 1 EXTERNAL_MULTILATERAL (counts as debt)
- 1 DOMESTIC_BONDS (counts as debt)
- 1 PENDING_BILLS (excluded from debt total)
- 1 with `debt_category=None` (must still count as debt — the load-bearing piece)

Asserts:
- `total_outstanding` = 1.43T (excludes the 200B PENDING_BILLS, **includes the 50B NULL**)
- `summary.pending_bills` = 200B (still reported under its own line)

The NULL row is what makes this a real regression test — without it, the test would still pass against the broken `!=` filter.

## Test plan

- [x] Full unit suite: **503 passed, 1 skipped** (was 502 + 1 new regression test)
- [x] New test fails against the broken filter, passes against the fixed one (verified by toggling locally)
- [ ] Re-trigger Actions seed workflow after merge — verify `/api/v1/debt/national` `total_outstanding` matches what `_is_debt_loan` would compute via Python iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)