### PR TITLE
fix(auth): never auto-login on password-reset link click

### DIFF
--- a/frontend/app/api/auth/reset-password/route.ts
+++ b/frontend/app/api/auth/reset-password/route.ts
@@ -1,0 +1,120 @@
+/**
+ * POST /api/auth/reset-password
+ *
+ * Atomic password-reset endpoint that intentionally avoids ever
+ * persisting a session in the user's browser. Inputs:
+ *
+ *   { code: string, password: string }
+ *
+ * where ``code`` is the PKCE code Supabase forwarded to /auth/callback
+ * (passed through to /reset-password as a query param without being
+ * exchanged — see app/auth/callback/route.ts for that decision).
+ *
+ * Why it lives here instead of being done client-side
+ * ---------------------------------------------------
+ * Doing the exchange + updateUser on the client (via the @supabase/ssr
+ * browser client) writes session cookies the moment the exchange
+ * succeeds, which:
+ *
+ *   1. Logs the user into the app while they're mid-reset (the
+ *      "click email link, find myself signed in" UX surprise the
+ *      user flagged on PR #95 and again afterwards).
+ *   2. Starts the GoTrueClient's ``_autoRefreshTokenTick`` running on
+ *      a 30s interval, fighting ``updateUser`` for the gotrue Web
+ *      Lock — the actual cause of the duplicate ``PUT /auth/v1/user``
+ *      → ``code: same_password`` error we've been chasing across
+ *      PRs #87, #92, #93, #94, #95.
+ *
+ * The fix is to do the whole exchange→update→signOut sequence on the
+ * server with a custom cookie adapter that READS the request's
+ * ``sb-...-code-verifier`` cookie (set by the browser when it called
+ * ``resetPasswordForEmail``) but DOES NOT write anything back. The
+ * Supabase server client thinks it's setting cookies; we silently drop
+ * them. So no session cookie ever reaches the browser, the auto-refresh
+ * tick never starts, and the user ends the flow unauthenticated and is
+ * prompted to sign in fresh with their new password.
+ */
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  let body: { code?: unknown; password?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
+
+  const code = typeof body.code === 'string' ? body.code : null;
+  const password = typeof body.password === 'string' ? body.password : null;
+
+  if (!code) {
+    return NextResponse.json(
+      { error: 'Missing or invalid reset code. Please request a new reset link.' },
+      { status: 400 }
+    );
+  }
+  if (!password || password.length < 8) {
+    return NextResponse.json(
+      { error: 'Password must be at least 8 characters.' },
+      { status: 400 }
+    );
+  }
+
+  const cookieStore = await cookies();
+
+  // Read-only cookie adapter. ``getAll`` lets the SDK read the
+  // ``sb-...-code-verifier`` cookie it needs to validate the PKCE
+  // code; ``setAll`` is intentionally a no-op so any session cookies
+  // the SDK tries to write during the exchange are silently dropped.
+  // Net effect: the server can complete the exchange and updateUser,
+  // but the browser's cookie jar is never touched.
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => cookieStore.getAll(),
+        setAll: () => {
+          // intentional no-op: see file-level comment about why we
+          // refuse to write any auth cookies to the response.
+        },
+      },
+    }
+  );
+
+  // 1. Exchange the recovery code for an in-memory session.
+  const { data: exchangeData, error: exchangeError } =
+    await supabase.auth.exchangeCodeForSession(code);
+
+  if (exchangeError || !exchangeData.session) {
+    return NextResponse.json(
+      {
+        error:
+          exchangeError?.message ??
+          'The reset link is invalid or has expired. Please request a new one.',
+      },
+      { status: 400 }
+    );
+  }
+
+  // 2. Update the password using the in-memory session.
+  const { error: updateError } = await supabase.auth.updateUser({ password });
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: updateError.message ?? 'Failed to update password.' },
+      { status: 400 }
+    );
+  }
+
+  // 3. Sign out for tidiness — invalidates the just-issued refresh
+  // token server-side. No-op for the browser since we never wrote
+  // any cookies, but it keeps the Supabase auth state clean.
+  await supabase.auth.signOut().catch(() => {
+    /* best-effort cleanup; the password update already succeeded */
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/app/api/auth/reset-password/route.ts
+++ b/frontend/app/api/auth/reset-password/route.ts
@@ -64,6 +64,18 @@ export async function POST(request: Request) {
 
   const cookieStore = await cookies();
 
+  // Diagnostic: log cookie names received so a future
+  // ``AuthPKCECodeVerifierMissingError`` is debuggable from the dev
+  // server log without re-instrumenting. Values are deliberately not
+  // logged (verifier is sensitive). Names alone tell us whether the
+  // browser sent the verifier cookie with this request.
+  const cookieNames = cookieStore.getAll().map((c) => c.name);
+  // eslint-disable-next-line no-console
+  console.log(
+    `[api/auth/reset-password] received ${cookieNames.length} cookie(s)`,
+    cookieNames.filter((n) => n.startsWith('sb-'))
+  );
+
   // Read-only cookie adapter. ``getAll`` lets the SDK read the
   // ``sb-...-code-verifier`` cookie it needs to validate the PKCE
   // code; ``setAll`` is intentionally a no-op so any session cookies

--- a/frontend/app/auth/callback/route.ts
+++ b/frontend/app/auth/callback/route.ts
@@ -9,45 +9,44 @@
  * Special case: password recovery
  * -------------------------------
  * For the password-reset flow (``next=/reset-password``) we deliberately
- * DO NOT exchange the code here, AND we also clear any pre-existing
- * session cookies the browser already has. There are two distinct ways
- * a user can end up looking signed-in on /reset-password, and both
- * needed to be handled:
+ * DO NOT exchange the code here, AND we forward it under a renamed
+ * query parameter so the browser SDK can't auto-exchange it either.
+ * Three things conspire to make naive approaches fail, and all three
+ * have to be defeated:
  *
- *   1. ``exchangeCodeForSession`` would create a fresh session for THIS
- *      click. We skip that — the code is forwarded to the page as a
- *      query param and only exchanged server-side at form-submit time
- *      (see /api/auth/reset-password/route.ts), with a read-only cookie
- *      adapter so even that exchange leaks no cookies to the browser.
+ *   1. ``exchangeCodeForSession`` here would create a fresh session
+ *      via Set-Cookie. So we skip the server exchange.
  *
- *   2. The user might already be signed in from an unrelated prior
- *      login on this device — e.g. they logged in last week, never
- *      signed out, and now click a reset link. ``getSession()`` in
- *      AuthProvider would happily restore that session from cookies
- *      and the page would render as if they're signed in.
+ *   2. ``createBrowserClient`` runs with ``detectSessionInUrl: true``
+ *      and ``flowType: 'pkce'`` (set by @supabase/ssr defaults). On
+ *      every page load the SDK's ``_initialize()`` checks
+ *      ``_isPKCECallback(params)`` — which returns true if there is
+ *      both a ``?code=`` URL param AND a ``-code-verifier`` cookie.
+ *      When it returns true the SDK fires
+ *      ``_exchangeCodeForSession`` itself, from the browser, ending
+ *      up exactly where we started: a fresh session created behind
+ *      our back. The user reported the matching
+ *      ``POST /auth/v1/token?grant_type=pkce`` showing up in their
+ *      Network panel. To bypass this we forward the code under the
+ *      query parameter name ``recovery`` instead of ``code``. The
+ *      SDK looks for ``code`` specifically; ``recovery`` is invisible
+ *      to it. The page reads ``recovery`` and POSTs it as ``code``
+ *      to /api/auth/reset-password where the server-side
+ *      ``createServerClient`` runs with ``detectSessionInUrl: false``
+ *      and won't auto-exchange.
  *
- * Why we clear cookies manually instead of calling ``signOut()``
- * --------------------------------------------------------------
- * An earlier version of this handler called ``supabase.auth.signOut()``
- * to clear (1)'s session. In theory the SDK's ``signOut`` only removes
- * the ``sb-<ref>-auth-token`` cookie via its ``-auth-token`` storage
- * key, leaving the ``-code-verifier`` cookie alone. In practice users
- * reported ``AuthPKCECodeVerifierMissingError`` on the next form
- * submit — somehow the verifier was being lost between this handler
- * and /api/auth/reset-password.
+ *   3. The user might already be signed in from an unrelated prior
+ *      login on this device. ``AuthProvider``'s ``getSession()``
+ *      restores that session from cookies regardless of the URL.
+ *      We clear those session cookies (auth-token + chunked
+ *      variants) directly here. The clear regex is tight enough to
+ *      leave the ``-code-verifier`` cookie alone — it's needed by
+ *      the form-submit exchange:
  *
- * Rather than chase that side effect through the SSR/auth-js cookie
- * abstraction, we now clear cookies directly with a regex tight
- * enough to match ONLY the session cookies:
+ *          /-auth-token(\.\d+)?$/
  *
- *     /-auth-token(\.\d+)?$/
- *
- * This matches ``sb-<ref>-auth-token`` and any chunked variants like
- * ``sb-<ref>-auth-token.0``, ``sb-<ref>-auth-token.1``, … but does
- * NOT match ``sb-<ref>-auth-token-code-verifier`` (which ends in
- * ``-code-verifier``, not ``-auth-token`` or ``-auth-token.<n>``).
- * The verifier survives, the form-submit exchange can find it, and
- * the user lands on the page unauthenticated.
+ *      Matches ``sb-<ref>-auth-token`` / ``…auth-token.0`` / ``.1``
+ *      etc. but NOT ``sb-<ref>-auth-token-code-verifier``.
  *
  * Other flows (email confirmation, magic-link sign-in) keep the
  * existing exchange-and-redirect behaviour because they DO want a
@@ -86,8 +85,12 @@ export async function GET(request: Request) {
     // code-verifier cookie is intentionally left alone — the
     // form-submit exchange in /api/auth/reset-password needs it.
     if (next === '/reset-password') {
+      // CRITICAL: forward the code under a renamed query param.
+      // ``?code=`` would be auto-exchanged by the browser SDK on
+      // page mount (see file-level comment); ``?recovery=`` is
+      // invisible to the SDK's PKCE-callback detection.
       const response = NextResponse.redirect(
-        `${origin}/reset-password?code=${encodeURIComponent(code)}`
+        `${origin}/reset-password?recovery=${encodeURIComponent(code)}`
       );
 
       const cookieStore = await cookies();

--- a/frontend/app/auth/callback/route.ts
+++ b/frontend/app/auth/callback/route.ts
@@ -3,8 +3,30 @@
  *
  * When a user clicks any Supabase-generated email link (password reset,
  * magic-link, email confirmation), Supabase appends a `code` query
- * parameter. This route exchanges the code for a session, then
- * redirects to the intended destination (e.g. /reset-password).
+ * parameter. This route normally exchanges the code for a session, then
+ * redirects to the intended destination.
+ *
+ * Special case: password recovery
+ * -------------------------------
+ * For the password-reset flow (``next=/reset-password``) we deliberately
+ * DO NOT exchange the code here. Exchanging would write Supabase auth
+ * cookies and the user would land on /reset-password already logged in
+ * — which is what produced the "click email link, get auto-logged-in"
+ * behaviour the user flagged on PR #95, and is the underlying source of
+ * the duplicate ``PUT /auth/v1/user`` lock contention (the SDK's
+ * ``_autoRefreshTokenTick`` starts running the moment a session exists).
+ *
+ * Instead, we forward the code to /reset-password as a query param.
+ * The page itself never logs the user in: when they submit the form,
+ * a server-side route (``/api/auth/reset-password``) does the exchange,
+ * the password update, and the sign-out atomically with a read-only
+ * cookie adapter, so no auth cookies ever reach the browser. The user
+ * stays unauthenticated end-to-end and has to log in afterwards with
+ * their new password.
+ *
+ * Other flows (email confirmation, magic-link sign-in) keep the
+ * existing exchange-and-redirect behaviour because they DO want a
+ * session to be established.
  */
 import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
@@ -16,6 +38,16 @@ export async function GET(request: Request) {
   const next = searchParams.get('next') ?? '/';
 
   if (code) {
+    // Recovery flow: forward the code without creating a session.
+    // The reset-password page will POST it to /api/auth/reset-password
+    // along with the new password, and that endpoint does the exchange
+    // server-side without leaking cookies back to the browser.
+    if (next === '/reset-password') {
+      return NextResponse.redirect(
+        `${origin}/reset-password?code=${encodeURIComponent(code)}`
+      );
+    }
+
     const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
 

--- a/frontend/app/auth/callback/route.ts
+++ b/frontend/app/auth/callback/route.ts
@@ -9,27 +9,37 @@
  * Special case: password recovery
  * -------------------------------
  * For the password-reset flow (``next=/reset-password``) we deliberately
- * DO NOT exchange the code here. Exchanging would write Supabase auth
- * cookies and the user would land on /reset-password already logged in
- * — which is what produced the "click email link, get auto-logged-in"
- * behaviour the user flagged on PR #95, and is the underlying source of
- * the duplicate ``PUT /auth/v1/user`` lock contention (the SDK's
- * ``_autoRefreshTokenTick`` starts running the moment a session exists).
+ * DO NOT exchange the code here, AND we also clear any pre-existing
+ * session cookies the browser already has. There are two distinct ways
+ * a user can end up looking signed-in on /reset-password, and both
+ * needed to be handled:
  *
- * Instead, we forward the code to /reset-password as a query param.
- * The page itself never logs the user in: when they submit the form,
- * a server-side route (``/api/auth/reset-password``) does the exchange,
- * the password update, and the sign-out atomically with a read-only
- * cookie adapter, so no auth cookies ever reach the browser. The user
- * stays unauthenticated end-to-end and has to log in afterwards with
- * their new password.
+ *   1. ``exchangeCodeForSession`` would create a fresh session for THIS
+ *      click. We skip that — the code is forwarded to the page as a
+ *      query param and only exchanged server-side at form-submit time
+ *      (see /api/auth/reset-password/route.ts), with a read-only cookie
+ *      adapter so even that exchange leaks no cookies to the browser.
+ *
+ *   2. The user might already be signed in from an unrelated prior
+ *      login on this device — e.g. they logged in last week, never
+ *      signed out, and now click a reset link. ``getSession()`` in
+ *      AuthProvider would happily restore that session from cookies
+ *      and the page would render as if they're signed in. We fix
+ *      this by calling ``signOut()`` here, which clears the auth-token
+ *      cookie via the SSR client. The PKCE ``code-verifier`` cookie is
+ *      preserved (it's needed by the form-submit exchange), and the
+ *      cleared cookies are explicitly attached to the redirect response
+ *      so the Set-Cookie headers actually reach the browser.
  *
  * Other flows (email confirmation, magic-link sign-in) keep the
  * existing exchange-and-redirect behaviour because they DO want a
  * session to be established.
  */
-import { createClient } from '@/lib/supabase/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+
+import { createClient } from '@/lib/supabase/server';
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
@@ -37,15 +47,60 @@ export async function GET(request: Request) {
   const code = searchParams.get('code');
   const next = searchParams.get('next') ?? '/';
 
+  // Server log so anyone running ``npm run dev`` can verify which
+  // branch this handler took. The "stuck on the old behaviour"
+  // reports we kept getting were almost always "the dev server is
+  // serving stale code"; this log makes that immediately obvious.
+  // eslint-disable-next-line no-console
+  console.log(
+    `[auth/callback] hit — code=${code ? 'present' : 'missing'} next=${next}`
+  );
+
   if (code) {
-    // Recovery flow: forward the code without creating a session.
-    // The reset-password page will POST it to /api/auth/reset-password
-    // along with the new password, and that endpoint does the exchange
-    // server-side without leaking cookies back to the browser.
+    // Recovery flow: forward the code without creating a new session,
+    // AND clear any pre-existing session so the user lands on the
+    // form unauthenticated.
     if (next === '/reset-password') {
-      return NextResponse.redirect(
+      // Build a redirect response up-front so we can mutate its
+      // cookies directly. We do this via the SSR client's ``setAll``
+      // adapter, which writes to ``response.cookies`` instead of
+      // request-scoped ``cookies()`` — that's the reliable way to
+      // get Set-Cookie headers attached to a NextResponse.redirect.
+      const response = NextResponse.redirect(
         `${origin}/reset-password?code=${encodeURIComponent(code)}`
       );
+
+      const cookieStore = await cookies();
+      const supabase = createServerClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        {
+          cookies: {
+            getAll: () => cookieStore.getAll(),
+            setAll: (cookiesToSet) => {
+              cookiesToSet.forEach(({ name, value, options }) => {
+                response.cookies.set(name, value, options);
+              });
+            },
+          },
+        }
+      );
+
+      // Best-effort: signOut hits Supabase's ``DELETE /logout`` to
+      // invalidate the session server-side, and clears the
+      // auth-token cookie via setAll above. If the user has no
+      // active session, this errors silently — that's fine, we
+      // just want the cleared-cookie side effect.
+      await supabase.auth.signOut().catch((err) => {
+        // eslint-disable-next-line no-console
+        console.warn('[auth/callback] recovery signOut failed', err);
+      });
+
+      // eslint-disable-next-line no-console
+      console.log(
+        '[auth/callback] recovery flow: cleared session, forwarding code to /reset-password'
+      );
+      return response;
     }
 
     const supabase = await createClient();

--- a/frontend/app/auth/callback/route.ts
+++ b/frontend/app/auth/callback/route.ts
@@ -24,22 +24,45 @@
  *      login on this device — e.g. they logged in last week, never
  *      signed out, and now click a reset link. ``getSession()`` in
  *      AuthProvider would happily restore that session from cookies
- *      and the page would render as if they're signed in. We fix
- *      this by calling ``signOut()`` here, which clears the auth-token
- *      cookie via the SSR client. The PKCE ``code-verifier`` cookie is
- *      preserved (it's needed by the form-submit exchange), and the
- *      cleared cookies are explicitly attached to the redirect response
- *      so the Set-Cookie headers actually reach the browser.
+ *      and the page would render as if they're signed in.
+ *
+ * Why we clear cookies manually instead of calling ``signOut()``
+ * --------------------------------------------------------------
+ * An earlier version of this handler called ``supabase.auth.signOut()``
+ * to clear (1)'s session. In theory the SDK's ``signOut`` only removes
+ * the ``sb-<ref>-auth-token`` cookie via its ``-auth-token`` storage
+ * key, leaving the ``-code-verifier`` cookie alone. In practice users
+ * reported ``AuthPKCECodeVerifierMissingError`` on the next form
+ * submit — somehow the verifier was being lost between this handler
+ * and /api/auth/reset-password.
+ *
+ * Rather than chase that side effect through the SSR/auth-js cookie
+ * abstraction, we now clear cookies directly with a regex tight
+ * enough to match ONLY the session cookies:
+ *
+ *     /-auth-token(\.\d+)?$/
+ *
+ * This matches ``sb-<ref>-auth-token`` and any chunked variants like
+ * ``sb-<ref>-auth-token.0``, ``sb-<ref>-auth-token.1``, … but does
+ * NOT match ``sb-<ref>-auth-token-code-verifier`` (which ends in
+ * ``-code-verifier``, not ``-auth-token`` or ``-auth-token.<n>``).
+ * The verifier survives, the form-submit exchange can find it, and
+ * the user lands on the page unauthenticated.
  *
  * Other flows (email confirmation, magic-link sign-in) keep the
  * existing exchange-and-redirect behaviour because they DO want a
  * session to be established.
  */
-import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 import { createClient } from '@/lib/supabase/server';
+
+// Matches ``sb-<anything>-auth-token`` and chunked variants
+// ``sb-<anything>-auth-token.0`` / ``.1`` / ... but explicitly NOT
+// ``sb-<anything>-auth-token-code-verifier``. See the file-level
+// comment for why this distinction matters.
+const SESSION_COOKIE_TAIL = /-auth-token(\.\d+)?$/;
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
@@ -58,47 +81,36 @@ export async function GET(request: Request) {
 
   if (code) {
     // Recovery flow: forward the code without creating a new session,
-    // AND clear any pre-existing session so the user lands on the
-    // form unauthenticated.
+    // AND clear any pre-existing session-cookie chunks so AuthProvider
+    // doesn't restore a stale session on /reset-password mount. The
+    // code-verifier cookie is intentionally left alone — the
+    // form-submit exchange in /api/auth/reset-password needs it.
     if (next === '/reset-password') {
-      // Build a redirect response up-front so we can mutate its
-      // cookies directly. We do this via the SSR client's ``setAll``
-      // adapter, which writes to ``response.cookies`` instead of
-      // request-scoped ``cookies()`` — that's the reliable way to
-      // get Set-Cookie headers attached to a NextResponse.redirect.
       const response = NextResponse.redirect(
         `${origin}/reset-password?code=${encodeURIComponent(code)}`
       );
 
       const cookieStore = await cookies();
-      const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-        {
-          cookies: {
-            getAll: () => cookieStore.getAll(),
-            setAll: (cookiesToSet) => {
-              cookiesToSet.forEach(({ name, value, options }) => {
-                response.cookies.set(name, value, options);
-              });
-            },
-          },
+      const cleared: string[] = [];
+      cookieStore.getAll().forEach(({ name }) => {
+        if (name.startsWith('sb-') && SESSION_COOKIE_TAIL.test(name)) {
+          // Set with empty value + maxAge 0 to delete. Path must
+          // match the path the cookie was originally set with
+          // (DEFAULT_COOKIE_OPTIONS in @supabase/ssr uses '/').
+          response.cookies.set(name, '', {
+            maxAge: 0,
+            path: '/',
+            sameSite: 'lax',
+          });
+          cleared.push(name);
         }
-      );
-
-      // Best-effort: signOut hits Supabase's ``DELETE /logout`` to
-      // invalidate the session server-side, and clears the
-      // auth-token cookie via setAll above. If the user has no
-      // active session, this errors silently — that's fine, we
-      // just want the cleared-cookie side effect.
-      await supabase.auth.signOut().catch((err) => {
-        // eslint-disable-next-line no-console
-        console.warn('[auth/callback] recovery signOut failed', err);
       });
 
       // eslint-disable-next-line no-console
       console.log(
-        '[auth/callback] recovery flow: cleared session, forwarding code to /reset-password'
+        `[auth/callback] recovery flow: forwarding code, cleared ${cleared.length} session cookie(s)${
+          cleared.length ? ' [' + cleared.join(', ') + ']' : ''
+        }`
       );
       return response;
     }

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -28,7 +28,7 @@ function getPasswordStrength(pw: string) {
 }
 
 function ResetPasswordForm() {
-  const { updatePassword, isAuthenticated, isLoading: authLoading } = useAuth();
+  const { updatePassword, logout, isAuthenticated, isLoading: authLoading } = useAuth();
   const searchParams = useSearchParams();
   const linkError = searchParams.get('error');
 
@@ -93,6 +93,37 @@ function ResetPasswordForm() {
       try {
         await updatePassword(password);
         setSuccess(true);
+        // Sign the user out as soon as the password is updated.
+        //
+        // Why: Supabase's PKCE recovery link auto-logs the user in
+        // (see /auth/callback/route.ts → exchangeCodeForSession),
+        // because the SDK needs an active session to call
+        // ``updateUser({password})``. Once the password change is
+        // committed we no longer need that session — and keeping it
+        // means:
+        //
+        //   1. UX surprise: clicking a "reset password" email
+        //      silently logs the user into the app, which the user
+        //      flagged as confusing/wrong.
+        //   2. Background lock contention: the SDK's
+        //      ``_autoRefreshTokenTick`` keeps running on a 30s
+        //      interval as long as the session is active, fighting
+        //      for the same gotrue Web Lock that ``updateUser``
+        //      uses. Under HMR or prior contamination this is what
+        //      was producing the duplicate ``PUT /auth/v1/user``
+        //      → ``code: same_password`` error.
+        //
+        // Signing out here cancels the auto-refresh tick and
+        // forces an explicit re-login with the new password. We
+        // don't ``await`` it: the success UI is the user's signal
+        // that the password change worked, and the sign-out is a
+        // cleanup step; surfacing a sign-out error here would just
+        // confuse the user mid-celebration. If sign-out fails the
+        // session simply expires on its own.
+        logout().catch((err) => {
+          // eslint-disable-next-line no-console
+          console.warn('[reset-password] post-update sign-out failed', err);
+        });
       } catch (err: any) {
         // Surface the Supabase error verbatim when present — e.g.
         // "New password should be different from the old password."
@@ -110,7 +141,7 @@ function ResetPasswordForm() {
         setIsSubmitting(false);
       }
     },
-    [password, confirmPassword, allMet, passwordsMatch, updatePassword]
+    [password, confirmPassword, allMet, passwordsMatch, updatePassword, logout]
   );
 
   // If auth is still loading, show spinner
@@ -141,7 +172,7 @@ function ResetPasswordForm() {
             </h1>
             <p className='text-white/60 text-sm mt-2'>
               {success
-                ? 'Your password has been reset successfully.'
+                ? "You've been signed out. Sign in with your new password to continue."
                 : 'Enter your new password below. Make it strong and unique.'}
             </p>
           </div>
@@ -155,12 +186,13 @@ function ResetPasswordForm() {
                 className='text-center'>
                 <CheckCircle2 className='w-16 h-16 mx-auto text-gov-sage mb-4' />
                 <p className='text-gov-forest/70 text-sm mb-6'>
-                  You can now sign in with your new password. Your account is secure.
+                  Your password has been changed and you&apos;ve been signed out for security. Head
+                  back to the homepage and sign in with your new password.
                 </p>
                 <Link
                   href='/'
                   className='inline-flex items-center gap-2 px-6 py-3 bg-gov-sage text-white font-semibold rounded-xl hover:bg-gov-sage/90 transition-colors shadow-md'>
-                  Go to Homepage
+                  Sign in with new password
                   <ArrowRight className='w-4 h-4' />
                 </Link>
               </motion.div>

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -28,9 +28,16 @@ function getPasswordStrength(pw: string) {
 }
 
 function ResetPasswordForm() {
-  const { updatePassword, logout, isAuthenticated, isLoading: authLoading } = useAuth();
+  const { logout, isAuthenticated, isLoading: authLoading } = useAuth();
   const searchParams = useSearchParams();
   const linkError = searchParams.get('error');
+  // PKCE recovery code, forwarded by /auth/callback without being
+  // exchanged. Submitting the form POSTs this to
+  // /api/auth/reset-password where the exchange + password update +
+  // sign-out all happen server-side without ever creating a client
+  // session. See app/auth/callback/route.ts and the API route file
+  // for the full reasoning.
+  const recoveryCode = searchParams.get('code');
 
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -88,50 +95,61 @@ function ResetPasswordForm() {
         return;
       }
 
+      if (!recoveryCode) {
+        setError('Reset link is missing its verification code. Please request a new one.');
+        return;
+      }
+
       submittingRef.current = true;
       setIsSubmitting(true);
       try {
-        await updatePassword(password);
+        // Server-side endpoint exchanges the PKCE code, updates the
+        // password, and signs out — all in one request, with a
+        // read-only cookie adapter so no auth cookies ever reach
+        // the browser. See app/api/auth/reset-password/route.ts.
+        // This replaces the previous client-side
+        // ``supabase.auth.updateUser({ password })`` flow, which
+        // unavoidably ran the GoTrueClient's auto-refresh tick
+        // alongside the update and produced the duplicate
+        // ``PUT /auth/v1/user`` → ``same_password`` error chain.
+        const res = await fetch('/api/auth/reset-password', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code: recoveryCode, password }),
+        });
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(
+            body.error ||
+              'Failed to update password. The link may have expired — please request a new one.'
+          );
+        }
+
         setSuccess(true);
-        // Sign the user out as soon as the password is updated.
-        //
-        // Why: Supabase's PKCE recovery link auto-logs the user in
-        // (see /auth/callback/route.ts → exchangeCodeForSession),
-        // because the SDK needs an active session to call
-        // ``updateUser({password})``. Once the password change is
-        // committed we no longer need that session — and keeping it
-        // means:
-        //
-        //   1. UX surprise: clicking a "reset password" email
-        //      silently logs the user into the app, which the user
-        //      flagged as confusing/wrong.
-        //   2. Background lock contention: the SDK's
-        //      ``_autoRefreshTokenTick`` keeps running on a 30s
-        //      interval as long as the session is active, fighting
-        //      for the same gotrue Web Lock that ``updateUser``
-        //      uses. Under HMR or prior contamination this is what
-        //      was producing the duplicate ``PUT /auth/v1/user``
-        //      → ``code: same_password`` error.
-        //
-        // Signing out here cancels the auto-refresh tick and
-        // forces an explicit re-login with the new password. We
-        // don't ``await`` it: the success UI is the user's signal
-        // that the password change worked, and the sign-out is a
-        // cleanup step; surfacing a sign-out error here would just
-        // confuse the user mid-celebration. If sign-out fails the
-        // session simply expires on its own.
+
+        // If the user happened to already be signed in (e.g. they
+        // reset their own password while still in a logged-in
+        // tab, or they're signed in as a different account), the
+        // server only invalidated *that user's* session in the
+        // recovery flow — the existing browser cookies are
+        // untouched. Sign out client-side to guarantee a clean
+        // "log back in with your new password" experience. This
+        // is best-effort; we don't surface failures because the
+        // password change itself already succeeded.
         logout().catch((err) => {
           // eslint-disable-next-line no-console
-          console.warn('[reset-password] post-update sign-out failed', err);
+          console.warn('[reset-password] post-reset client logout failed', err);
         });
       } catch (err: any) {
-        // Surface the Supabase error verbatim when present — e.g.
-        // "New password should be different from the old password."
-        // for the same_password code. Console-log the full object so
-        // a future "spinner stuck, no message" report is debuggable
-        // from DevTools without round-tripping back to this fix.
+        // Surface the server error verbatim when present —
+        // typically "New password should be different from the old
+        // password." for the same_password code. Console-log the
+        // full object so a future "spinner stuck, no message"
+        // report is debuggable from DevTools without round-tripping
+        // back to this fix.
         // eslint-disable-next-line no-console
-        console.error('[reset-password] updatePassword failed', err);
+        console.error('[reset-password] reset failed', err);
         setError(
           err?.message ||
             'Failed to update password. The link may have expired — please request a new one.'
@@ -141,7 +159,7 @@ function ResetPasswordForm() {
         setIsSubmitting(false);
       }
     },
-    [password, confirmPassword, allMet, passwordsMatch, updatePassword, logout]
+    [password, confirmPassword, allMet, passwordsMatch, recoveryCode, logout]
   );
 
   // If auth is still loading, show spinner
@@ -172,7 +190,7 @@ function ResetPasswordForm() {
             </h1>
             <p className='text-white/60 text-sm mt-2'>
               {success
-                ? "You've been signed out. Sign in with your new password to continue."
+                ? 'Sign in with your new password to continue.'
                 : 'Enter your new password below. Make it strong and unique.'}
             </p>
           </div>
@@ -186,8 +204,8 @@ function ResetPasswordForm() {
                 className='text-center'>
                 <CheckCircle2 className='w-16 h-16 mx-auto text-gov-sage mb-4' />
                 <p className='text-gov-forest/70 text-sm mb-6'>
-                  Your password has been changed and you&apos;ve been signed out for security. Head
-                  back to the homepage and sign in with your new password.
+                  Your password has been changed. Head back to the homepage and sign in with your
+                  new password to continue.
                 </p>
                 <Link
                   href='/'

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -31,13 +31,18 @@ function ResetPasswordForm() {
   const { logout, isAuthenticated, isLoading: authLoading } = useAuth();
   const searchParams = useSearchParams();
   const linkError = searchParams.get('error');
-  // PKCE recovery code, forwarded by /auth/callback without being
-  // exchanged. Submitting the form POSTs this to
-  // /api/auth/reset-password where the exchange + password update +
-  // sign-out all happen server-side without ever creating a client
-  // session. See app/auth/callback/route.ts and the API route file
-  // for the full reasoning.
-  const recoveryCode = searchParams.get('code');
+  // PKCE recovery code, forwarded by /auth/callback under the query
+  // parameter name ``recovery`` (not ``code``) — this is critical:
+  // the browser Supabase SDK auto-detects ``?code=`` on page load
+  // and would exchange it itself, creating a session behind our
+  // back. Forwarding under ``recovery`` keeps the SDK's
+  // ``_isPKCECallback`` check returning false. See
+  // /auth/callback/route.ts for the full reasoning. The form-submit
+  // handler then POSTs this value as ``code`` to
+  // /api/auth/reset-password, which runs on the server with
+  // ``detectSessionInUrl: false`` and is the only place the
+  // exchange actually happens.
+  const recoveryCode = searchParams.get('recovery');
 
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');


### PR DESCRIPTION
## Summary

The user reported (with a screenshot showing the network panel) that clicking the password-reset email link drops them into the app already signed in — profile loaded, watchlist fetched, "Sign Out" option visible. The first commit on this branch (sign out *after* a successful password change) addressed only the cleanup phase. This second commit fixes the actual cause: an auth session is currently created the instant the link is clicked, before the user has done anything.

### What changed

Three coordinated edits ensure no auth cookie ever reaches the browser during the recovery flow:

1. **`/auth/callback` (server)** — when `next=/reset-password`, the PKCE code is forwarded to the page as a query param without being exchanged. No `exchangeCodeForSession` ⇒ no `Set-Cookie` headers ⇒ user lands on `/reset-password` unauthenticated.

2. **`POST /api/auth/reset-password` (new server route)** — does the whole `exchange + updateUser + signOut` sequence atomically with a custom cookie adapter:
   - `getAll`: reads the request's existing `sb-…-code-verifier` cookie so the PKCE exchange has the verifier it needs.
   - `setAll`: deliberate no-op — every session cookie the SDK tries to write during the exchange is silently dropped.

   Net result: the password is updated, the just-issued session is invalidated server-side, the browser's cookie jar is never touched.

3. **`/reset-password` page** — reads `code` from query params, POSTs `{ code, password }` to the new endpoint instead of calling `supabase.auth.updateUser` client-side. The previous client-side `updatePassword` path no longer runs in the reset flow, which removes the GoTrueClient auto-refresh tick that PRs #87, #92, #93, #94, #95 had been chasing as the source of the duplicate `PUT /auth/v1/user` → `same_password` error.

### What this *should* fix

- ❎ Clicking the email link auto-logs the user in
- ❎ Header avatar shows up while filling out the password form
- ❎ Duplicate `PUT /auth/v1/user` (one 200, one 422 `same_password`)
- ❎ "Lock broken… should be different" error after a password that actually changed

### Test plan

- [ ] Click reset-password email link → land on `/reset-password?code=…` form, **not signed in** (header should show login button, no avatar)
- [ ] Network panel: only the page navigation; no `/auth/v1/token` exchange, no `/rest/v1/profiles` fetch
- [ ] Submit a valid new password → success UI shows "Password Updated · Sign in with your new password"
- [ ] Network panel: exactly **one** `POST /api/auth/reset-password` (200), no client-side `PUT /auth/v1/user` requests
- [ ] No `Set-Cookie: sb-…` headers in any response from the flow
- [ ] Click "Sign in with new password" → homepage, no session, login form available
- [ ] Sign in with new password → succeeds
- [ ] Edge case: while still signed in as user A, click reset link for user B's account → form works, B's password is reset, A is signed out client-side after success
- [ ] Edge case: navigate directly to `/reset-password` (no code) → submit shows "missing verification code, request a new one"

🤖 Generated with [Claude Code](https://claude.com/claude-code)