### PR TITLE
feat(admin): add /admin overview + /admin/ingestion pages (step 1 of admin dashboard)

### DIFF
--- a/frontend/app/admin/ingestion/[jobId]/page.tsx
+++ b/frontend/app/admin/ingestion/[jobId]/page.tsx
@@ -1,0 +1,260 @@
+/**
+ * /admin/ingestion/[jobId] — single-job detail view.
+ *
+ * Drill-in target from the ingestion list. Shows the full
+ * ``IngestionJobResponse`` payload — all timing fields, every metric,
+ * every error, plus the raw metadata blob — so an operator can see
+ * exactly what an ETL run did and what (if anything) went wrong.
+ */
+'use client';
+
+import api from '@/lib/api/axios';
+import { useQuery } from '@tanstack/react-query';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  Clock,
+  Loader2,
+  PlayCircle,
+  RefreshCcw,
+  XCircle,
+} from 'lucide-react';
+import Link from 'next/link';
+import { use } from 'react';
+
+interface IngestionJob {
+  id: number;
+  domain: string;
+  status: string;
+  dry_run: boolean;
+  started_at: string;
+  finished_at: string | null;
+  duration_seconds: number | null;
+  items_processed: number;
+  items_created: number;
+  items_updated: number;
+  errors: unknown[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+export default function IngestionJobDetailPage({
+  params,
+}: {
+  params: Promise<{ jobId: string }>;
+}) {
+  const { jobId } = use(params);
+  const { data, isLoading, error, refetch, isFetching } = useQuery<IngestionJob>({
+    queryKey: ['admin', 'ingestion-job', jobId],
+    queryFn: async () => (await api.get(`/admin/ingestion-jobs/${jobId}`)).data,
+    staleTime: 15_000,
+  });
+
+  return (
+    <div className='max-w-4xl mx-auto px-4 sm:px-6 py-8 space-y-5'>
+      <div className='flex items-center justify-between gap-3 flex-wrap'>
+        <Link
+          href='/admin/ingestion'
+          className='inline-flex items-center gap-1 text-sm text-gov-sage hover:text-gov-forest'>
+          <ArrowLeft className='w-4 h-4' />
+          Back to ingestion jobs
+        </Link>
+        <button
+          onClick={() => refetch()}
+          disabled={isFetching}
+          className='inline-flex items-center gap-2 px-3 py-1.5 bg-white border border-gov-sage/30 hover:border-gov-sage text-gov-forest rounded-lg text-sm transition-colors disabled:opacity-50'>
+          <RefreshCcw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      {isLoading ? (
+        <BodyState>
+          <Loader2 className='w-6 h-6 text-gov-sage animate-spin' />
+          <p className='text-gov-forest/60 text-sm'>Loading job…</p>
+        </BodyState>
+      ) : error || !data ? (
+        <BodyState>
+          <XCircle className='w-8 h-8 text-red-500' />
+          <p className='text-red-600 text-sm'>Job not found or failed to load.</p>
+        </BodyState>
+      ) : (
+        <>
+          {/* ── Header card ── */}
+          <div className='bg-white border border-gov-sage/20 rounded-xl p-6 shadow-sm'>
+            <div className='flex items-start justify-between gap-3 flex-wrap'>
+              <div>
+                <p className='text-xs uppercase tracking-wide text-gov-forest/60 font-semibold'>
+                  Ingestion Job #{data.id}
+                </p>
+                <h1 className='text-2xl font-bold text-gov-dark mt-1 font-mono'>{data.domain}</h1>
+                <div className='flex items-center gap-2 mt-3'>
+                  <StatusBadge status={data.status} hasErrors={data.errors.length > 0} />
+                  {data.dry_run && (
+                    <span className='inline-flex items-center text-[10px] uppercase tracking-wide bg-amber-100 text-amber-800 px-1.5 py-0.5 rounded'>
+                      dry-run
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Timing + metrics grid */}
+            <div className='grid grid-cols-2 sm:grid-cols-4 gap-4 mt-6 pt-6 border-t border-gov-sage/10'>
+              <Field label='Items processed' value={data.items_processed.toLocaleString()} />
+              <Field
+                label='Created'
+                value={data.items_created.toLocaleString()}
+                tone='ok'
+              />
+              <Field
+                label='Updated'
+                value={data.items_updated.toLocaleString()}
+                tone='info'
+              />
+              <Field label='Errors' value={data.errors.length.toString()} tone={data.errors.length > 0 ? 'bad' : 'muted'} />
+              <Field label='Started' value={formatDate(data.started_at)} />
+              <Field
+                label='Finished'
+                value={data.finished_at ? formatDate(data.finished_at) : '—'}
+              />
+              <Field label='Duration' value={formatDuration(data.duration_seconds)} />
+              <Field label='Created at' value={formatDate(data.created_at)} />
+            </div>
+          </div>
+
+          {/* ── Errors ── */}
+          {data.errors.length > 0 && (
+            <section className='bg-white border border-red-200 rounded-xl p-5 shadow-sm'>
+              <div className='flex items-center gap-2 mb-3'>
+                <AlertTriangle className='w-4 h-4 text-red-600' />
+                <h2 className='text-sm font-semibold text-gov-dark'>
+                  Errors ({data.errors.length})
+                </h2>
+              </div>
+              <ul className='space-y-2'>
+                {data.errors.map((err, i) => (
+                  <li
+                    key={i}
+                    className='bg-red-50 border border-red-100 rounded-lg p-3 text-xs font-mono text-red-900 overflow-x-auto'>
+                    <pre className='whitespace-pre-wrap break-all'>
+                      {typeof err === 'string' ? err : JSON.stringify(err, null, 2)}
+                    </pre>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {/* ── Metadata ── */}
+          {Object.keys(data.metadata).length > 0 && (
+            <section className='bg-white border border-gov-sage/20 rounded-xl p-5 shadow-sm'>
+              <h2 className='text-sm font-semibold text-gov-dark mb-3'>Metadata</h2>
+              <pre className='text-xs font-mono bg-gov-cream/50 border border-gov-sage/10 rounded-lg p-3 overflow-x-auto whitespace-pre-wrap break-all text-gov-dark'>
+                {JSON.stringify(data.metadata, null, 2)}
+              </pre>
+            </section>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/* ── Helpers ── */
+
+function Field({
+  label,
+  value,
+  tone = 'default',
+}: {
+  label: string;
+  value: string;
+  tone?: 'ok' | 'bad' | 'info' | 'muted' | 'default';
+}) {
+  const colour = {
+    ok: 'text-emerald-600',
+    bad: 'text-red-600',
+    info: 'text-blue-600',
+    muted: 'text-gov-forest/50',
+    default: 'text-gov-dark',
+  }[tone];
+  return (
+    <div>
+      <p className='text-[10px] uppercase tracking-wide text-gov-forest/60 font-semibold'>
+        {label}
+      </p>
+      <p className={`text-sm font-medium mt-0.5 ${colour}`}>{value}</p>
+    </div>
+  );
+}
+
+function StatusBadge({ status, hasErrors }: { status: string; hasErrors: boolean }) {
+  const config = ((): {
+    bg: string;
+    text: string;
+    icon: React.ElementType;
+    label: string;
+  } => {
+    switch (status) {
+      case 'completed':
+        return hasErrors
+          ? { bg: 'bg-amber-100', text: 'text-amber-800', icon: AlertTriangle, label: 'completed*' }
+          : { bg: 'bg-emerald-100', text: 'text-emerald-800', icon: CheckCircle2, label: status };
+      case 'completed_with_errors':
+        return {
+          bg: 'bg-amber-100',
+          text: 'text-amber-800',
+          icon: AlertTriangle,
+          label: 'completed w/ errors',
+        };
+      case 'failed':
+        return { bg: 'bg-red-100', text: 'text-red-800', icon: XCircle, label: status };
+      case 'running':
+        return { bg: 'bg-blue-100', text: 'text-blue-800', icon: PlayCircle, label: status };
+      case 'pending':
+        return { bg: 'bg-gray-100', text: 'text-gray-700', icon: Clock, label: status };
+      default:
+        return { bg: 'bg-gray-100', text: 'text-gray-700', icon: Clock, label: status };
+    }
+  })();
+  const Icon = config.icon;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${config.bg} ${config.text}`}>
+      <Icon className='w-3 h-3' />
+      {config.label}
+    </span>
+  );
+}
+
+function BodyState({ children }: { children: React.ReactNode }) {
+  return (
+    <div className='bg-white border border-gov-sage/20 rounded-xl py-16 flex flex-col items-center justify-center gap-3 shadow-sm'>
+      {children}
+    </div>
+  );
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatDuration(seconds: number | null): string {
+  if (seconds == null) return '—';
+  if (seconds < 1) return '<1s';
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const mins = Math.floor(seconds / 60);
+  const rem = Math.round(seconds % 60);
+  if (mins < 60) return `${mins}m ${rem}s`;
+  const hrs = Math.floor(mins / 60);
+  return `${hrs}h ${mins % 60}m`;
+}

--- a/frontend/app/admin/ingestion/page.tsx
+++ b/frontend/app/admin/ingestion/page.tsx
@@ -1,0 +1,449 @@
+/**
+ * /admin/ingestion — list + filter ingestion jobs.
+ *
+ * Operator's primary tool for inspecting what the data pipeline did
+ * recently. Reads the existing ``GET /api/v1/admin/ingestion-jobs``
+ * endpoint with filters (domain, status, days, page). Each row links
+ * to /admin/ingestion/[jobId] for full details and errors.
+ */
+'use client';
+
+import api from '@/lib/api/axios';
+import { useQuery } from '@tanstack/react-query';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  ChevronRight,
+  Clock,
+  Loader2,
+  Pause,
+  PlayCircle,
+  RefreshCcw,
+  XCircle,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useCallback, useState } from 'react';
+
+interface IngestionJob {
+  id: number;
+  domain: string;
+  status: string;
+  dry_run: boolean;
+  started_at: string;
+  finished_at: string | null;
+  duration_seconds: number | null;
+  items_processed: number;
+  items_created: number;
+  items_updated: number;
+  errors: unknown[];
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+interface IngestionJobList {
+  jobs: IngestionJob[];
+  total: number;
+  page: number;
+  page_size: number;
+  has_more: boolean;
+}
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'All statuses' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'completed_with_errors', label: 'Completed w/ errors' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'running', label: 'Running' },
+  { value: 'pending', label: 'Pending' },
+];
+
+const DAYS_OPTIONS = [
+  { value: 1, label: '24 hours' },
+  { value: 7, label: '7 days' },
+  { value: 30, label: '30 days' },
+  { value: 90, label: '90 days' },
+];
+
+const PAGE_SIZE = 20;
+
+export default function IngestionJobsPage() {
+  return (
+    <Suspense fallback={<PageLoader />}>
+      <IngestionJobsInner />
+    </Suspense>
+  );
+}
+
+function IngestionJobsInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Filter state mirrors URL query params so links/refresh work cleanly.
+  const domain = searchParams.get('domain') ?? '';
+  const status = searchParams.get('status') ?? '';
+  const days = Number(searchParams.get('days') ?? '7');
+  const page = Number(searchParams.get('page') ?? '1');
+
+  const setQuery = useCallback(
+    (updates: Record<string, string | number | null>) => {
+      const next = new URLSearchParams(searchParams);
+      for (const [k, v] of Object.entries(updates)) {
+        if (v === null || v === '') next.delete(k);
+        else next.set(k, String(v));
+      }
+      // Reset page to 1 whenever a filter (other than page itself) changes.
+      if (!('page' in updates)) next.delete('page');
+      router.replace(`/admin/ingestion${next.size ? '?' + next.toString() : ''}`);
+    },
+    [router, searchParams]
+  );
+
+  const { data, isLoading, error, refetch, isFetching } = useQuery<IngestionJobList>({
+    queryKey: ['admin', 'ingestion-jobs', { domain, status, days, page }],
+    queryFn: async () => {
+      const params: Record<string, string | number> = { page, page_size: PAGE_SIZE, days };
+      if (domain) params.domain = domain;
+      if (status) params.status = status;
+      return (await api.get('/admin/ingestion-jobs', { params })).data;
+    },
+    staleTime: 15_000,
+  });
+
+  return (
+    <div className='max-w-6xl mx-auto px-4 sm:px-6 py-8 space-y-5'>
+      {/* ── Header row ── */}
+      <div className='flex flex-wrap items-center justify-between gap-3'>
+        <div>
+          <Link
+            href='/admin'
+            className='inline-flex items-center gap-1 text-xs text-gov-sage hover:text-gov-forest mb-1'>
+            <ArrowLeft className='w-3 h-3' />
+            Back to overview
+          </Link>
+          <h1 className='text-2xl sm:text-3xl font-bold text-gov-dark'>Ingestion Jobs</h1>
+          <p className='text-gov-forest/60 text-sm mt-1'>
+            {data
+              ? `${data.total.toLocaleString()} job${data.total === 1 ? '' : 's'} match the current filters.`
+              : 'Loading…'}
+          </p>
+        </div>
+        <button
+          onClick={() => refetch()}
+          disabled={isFetching}
+          className='inline-flex items-center gap-2 px-3 py-2 bg-white border border-gov-sage/30 hover:border-gov-sage text-gov-forest rounded-lg text-sm transition-colors disabled:opacity-50'>
+          <RefreshCcw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      {/* ── Filter bar ── */}
+      <div className='bg-white border border-gov-sage/20 rounded-xl p-4 shadow-sm flex flex-wrap items-end gap-3'>
+        <FilterField label='Domain'>
+          <input
+            type='text'
+            value={domain}
+            onChange={(e) => setQuery({ domain: e.target.value || null })}
+            placeholder='e.g. counties_budget'
+            className='w-44 px-3 py-1.5 text-sm rounded-lg border border-gov-sage/30 focus:outline-none focus:ring-2 focus:ring-gov-sage/40 focus:border-gov-sage/40 bg-gov-cream/30'
+          />
+        </FilterField>
+        <FilterField label='Status'>
+          <select
+            value={status}
+            onChange={(e) => setQuery({ status: e.target.value || null })}
+            className='w-48 px-3 py-1.5 text-sm rounded-lg border border-gov-sage/30 focus:outline-none focus:ring-2 focus:ring-gov-sage/40 focus:border-gov-sage/40 bg-gov-cream/30'>
+            {STATUS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </FilterField>
+        <FilterField label='Time window'>
+          <select
+            value={days}
+            onChange={(e) => setQuery({ days: e.target.value })}
+            className='w-36 px-3 py-1.5 text-sm rounded-lg border border-gov-sage/30 focus:outline-none focus:ring-2 focus:ring-gov-sage/40 focus:border-gov-sage/40 bg-gov-cream/30'>
+            {DAYS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                Last {opt.label}
+              </option>
+            ))}
+          </select>
+        </FilterField>
+
+        {(domain || status || days !== 7) && (
+          <button
+            onClick={() => router.replace('/admin/ingestion')}
+            className='ml-auto text-xs text-gov-forest/60 hover:text-gov-forest underline underline-offset-2'>
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      {/* ── Body ── */}
+      {isLoading ? (
+        <BodyState>
+          <Loader2 className='w-6 h-6 text-gov-sage animate-spin' />
+          <p className='text-gov-forest/60 text-sm'>Loading jobs…</p>
+        </BodyState>
+      ) : error ? (
+        <BodyState>
+          <XCircle className='w-8 h-8 text-red-500' />
+          <p className='text-red-600 text-sm'>Could not load jobs.</p>
+          <button
+            onClick={() => refetch()}
+            className='px-3 py-1.5 bg-gov-sage/10 hover:bg-gov-sage/20 text-gov-forest rounded-lg text-sm'>
+            Retry
+          </button>
+        </BodyState>
+      ) : !data || data.jobs.length === 0 ? (
+        <BodyState>
+          <Pause className='w-8 h-8 text-gov-forest/30' />
+          <p className='text-gov-forest/60 text-sm'>No jobs match these filters.</p>
+        </BodyState>
+      ) : (
+        <>
+          <div className='bg-white border border-gov-sage/20 rounded-xl overflow-hidden shadow-sm'>
+            {/* Desktop table */}
+            <table className='hidden md:table w-full text-sm'>
+              <thead className='bg-gov-cream border-b border-gov-sage/20 text-xs uppercase tracking-wide text-gov-forest/60'>
+                <tr>
+                  <th className='px-4 py-3 text-left font-semibold'>Domain</th>
+                  <th className='px-4 py-3 text-left font-semibold'>Status</th>
+                  <th className='px-4 py-3 text-left font-semibold'>Started</th>
+                  <th className='px-4 py-3 text-right font-semibold'>Duration</th>
+                  <th className='px-4 py-3 text-right font-semibold'>Items</th>
+                  <th className='px-4 py-3 text-right font-semibold'>Created</th>
+                  <th className='px-4 py-3 text-right font-semibold'>Updated</th>
+                  <th className='px-2 py-3'></th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.jobs.map((job) => (
+                  <tr
+                    key={job.id}
+                    onClick={() => router.push(`/admin/ingestion/${job.id}`)}
+                    className='border-b last:border-0 border-gov-sage/10 hover:bg-gov-cream/50 cursor-pointer transition-colors'>
+                    <td className='px-4 py-3'>
+                      <div className='flex items-center gap-2'>
+                        <span className='font-mono text-xs font-medium text-gov-dark'>
+                          {job.domain}
+                        </span>
+                        {job.dry_run && (
+                          <span className='text-[10px] uppercase tracking-wide bg-amber-100 text-amber-800 px-1.5 py-0.5 rounded'>
+                            dry-run
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className='px-4 py-3'>
+                      <StatusBadge status={job.status} hasErrors={job.errors.length > 0} />
+                    </td>
+                    <td className='px-4 py-3 text-gov-forest/70 whitespace-nowrap'>
+                      {timeAgo(job.started_at)}
+                    </td>
+                    <td className='px-4 py-3 text-right text-gov-forest/70 whitespace-nowrap'>
+                      {formatDuration(job.duration_seconds)}
+                    </td>
+                    <td className='px-4 py-3 text-right text-gov-dark font-medium'>
+                      {job.items_processed.toLocaleString()}
+                    </td>
+                    <td className='px-4 py-3 text-right text-emerald-600'>
+                      {job.items_created.toLocaleString()}
+                    </td>
+                    <td className='px-4 py-3 text-right text-blue-600'>
+                      {job.items_updated.toLocaleString()}
+                    </td>
+                    <td className='px-2 py-3'>
+                      <ChevronRight className='w-4 h-4 text-gov-forest/30' />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            {/* Mobile card list */}
+            <ul className='md:hidden divide-y divide-gov-sage/10'>
+              {data.jobs.map((job) => (
+                <li key={job.id}>
+                  <Link
+                    href={`/admin/ingestion/${job.id}`}
+                    className='block px-4 py-3 hover:bg-gov-cream/50 transition-colors'>
+                    <div className='flex items-center justify-between gap-2 mb-1'>
+                      <span className='font-mono text-xs font-medium text-gov-dark'>
+                        {job.domain}
+                      </span>
+                      <StatusBadge status={job.status} hasErrors={job.errors.length > 0} />
+                    </div>
+                    <div className='flex items-center justify-between text-xs text-gov-forest/60'>
+                      <span>{timeAgo(job.started_at)}</span>
+                      <span>{formatDuration(job.duration_seconds)}</span>
+                    </div>
+                    <div className='flex items-center gap-3 text-xs text-gov-forest/70 mt-1'>
+                      <span>{job.items_processed.toLocaleString()} processed</span>
+                      <span className='text-emerald-600'>
+                        +{job.items_created.toLocaleString()}
+                      </span>
+                      <span className='text-blue-600'>~{job.items_updated.toLocaleString()}</span>
+                    </div>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* ── Pagination ── */}
+          <Pagination
+            page={page}
+            pageSize={PAGE_SIZE}
+            total={data.total}
+            hasMore={data.has_more}
+            onChange={(p) => setQuery({ page: p })}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+/* ── Helpers ── */
+
+function StatusBadge({ status, hasErrors }: { status: string; hasErrors: boolean }) {
+  const config = ((): {
+    bg: string;
+    text: string;
+    icon: React.ElementType;
+    label: string;
+  } => {
+    switch (status) {
+      case 'completed':
+        return hasErrors
+          ? {
+              bg: 'bg-amber-100',
+              text: 'text-amber-800',
+              icon: AlertTriangle,
+              label: 'completed*',
+            }
+          : { bg: 'bg-emerald-100', text: 'text-emerald-800', icon: CheckCircle2, label: status };
+      case 'completed_with_errors':
+        return {
+          bg: 'bg-amber-100',
+          text: 'text-amber-800',
+          icon: AlertTriangle,
+          label: 'completed w/ errors',
+        };
+      case 'failed':
+        return { bg: 'bg-red-100', text: 'text-red-800', icon: XCircle, label: status };
+      case 'running':
+        return { bg: 'bg-blue-100', text: 'text-blue-800', icon: PlayCircle, label: status };
+      case 'pending':
+        return { bg: 'bg-gray-100', text: 'text-gray-700', icon: Clock, label: status };
+      default:
+        return { bg: 'bg-gray-100', text: 'text-gray-700', icon: Clock, label: status };
+    }
+  })();
+  const Icon = config.icon;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${config.bg} ${config.text}`}>
+      <Icon className='w-3 h-3' />
+      {config.label}
+    </span>
+  );
+}
+
+function FilterField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className='flex flex-col'>
+      <label className='text-[10px] uppercase tracking-wide text-gov-forest/60 font-semibold mb-1'>
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function Pagination({
+  page,
+  pageSize,
+  total,
+  hasMore,
+  onChange,
+}: {
+  page: number;
+  pageSize: number;
+  total: number;
+  hasMore: boolean;
+  onChange: (page: number) => void;
+}) {
+  const start = (page - 1) * pageSize + 1;
+  const end = Math.min(page * pageSize, total);
+  return (
+    <div className='flex items-center justify-between text-sm'>
+      <span className='text-gov-forest/60'>
+        Showing <span className='font-medium text-gov-dark'>{start.toLocaleString()}</span>–
+        <span className='font-medium text-gov-dark'>{end.toLocaleString()}</span> of{' '}
+        <span className='font-medium text-gov-dark'>{total.toLocaleString()}</span>
+      </span>
+      <div className='flex items-center gap-2'>
+        <button
+          onClick={() => onChange(Math.max(1, page - 1))}
+          disabled={page <= 1}
+          className='inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-gov-sage/30 hover:border-gov-sage text-gov-forest disabled:opacity-40 disabled:hover:border-gov-sage/30'>
+          <ArrowLeft className='w-3.5 h-3.5' />
+          Prev
+        </button>
+        <span className='text-gov-forest/60'>Page {page}</span>
+        <button
+          onClick={() => onChange(page + 1)}
+          disabled={!hasMore}
+          className='inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-gov-sage/30 hover:border-gov-sage text-gov-forest disabled:opacity-40 disabled:hover:border-gov-sage/30'>
+          Next
+          <ArrowRight className='w-3.5 h-3.5' />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function BodyState({ children }: { children: React.ReactNode }) {
+  return (
+    <div className='bg-white border border-gov-sage/20 rounded-xl py-16 flex flex-col items-center justify-center gap-3 shadow-sm'>
+      {children}
+    </div>
+  );
+}
+
+function PageLoader() {
+  return (
+    <div className='max-w-6xl mx-auto py-32 flex justify-center'>
+      <Loader2 className='w-6 h-6 text-gov-sage animate-spin' />
+    </div>
+  );
+}
+
+function timeAgo(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+function formatDuration(seconds: number | null): string {
+  if (seconds == null) return '—';
+  if (seconds < 1) return '<1s';
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const mins = Math.floor(seconds / 60);
+  const rem = Math.round(seconds % 60);
+  if (mins < 60) return `${mins}m ${rem}s`;
+  const hrs = Math.floor(mins / 60);
+  return `${hrs}h ${mins % 60}m`;
+}

--- a/frontend/app/admin/layout.tsx
+++ b/frontend/app/admin/layout.tsx
@@ -1,0 +1,71 @@
+/**
+ * /admin – shared shell for the admin section.
+ *
+ * Wraps every admin route in <AdminGuard>, which redirects non-admins
+ * to "/" client-side. Server-side enforcement still lives in the
+ * Next.js middleware (matches /admin/* and rejects via the same role
+ * check), and the backend endpoints all carry require_roles(["admin"])
+ * — so this guard is the third layer rather than the only one.
+ *
+ * Renders a sticky nav bar with the section links so navigating between
+ * Overview / Ingestion / Status doesn't require a full page reload.
+ */
+'use client';
+
+import { AdminGuard } from '@/lib/auth/admin';
+import { Activity, BarChart3, Database, ListChecks } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const NAV_ITEMS = [
+  { href: '/admin', label: 'Overview', icon: BarChart3, exact: true },
+  { href: '/admin/ingestion', label: 'Ingestion Jobs', icon: ListChecks },
+  { href: '/status', label: 'Pipeline Status', icon: Activity },
+];
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <AdminGuard>
+      <div className='min-h-screen bg-gov-cream'>
+        <AdminNav />
+        {children}
+      </div>
+    </AdminGuard>
+  );
+}
+
+function AdminNav() {
+  const pathname = usePathname();
+
+  const isActive = (href: string, exact?: boolean) =>
+    exact ? pathname === href : pathname.startsWith(href);
+
+  return (
+    <nav className='sticky top-0 z-30 bg-gov-dark border-b border-gov-forest/40 shadow-md'>
+      <div className='max-w-6xl mx-auto px-4 sm:px-6'>
+        <div className='flex items-center gap-1 sm:gap-2 overflow-x-auto'>
+          <div className='flex items-center gap-2 py-3 pr-4 border-r border-gov-forest/40 mr-2 shrink-0'>
+            <Database className='w-4 h-4 text-gov-gold' />
+            <span className='text-sm font-semibold text-white whitespace-nowrap'>Admin</span>
+          </div>
+          {NAV_ITEMS.map(({ href, label, icon: Icon, exact }) => {
+            const active = isActive(href, exact);
+            return (
+              <Link
+                key={href}
+                href={href}
+                className={`inline-flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors whitespace-nowrap ${
+                  active
+                    ? 'bg-gov-gold/20 text-gov-gold font-medium'
+                    : 'text-gov-sage/70 hover:text-white hover:bg-gov-forest/40'
+                }`}>
+                <Icon className='w-4 h-4' />
+                {label}
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,0 +1,337 @@
+/**
+ * /admin — admin overview dashboard.
+ *
+ * Top-level landing page for admins. Aggregates a few "what's the
+ * system doing right now?" widgets pulled from the existing backend
+ * admin endpoints — ingestion jobs, ETL schedule, and ETL health.
+ * Kept intentionally lean: each card answers a single question and
+ * links to the sub-page where the operator can drill in.
+ */
+'use client';
+
+import api from '@/lib/api/axios';
+import { useQuery } from '@tanstack/react-query';
+import {
+  Activity,
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  Clock,
+  Loader2,
+  ListChecks,
+  PlayCircle,
+  TrendingUp,
+  XCircle,
+} from 'lucide-react';
+import Link from 'next/link';
+
+/* ── API response shapes (mirroring backend/routers/admin.py + etl_admin.py) ── */
+interface IngestionStats {
+  total_jobs: number;
+  completed: number;
+  failed: number;
+  running: number;
+  pending: number;
+  completed_with_errors: number;
+  total_items_processed: number;
+  total_items_created: number;
+  total_items_updated: number;
+  domains: Record<string, number>;
+}
+
+interface ScheduleSummary {
+  timestamp: string;
+  running_today: number;
+  skipping_today: number;
+  total_sources: number;
+  efficiency: { skip_percentage: number; vs_fixed_schedule: string };
+  sources_to_run: Array<{ source: string; reason: string }>;
+}
+
+interface EtlHealth {
+  timestamp: string;
+  scheduler_status: string;
+  schedule_summary: unknown;
+}
+
+export default function AdminOverviewPage() {
+  // Each query is independent — failing one doesn't blank the others.
+  const ingestion = useQuery<IngestionStats>({
+    queryKey: ['admin', 'ingestion-stats', 7],
+    queryFn: async () =>
+      (await api.get('/admin/ingestion-jobs/stats/summary', { params: { days: 7 } })).data,
+    staleTime: 30_000,
+  });
+
+  const schedule = useQuery<ScheduleSummary>({
+    queryKey: ['admin', 'etl-schedule-summary'],
+    queryFn: async () => (await api.get('/admin/etl/schedule/summary')).data,
+    staleTime: 60_000,
+  });
+
+  const health = useQuery<EtlHealth>({
+    queryKey: ['admin', 'etl-health'],
+    queryFn: async () => (await api.get('/admin/etl/health')).data,
+    staleTime: 60_000,
+  });
+
+  return (
+    <div className='max-w-6xl mx-auto px-4 sm:px-6 py-8 space-y-6'>
+      <header>
+        <h1 className='text-2xl sm:text-3xl font-bold text-gov-dark'>Admin Overview</h1>
+        <p className='text-gov-forest/60 text-sm mt-1'>
+          Monitor ingestion pipelines, ETL schedule, and system health at a glance.
+        </p>
+      </header>
+
+      {/* ── Top stat grid ── */}
+      <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
+        <StatCard
+          title='Ingestion (last 7 days)'
+          icon={ListChecks}
+          query={ingestion}
+          href='/admin/ingestion'
+          renderValue={(d) => (
+            <>
+              <div className='flex items-baseline gap-2'>
+                <span className='text-3xl font-bold text-gov-dark'>{d.total_jobs}</span>
+                <span className='text-xs text-gov-forest/60'>jobs</span>
+              </div>
+              <div className='flex flex-wrap gap-x-4 gap-y-1 mt-3 text-xs'>
+                <SubStat label='Completed' value={d.completed} tone='ok' />
+                {d.completed_with_errors > 0 && (
+                  <SubStat
+                    label='Completed w/ errors'
+                    value={d.completed_with_errors}
+                    tone='warn'
+                  />
+                )}
+                <SubStat label='Failed' value={d.failed} tone={d.failed > 0 ? 'bad' : 'muted'} />
+                {d.running > 0 && <SubStat label='Running' value={d.running} tone='info' />}
+              </div>
+            </>
+          )}
+        />
+
+        <StatCard
+          title='ETL schedule today'
+          icon={PlayCircle}
+          query={schedule}
+          href='/status'
+          renderValue={(d) => (
+            <>
+              <div className='flex items-baseline gap-2'>
+                <span className='text-3xl font-bold text-gov-dark'>
+                  {d.running_today}
+                  <span className='text-base text-gov-forest/50'>/{d.total_sources}</span>
+                </span>
+                <span className='text-xs text-gov-forest/60'>sources running</span>
+              </div>
+              <p className='text-xs text-gov-forest/60 mt-3 line-clamp-1'>
+                {d.efficiency.vs_fixed_schedule}
+              </p>
+            </>
+          )}
+        />
+
+        <StatCard
+          title='ETL system health'
+          icon={Activity}
+          query={health}
+          href='/status'
+          renderValue={(d) => {
+            const ok = d.scheduler_status === 'healthy';
+            return (
+              <>
+                <div className='flex items-center gap-2'>
+                  {ok ? (
+                    <CheckCircle2 className='w-6 h-6 text-emerald-500' />
+                  ) : (
+                    <XCircle className='w-6 h-6 text-red-500' />
+                  )}
+                  <span className='text-2xl font-bold text-gov-dark capitalize'>
+                    {d.scheduler_status.split(':')[0]}
+                  </span>
+                </div>
+                <p className='text-xs text-gov-forest/60 mt-3'>
+                  Updated {timeAgo(d.timestamp)}
+                </p>
+              </>
+            );
+          }}
+        />
+      </div>
+
+      {/* ── Ingestion: items processed widget ── */}
+      {ingestion.data && (
+        <section className='bg-white border border-gov-sage/20 rounded-xl p-5 shadow-sm'>
+          <div className='flex items-center gap-2 mb-3'>
+            <TrendingUp className='w-4 h-4 text-gov-sage' />
+            <h2 className='text-sm font-semibold text-gov-dark'>
+              Ingestion volume (last 7 days)
+            </h2>
+          </div>
+          <div className='grid grid-cols-3 gap-4'>
+            <Metric label='Items processed' value={ingestion.data.total_items_processed} />
+            <Metric label='Created' value={ingestion.data.total_items_created} tone='ok' />
+            <Metric label='Updated' value={ingestion.data.total_items_updated} tone='info' />
+          </div>
+
+          {Object.keys(ingestion.data.domains).length > 0 && (
+            <>
+              <p className='text-xs text-gov-forest/60 mt-5 mb-2 uppercase tracking-wide font-medium'>
+                Jobs by domain
+              </p>
+              <div className='flex flex-wrap gap-2'>
+                {Object.entries(ingestion.data.domains)
+                  .sort(([, a], [, b]) => b - a)
+                  .map(([domain, count]) => (
+                    <Link
+                      key={domain}
+                      href={`/admin/ingestion?domain=${encodeURIComponent(domain)}`}
+                      className='inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-gov-sage/10 hover:bg-gov-sage/20 text-xs text-gov-forest font-medium transition-colors'>
+                      <span className='font-mono'>{domain}</span>
+                      <span className='text-gov-forest/50'>·</span>
+                      <span className='text-gov-sage font-semibold'>{count}</span>
+                    </Link>
+                  ))}
+              </div>
+            </>
+          )}
+        </section>
+      )}
+
+      {/* ── ETL sources to run today ── */}
+      {schedule.data && schedule.data.sources_to_run.length > 0 && (
+        <section className='bg-white border border-gov-sage/20 rounded-xl p-5 shadow-sm'>
+          <div className='flex items-center gap-2 mb-3'>
+            <Clock className='w-4 h-4 text-gov-sage' />
+            <h2 className='text-sm font-semibold text-gov-dark'>Sources scheduled today</h2>
+          </div>
+          <ul className='space-y-2'>
+            {schedule.data.sources_to_run.map(({ source, reason }) => (
+              <li
+                key={source}
+                className='flex items-start justify-between gap-3 px-3 py-2 rounded-lg bg-gov-cream'>
+                <div>
+                  <span className='text-sm font-mono font-semibold text-gov-dark'>{source}</span>
+                  <p className='text-xs text-gov-forest/60 mt-0.5'>{reason}</p>
+                </div>
+                <PlayCircle className='w-4 h-4 text-gov-sage shrink-0 mt-0.5' />
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+/* ── Building blocks ── */
+
+interface QueryLike<T> {
+  data?: T;
+  isLoading: boolean;
+  error: unknown;
+}
+
+function StatCard<T>({
+  title,
+  icon: Icon,
+  query,
+  href,
+  renderValue,
+}: {
+  title: string;
+  icon: React.ElementType;
+  query: QueryLike<T>;
+  href: string;
+  renderValue: (data: T) => React.ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      className='group bg-white border border-gov-sage/20 rounded-xl p-5 shadow-sm hover:shadow-md hover:border-gov-sage/40 transition-all'>
+      <div className='flex items-center justify-between mb-3'>
+        <div className='flex items-center gap-2'>
+          <Icon className='w-4 h-4 text-gov-sage' />
+          <h3 className='text-xs font-semibold uppercase tracking-wide text-gov-forest/60'>
+            {title}
+          </h3>
+        </div>
+        <ArrowRight className='w-4 h-4 text-gov-forest/30 group-hover:text-gov-sage transition-colors' />
+      </div>
+
+      {query.isLoading ? (
+        <div className='flex items-center gap-2 text-gov-forest/50 text-sm h-16'>
+          <Loader2 className='w-4 h-4 animate-spin' />
+          Loading…
+        </div>
+      ) : query.error || !query.data ? (
+        <div className='flex items-center gap-2 text-amber-600 text-sm h-16'>
+          <AlertTriangle className='w-4 h-4' />
+          Could not load
+        </div>
+      ) : (
+        renderValue(query.data)
+      )}
+    </Link>
+  );
+}
+
+function SubStat({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: 'ok' | 'bad' | 'warn' | 'info' | 'muted';
+}) {
+  const colour = {
+    ok: 'text-emerald-600',
+    bad: 'text-red-600',
+    warn: 'text-amber-600',
+    info: 'text-blue-600',
+    muted: 'text-gov-forest/50',
+  }[tone];
+  return (
+    <span className={`${colour}`}>
+      <span className='font-semibold'>{value}</span>{' '}
+      <span className='text-gov-forest/60'>{label}</span>
+    </span>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  tone = 'default',
+}: {
+  label: string;
+  value: number;
+  tone?: 'ok' | 'info' | 'default';
+}) {
+  const colour = {
+    ok: 'text-emerald-600',
+    info: 'text-blue-600',
+    default: 'text-gov-dark',
+  }[tone];
+  return (
+    <div>
+      <p className='text-xs text-gov-forest/60 font-medium'>{label}</p>
+      <p className={`text-2xl font-bold ${colour}`}>{value.toLocaleString()}</p>
+    </div>
+  );
+}
+
+function timeAgo(iso: string | null | undefined): string {
+  if (!iso) return 'never';
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}


### PR DESCRIPTION
## Summary

First slice of the admin dashboard, building on the backend endpoints that already exist. **No new backend code** — purely frontend wiring on top of the existing infrastructure.

## Routes added

| Route | What it does | Backend it uses |
|---|---|---|
| \`/admin\` (layout) | Wraps every admin route in \`<AdminGuard>\` and renders the section nav. | n/a |
| \`/admin\` (page) | Overview cards: ingestion (7d), ETL schedule today, ETL health. Plus a volume widget and jobs-by-domain chip cloud. | \`GET /admin/ingestion-jobs/stats/summary\` · \`GET /admin/etl/schedule/summary\` · \`GET /admin/etl/health\` |
| \`/admin/ingestion\` | Paginated, filterable job list. Filters live in URL query params (\`?domain=&status=&days=&page=\`) so links/refresh round-trip cleanly. Desktop table + mobile card layout. | \`GET /admin/ingestion-jobs\` |
| \`/admin/ingestion/[jobId]\` | Full job detail: every timing field, every metric, errors array, metadata blob. | \`GET /admin/ingestion-jobs/{id}\` |

## Defense in depth (auth)

- **Middleware** ([lib/supabase/middleware.ts:13](frontend/lib/supabase/middleware.ts:13)) already protects \`/admin/*\` server-side and redirects to \`/?authRequired=1\` for non-admins. Verified locally: \`GET /admin\` returns 200 with that redirect for an unauthenticated user.
- **\`<AdminGuard>\`** wraps the admin layout client-side as a UX backstop.
- **Backend endpoints** all carry \`require_roles([\"admin\"])\` already.

## What was reused

- \`AdminGuard\` from \`lib/auth/admin.tsx\`
- \`api\` axios client (auto-attaches Supabase bearer token, handles cold-start retries)
- TanStack Query for fetching/caching, matching the \`/status\` page pattern
- Existing gov-\* Tailwind palette and lucide-react icons

## What's NOT in this PR (per the design doc)

These are the future steps and will land separately:
- \`/admin/etl\` — schedule + manual trigger (mostly existing endpoints, plus stub trigger/history endpoints)
- \`/admin/audit-log\` — new backend table + FastAPI dependency to log admin write actions
- \`/admin/users\` — full-stack user management (the biggest piece — needs all-new backend)

## Verified locally

- \`tsc --noEmit\` clean
- \`next lint\` clean
- Middleware redirects unauthenticated \`/admin\` requests to \`/?authRequired=1\` as expected
- No server or browser console errors

## Test plan

- [ ] Sign in as a non-admin user, visit \`/admin\` → redirected to \`/\` (server-side or client-side, either works)
- [ ] Sign in as an admin user, visit \`/admin\` → see the three overview cards loading their data
- [ ] Click "Ingestion Jobs" in the nav → land on \`/admin/ingestion\` with the most recent 7 days of jobs
- [ ] Apply filters (domain text, status select, days select) → URL updates and the list re-queries
- [ ] Refresh the page with filters in the URL → filters persist
- [ ] Click a job row → land on \`/admin/ingestion/[jobId]\` with the full detail
- [ ] Click "Back to ingestion jobs" → return to the list with filters preserved
- [ ] Click "Pipeline Status" in the nav → land on the existing \`/status\` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)