### PR TITLE
fix(auth): bump Supabase lockAcquireTimeout to 60s (fixes same_password race)

### DIFF
--- a/frontend/lib/supabase/client.ts
+++ b/frontend/lib/supabase/client.ts
@@ -3,12 +3,56 @@
  *
  * Use this in Client Components (`'use client'`).
  * It reads the public env vars set in `.env.local`.
+ *
+ * Why we override ``lockAcquireTimeout``
+ * --------------------------------------
+ * GoTrueClient defaults to 5s for the auth-lock acquisition timeout.
+ * On every auth call (``updateUser``, ``getSession``, ``refreshSession``
+ * …) the SDK acquires a navigator-LockManager lock. If that timeout
+ * fires while another holder is still in flight, the SDK assumes an
+ * orphaned lock (e.g. from React Strict Mode's double-mount) and
+ * recovers via ``navigator.locks.request(name, { steal: true })``,
+ * which forcefully releases the existing lock and runs the operation
+ * AGAIN on the new lock holder. See ``locks.js:163-206`` in
+ * @supabase/auth-js and supabase/supabase#42505.
+ *
+ * On real-world password resets the call regularly takes longer than
+ * 5s (token rotation + database round-trip + cold-start backend), so
+ * the steal-recovery kicks in mid-call and re-fires ``updateUser``.
+ * The first attempt actually succeeded — the password is changed —
+ * but the duplicate hits the API with the same body, gets back
+ * ``code: same_password`` ``message: New password should be
+ * different from the old password``, and the user sees a misleading
+ * error after their password actually changed. The original lock
+ * holder also surfaces "Lock broken by another request with the
+ * 'steal' option" in the console.
+ *
+ * Bump the timeout to 60s so a normal call has plenty of budget. The
+ * steal recovery is still in place if a lock is genuinely orphaned
+ * (it just won't fire on healthy slow calls). 60s also stays well
+ * under any reasonable user-perceived "this is hung, refresh"
+ * threshold.
  */
 import { createBrowserClient } from '@supabase/ssr';
 
 export function createClient() {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      // ``lockAcquireTimeout`` is a documented option on the
+      // underlying GoTrueClient (see
+      // node_modules/@supabase/auth-js/dist/module/lib/types.d.ts:119)
+      // but ``SupabaseClientOptions['auth']`` in supabase-js re-exports
+      // only a subset of those fields and omits this one. The runtime
+      // passes auth options straight through to GoTrueClient so the
+      // option works fine at runtime; we cast to satisfy the
+      // narrower public type. Tracking issue:
+      // https://github.com/supabase/supabase-js/issues — Supabase
+      // hasn't surfaced this in the public type yet.
+      auth: {
+        lockAcquireTimeout: 60_000, // 60 seconds (default 5s)
+      } as any,
+    }
   );
 }


### PR DESCRIPTION
## Summary

User reported the password-reset bug returning despite [PR #87](https://github.com/Rodgers31/audit_app/pull/87)'s three mitigations (UI rendering fix, ref-based double-submit gate, singleton client). Network panel reveals BOTH `/auth/v1/user` calls share the same initiator (`helpers.js:120`) — meaning the second call isn't from my form handler at all. It's from inside the Supabase SDK.

## Actual root cause

[`@supabase/auth-js/lib/locks.js:163-206`](https://github.com/supabase/auth-js/blob/main/src/lib/locks.ts) has a **lock-stealing recovery** path:

```js
// On AbortError after lockAcquireTimeout, the SDK assumes the lock
// is orphaned (e.g. from a React Strict Mode double-mount) and
// recovers via navigator.locks.request(name, { steal: true }) —
// which forcefully releases the original lock and RUNS THE
// OPERATION AGAIN under the new holder.
```

The default `lockAcquireTimeout` is **5 seconds** ([GoTrueClient.js:25](https://github.com/supabase/auth-js/blob/main/src/GoTrueClient.ts)). A real `updateUser` round-trip — token rotation + Supabase auth API + occasionally cold-start backend — routinely exceeds 5s. The SDK's "I bet this is orphaned" assumption fires on a perfectly healthy in-flight call and re-fires `updateUser` as a side effect.

Sequence:
1. T0: User submits, `updateUser` PUT starts
2. T1: 5s timeout fires, SDK steals the lock and re-runs the operation
3. T2: First PUT finishes — 200 OK, password changed ✓
4. T3: Stolen-lock retry's PUT finishes — **422 same_password** (because step T2 already changed the password to that value)
5. T4: Original holder surfaces "Lock broken by another request with the 'steal' option" in console

Tracking issue: [supabase/supabase#42505](https://github.com/supabase/supabase/issues/42505) — Supabase team's intended fix for React Strict Mode orphaned locks, but on real networks it fires on healthy slow calls.

## Fix

Bump `lockAcquireTimeout` to 60s in [lib/supabase/client.ts](frontend/lib/supabase/client.ts):

```ts
createBrowserClient(url, key, {
  auth: { lockAcquireTimeout: 60_000 },
})
```

The steal-recovery stays in place for genuinely orphaned locks (e.g. real React Strict Mode double-mounts in dev) — it just won't fire on slow-but-healthy 5-30s calls. 60s is still well under any user-perceived "page is hung" threshold.

## Type assertion note

`lockAcquireTimeout` is documented on `GoTrueClientOptions` (`node_modules/@supabase/auth-js/dist/module/lib/types.d.ts:119`) but omitted from supabase-js's narrower `SupabaseClientOptions['auth']` re-export. The runtime passes auth options straight through to GoTrueClient so the option works fine; cast to `any` to document the type-vs-runtime gap.

## Test plan

- [x] TypeScript: `tsc --noEmit` clean
- [x] Page loads in preview, debt total renders, no new console errors
- [ ] Manual on Vercel preview: trigger a real password reset → verify exactly ONE PUT /auth/v1/user fires (no duplicate, no `same_password`, no "Lock broken" trace)
- [ ] If preview validates, deploy to prod. The bug will only fully reproduce against the real Supabase auth API where calls actually take >5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)