### PR TITLE
feat(auth): auto-login user after successful password reset

### DIFF
--- a/frontend/app/api/auth/reset-password/route.ts
+++ b/frontend/app/api/auth/reset-password/route.ts
@@ -1,38 +1,40 @@
 /**
  * POST /api/auth/reset-password
  *
- * Atomic password-reset endpoint that intentionally avoids ever
- * persisting a session in the user's browser. Inputs:
+ * Atomic password-reset endpoint. Inputs:
  *
  *   { code: string, password: string }
  *
- * where ``code`` is the PKCE code Supabase forwarded to /auth/callback
- * (passed through to /reset-password as a query param without being
- * exchanged — see app/auth/callback/route.ts for that decision).
+ * where ``code`` is the PKCE recovery code Supabase forwarded to
+ * /auth/callback (passed through to /reset-password as a query param
+ * named ``recovery`` without being exchanged — see
+ * app/auth/callback/route.ts for that decision).
  *
- * Why it lives here instead of being done client-side
- * ---------------------------------------------------
- * Doing the exchange + updateUser on the client (via the @supabase/ssr
- * browser client) writes session cookies the moment the exchange
- * succeeds, which:
+ * Why exchange + updateUser run server-side
+ * -----------------------------------------
+ * Doing both on the client (via the browser SDK) starts the
+ * GoTrueClient's ``_autoRefreshTokenTick`` the moment the exchange
+ * succeeds, which races with the immediately-following ``updateUser``
+ * for the gotrue Web Lock — that lock-queue contention was the actual
+ * source of the duplicate ``PUT /auth/v1/user`` → ``code:
+ * same_password`` error we chased across PRs #87, #92, #93, #94, #95.
+ * The server-side @supabase/ssr client doesn't run an auto-refresh
+ * tick, so exchange + update happen sequentially with no race.
  *
- *   1. Logs the user into the app while they're mid-reset (the
- *      "click email link, find myself signed in" UX surprise the
- *      user flagged on PR #95 and again afterwards).
- *   2. Starts the GoTrueClient's ``_autoRefreshTokenTick`` running on
- *      a 30s interval, fighting ``updateUser`` for the gotrue Web
- *      Lock — the actual cause of the duplicate ``PUT /auth/v1/user``
- *      → ``code: same_password`` error we've been chasing across
- *      PRs #87, #92, #93, #94, #95.
+ * Why we DO write session cookies on success (auto-login)
+ * -------------------------------------------------------
+ * The user just typed the new password; making them retype the same
+ * thing on a sign-in page is friction with no security benefit (they
+ * already demonstrated control of the new credential, and PKCE
+ * already proved they're the browser that initiated the flow). So
+ * once update succeeds we let the SDK's normal cookie writes go
+ * through to the response, and the browser ends up with a fresh
+ * session attached to the just-changed password. The page then
+ * calls ``refreshUser()`` and redirects to home.
  *
- * The fix is to do the whole exchange→update→signOut sequence on the
- * server with a custom cookie adapter that READS the request's
- * ``sb-...-code-verifier`` cookie (set by the browser when it called
- * ``resetPasswordForEmail``) but DOES NOT write anything back. The
- * Supabase server client thinks it's setting cookies; we silently drop
- * them. So no session cookie ever reaches the browser, the auto-refresh
- * tick never starts, and the user ends the flow unauthenticated and is
- * prompted to sign in fresh with their new password.
+ * Pre-existing-session cleanup happens upstream in /auth/callback,
+ * which signs out any stale session before forwarding the recovery
+ * code here, so we never end up with the wrong account's cookies.
  */
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
@@ -64,39 +66,33 @@ export async function POST(request: Request) {
 
   const cookieStore = await cookies();
 
-  // Diagnostic: log cookie names received so a future
-  // ``AuthPKCECodeVerifierMissingError`` is debuggable from the dev
-  // server log without re-instrumenting. Values are deliberately not
-  // logged (verifier is sensitive). Names alone tell us whether the
-  // browser sent the verifier cookie with this request.
-  const cookieNames = cookieStore.getAll().map((c) => c.name);
-  // eslint-disable-next-line no-console
-  console.log(
-    `[api/auth/reset-password] received ${cookieNames.length} cookie(s)`,
-    cookieNames.filter((n) => n.startsWith('sb-'))
-  );
+  // Build the success response up-front so cookies the SDK writes
+  // during exchange/updateUser are attached to *this* response. If
+  // we returned a fresh ``NextResponse.json`` later we'd lose them
+  // — Next.js doesn't propagate cookies set via request-scoped
+  // ``cookies().set()`` onto a different response object reliably.
+  const successResponse = NextResponse.json({ ok: true });
 
-  // Read-only cookie adapter. ``getAll`` lets the SDK read the
-  // ``sb-...-code-verifier`` cookie it needs to validate the PKCE
-  // code; ``setAll`` is intentionally a no-op so any session cookies
-  // the SDK tries to write during the exchange are silently dropped.
-  // Net effect: the server can complete the exchange and updateUser,
-  // but the browser's cookie jar is never touched.
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
         getAll: () => cookieStore.getAll(),
-        setAll: () => {
-          // intentional no-op: see file-level comment about why we
-          // refuse to write any auth cookies to the response.
+        setAll: (cookiesToSet) => {
+          // Forward every cookie the SDK wants to set onto our
+          // success response. After ``exchangeCodeForSession`` this
+          // includes ``sb-<ref>-auth-token`` (the new session) and
+          // a cleared ``sb-<ref>-auth-token-code-verifier`` (the
+          // verifier is one-shot and gets removed on use).
+          cookiesToSet.forEach(({ name, value, options }) => {
+            successResponse.cookies.set(name, value, options);
+          });
         },
       },
     }
   );
 
