### PR TITLE
fix(auth): block double-submit on reset-password (the missing PR #87 commit)

### DIFF
--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { Suspense, useCallback, useState } from 'react';
+import { Suspense, useCallback, useRef, useState } from 'react';
 
 /* ── Minimum password requirements ── */
 function getPasswordStrength(pw: string) {
@@ -44,6 +44,23 @@ function ResetPasswordForm() {
   const [error, setError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
+  // Synchronous ref-based gate to block double submission. The
+  // ``isSubmitting`` state alone isn't enough: ``setIsSubmitting(true)``
+  // is async, so a fast double-tap (or the iOS quick-tap that fires
+  // both touchstart-derived and click events) slips past the
+  // button's ``disabled`` flag before React re-renders, and BOTH
+  // submits race in supabase.auth.updateUser. The first changes the
+  // password successfully; the second hits the API with the same
+  // body and returns ``code: same_password`` because the password
+  // is already this value. Net effect for the user: their password
+  // DID change, but they see a misleading "should be different"
+  // error and have to retry-and-fail to realise it's done.
+  //
+  // This guard was originally landed in PR #87 but only that PR's
+  // first commit (UI rendering fix) actually merged — the followup
+  // commits including this gate sat on the closed branch. Bringing
+  // it back here so it actually ships.
+  const submittingRef = useRef(false);
 
   const strength = getPasswordStrength(password);
   const allMet = strength.every((c) => c.met);
@@ -52,6 +69,14 @@ function ResetPasswordForm() {
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
+
+      // Hard-stop if a previous submit is still in flight. The ref
+      // mutates synchronously (unlike ``isSubmitting``'s state
+      // update) so it blocks the second event of a fast double-tap
+      // before either submit reaches updateUser. See ref's defining
+      // comment for the full failure mode this guards against.
+      if (submittingRef.current) return;
+
       setError('');
 
       if (!allMet) {
@@ -63,6 +88,7 @@ function ResetPasswordForm() {
         return;
       }
 
+      submittingRef.current = true;
       setIsSubmitting(true);
       try {
         await updatePassword(password);
@@ -80,6 +106,7 @@ function ResetPasswordForm() {
             'Failed to update password. The link may have expired — please request a new one.'
         );
       } finally {
+        submittingRef.current = false;
         setIsSubmitting(false);
       }
     },


### PR DESCRIPTION
## Summary

User is **still seeing the double-call bug** on production. Two parallel ``PUT /auth/v1/user`` calls fire on every reset-password submit, the first succeeds, the second returns ``code: same_password``, and the user sees a misleading ``"New password should be different"`` error even though the password actually changed.

Root cause was already diagnosed but the fix never shipped:

- PR #87 (Apr 27 ~05:30 UTC): I claimed three commits landed but the merge happened at the FIRST commit only — the rendering fix landed; the ref-gate (`8b84472`) and the singleton client (`cf71c0c`) sat on the closed branch.
- PR #92 (Apr 28 ~01:30 UTC): I added the ref-gate again on top of the lock-timeout. The merge happened at the FIRST commit again — the lock-timeout landed; the ref-gate (`a595585`) is once more on the closed branch.

This PR is **just the ref-gate, alone, on a fresh branch** so the merge button can't pick it up before the actual fix.

## What it does

- ``submittingRef = useRef(false)`` — synchronous, mutates immediately (unlike ``setIsSubmitting(true)`` which queues for the next render).
- ``if (submittingRef.current) return`` at the top of ``handleSubmit`` — blocks the second event before either submit reaches ``updateUser``.
- Set/reset in lockstep with the try/finally so the gate tracks the actual in-flight call.

## Why the bug exists in the first place

The button's ``disabled={isSubmitting || …}`` flag depends on a ``setIsSubmitting(true)`` state update which is async. A fast double-tap (or iOS touchstart→click duplication, or any rapid-fire double event) slips past the disabled gate before React re-renders, and both events reach ``handleSubmit`` → both reach ``supabase.auth.updateUser``. User-confirmed: first call completes in ~391ms, well below the SDK's 5s lock-acquire timeout, so this is NOT a timing/lock-recovery issue — it's literally two onSubmit invocations.

## Test plan

- [x] TypeScript check on frontend — clean.
- [ ] Manual verification on production after merge: submit form → expect exactly **one** ``PUT /auth/v1/user`` in DevTools Network tab → expect green success page (CheckCircle2 + "Go to Homepage" button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)