-  // 1. Exchange the recovery code for an in-memory session.
   const { data: exchangeData, error: exchangeError } =
     await supabase.auth.exchangeCodeForSession(code);
 
@@ -111,22 +107,23 @@ export async function POST(request: Request) {
     );
   }
 
-  // 2. Update the password using the in-memory session.
   const { error: updateError } = await supabase.auth.updateUser({ password });
 
   if (updateError) {
+    // We already wrote cookies on the successResponse during the
+    // exchange step above, but we're returning a different response
+    // for the error case — those orphaned cookie writes go nowhere,
+    // so the browser ends up with no session, which matches what
+    // we want when the password update failed. The just-exchanged
+    // session is also signed out below to invalidate it server-side.
+    await supabase.auth.signOut().catch(() => {
+      /* best-effort */
+    });
     return NextResponse.json(
       { error: updateError.message ?? 'Failed to update password.' },
       { status: 400 }
     );
   }
 
-  // 3. Sign out for tidiness — invalidates the just-issued refresh
-  // token server-side. No-op for the browser since we never wrote
-  // any cookies, but it keeps the Supabase auth state clean.
-  await supabase.auth.signOut().catch(() => {
-    /* best-effort cleanup; the password update already succeeded */
-  });
-
-  return NextResponse.json({ ok: true });
+  return successResponse;
 }

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -13,7 +13,7 @@ import {
   ShieldCheck,
 } from 'lucide-react';
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useRef, useState } from 'react';
 
 /* ── Minimum password requirements ── */
@@ -28,7 +28,8 @@ function getPasswordStrength(pw: string) {
 }
 
 function ResetPasswordForm() {
-  const { logout, isAuthenticated, isLoading: authLoading } = useAuth();
+  const { refreshUser, isAuthenticated, isLoading: authLoading } = useAuth();
+  const router = useRouter();
   const searchParams = useSearchParams();
   const linkError = searchParams.get('error');
   // PKCE recovery code, forwarded by /auth/callback under the query
@@ -133,19 +134,23 @@ function ResetPasswordForm() {
 
         setSuccess(true);
 
-        // If the user happened to already be signed in (e.g. they
-        // reset their own password while still in a logged-in
-        // tab, or they're signed in as a different account), the
-        // server only invalidated *that user's* session in the
-        // recovery flow — the existing browser cookies are
-        // untouched. Sign out client-side to guarantee a clean
-        // "log back in with your new password" experience. This
-        // is best-effort; we don't surface failures because the
-        // password change itself already succeeded.
-        logout().catch((err) => {
+        // The /api/auth/reset-password response set fresh
+        // ``sb-<ref>-auth-token`` cookies — the user is now
+        // logged in with their new password. Refresh the
+        // AuthProvider so authUser/profile pick up the new
+        // session, then redirect to the homepage. We brief-pause
+        // before navigating so the success state is visible long
+        // enough to register; this is purely cosmetic — by the
+        // time the timer fires, refreshUser has already settled.
+        try {
+          await refreshUser();
+        } catch (err) {
           // eslint-disable-next-line no-console
-          console.warn('[reset-password] post-reset client logout failed', err);
-        });
+          console.warn('[reset-password] refreshUser after reset failed', err);
+        }
+        setTimeout(() => {
+          router.replace('/');
+        }, 1200);
       } catch (err: any) {
         // Surface the server error verbatim when present —
         // typically "New password should be different from the old
@@ -164,7 +169,7 @@ function ResetPasswordForm() {
         setIsSubmitting(false);
       }
     },
-    [password, confirmPassword, allMet, passwordsMatch, recoveryCode, logout]
+    [password, confirmPassword, allMet, passwordsMatch, recoveryCode, refreshUser, router]
   );
 
   // If auth is still loading, show spinner
@@ -195,7 +200,7 @@ function ResetPasswordForm() {
             </h1>
             <p className='text-white/60 text-sm mt-2'>
               {success
-                ? 'Sign in with your new password to continue.'
+                ? 'Signing you in with your new password…'
                 : 'Enter your new password below. Make it strong and unique.'}
             </p>
           </div>
@@ -208,16 +213,14 @@ function ResetPasswordForm() {
                 animate={{ opacity: 1, y: 0 }}
                 className='text-center'>
                 <CheckCircle2 className='w-16 h-16 mx-auto text-gov-sage mb-4' />
-                <p className='text-gov-forest/70 text-sm mb-6'>
-                  Your password has been changed. Head back to the homepage and sign in with your
-                  new password to continue.
+                <p className='text-gov-forest/70 text-sm mb-2'>
+                  Your password has been updated and you&apos;re signed in. Taking you to the
+                  homepage…
                 </p>
-                <Link
-                  href='/'
-                  className='inline-flex items-center gap-2 px-6 py-3 bg-gov-sage text-white font-semibold rounded-xl hover:bg-gov-sage/90 transition-colors shadow-md'>
-                  Sign in with new password
-                  <ArrowRight className='w-4 h-4' />
-                </Link>
+                <div className='flex items-center justify-center gap-2 text-gov-forest/50 text-xs mt-4'>
+                  <Loader2 className='w-3.5 h-3.5 animate-spin' />
+                  Redirecting
+                </div>
               </motion.div>
             ) : linkError && !isAuthenticated ? (
               /* ── Link-error state (expired/invalid token) ── */


### PR DESCRIPTION
## Summary

After PR #95's reset flow shipped end-to-end, the user asked whether we could auto-sign-in the user once the new password is set, instead of bouncing them to the homepage to type the password they just chose. That's a clear UX win, and — importantly — it isn't what caused any of the bugs we'd been chasing.

This PR makes that change. Once `/api/auth/reset-password` confirms the password is updated, it lets the SSR client's session cookies write through to the response, so the browser ends up authenticated. The reset-password page then calls `refreshUser()` so `AuthProvider` picks up the new session and redirects to `/`.

## Why this is safe (re-introducing auto-login won't reopen the old bugs)

| Old bug | What caused it | Why this PR doesn't reintroduce it |
|---|---|---|
| Click email link, find myself signed in | `exchangeCodeForSession` ran on `/auth/callback` *before* password set | Still prevented — `/auth/callback` never creates a session for recovery links (PR #95) |
| Duplicate `PUT /auth/v1/user` → `same_password` | Browser SDK `_autoRefreshTokenTick` raced with `updateUser` for the gotrue lock | The exchange + update still happen server-side via the SSR client, which has no auto-refresh tick |
| Stale session restored on `/reset-password` | `getSession()` read existing `sb-…-auth-token` cookie | `/auth/callback` still signs out any pre-existing session before forwarding (PR #95) |

The auto-login only kicks in *after* `updateUser` succeeds. By that point all three root causes have already been mitigated upstream, so the session we hand back is uncontaminated and uncontested.

## Implementation

**`/api/auth/reset-password`** — Build a single `successResponse` up front, pass an SSR cookie adapter whose `setAll` forwards every cookie write onto that response. Exchange writes `sb-<ref>-auth-token` (the new session) and clears the consumed `code-verifier` directly onto the response. Trailing `signOut` removed. Error path returns a fresh response so orphaned cookie writes go nowhere.

**`/reset-password/page.tsx`** — Drop the post-success `logout()` call (it was actively undoing the auto-login). Call `refreshUser()` so `AuthProvider` picks up the new session, then `router.replace('/')` after a 1.2s pause so the success state registers visually. Header copy: "Signed out, sign in with new password" → "Signing you in with your new password…". Body copy becomes a brief "Redirecting" loader instead of a homepage link.

## Verified locally

- Page renders cleanly with no JS or server errors
- API rejects short passwords correctly
- API reaches into the SDK's exchange call (confirmed by `AuthPKCECodeVerifierMissingError` for a fake code, proving the cookie adapter is wired up correctly)

## Test plan

- [ ] Click "Forgot password" in the app → submit form → click email link
- [ ] Land on `/reset-password` form (no avatar in header — anonymous state)
- [ ] Type a new password → submit
- [ ] See "Password Updated / Signing you in… / Redirecting" success state for ~1.2s
- [ ] Land on `/` already signed in (avatar appears, no login prompt needed)
- [ ] Network panel shows exactly **one** `PUT /auth/v1/user` (regression check for the duplicate-PUT bug)
- [ ] Refresh `/` — still signed in (cookies persisted)
- [ ] Sign out manually, then sign in with the *new* password — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)