### PR TITLE
fix(deploy): drop prod gunicorn workers from 4 to 1

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -61,9 +61,14 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 # Run with Gunicorn for production.
 #
-# Worker count is overridable via the ``WEB_CONCURRENCY`` env var
-# (read natively by gunicorn) — leave it unset to use the default
-# below. We default to 1 worker because:
+# Worker count is intentionally NOT specified on the command line so
+# gunicorn falls back to the ``WEB_CONCURRENCY`` env var (its native
+# default lookup), which in turn defaults to 1 if unset. That makes
+# the worker count tunable from Render's env-vars panel without a
+# rebuild — set ``WEB_CONCURRENCY=2`` (or higher) when CPU saturates,
+# revert to ``1`` to drop memory.
+#
+# Why we err on the low side:
 #
 #   * Each Uvicorn worker re-imports the full app: pandas, numpy,
 #     pdfplumber, the auto-seeder, APScheduler, the in-memory
@@ -73,10 +78,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 #   * FastAPI/Uvicorn is async — a single worker handles dozens of
 #     concurrent I/O-bound requests (DB queries, HTTP fetches) on
 #     one event loop. The bottleneck for this app is RAM, not CPU.
-#   * If you do hit CPU saturation, bump to 2 via the env var
-#     (``WEB_CONCURRENCY=2``) instead of editing this Dockerfile.
 CMD ["gunicorn", "main:app", \
-     "--workers", "1", \
      "--worker-class", "uvicorn.workers.UvicornWorker", \
      "--bind", "0.0.0.0:8000", \
      "--access-logfile", "-", \

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -59,9 +59,24 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
-# Run with Gunicorn for production
+# Run with Gunicorn for production.
+#
+# Worker count is overridable via the ``WEB_CONCURRENCY`` env var
+# (read natively by gunicorn) — leave it unset to use the default
+# below. We default to 1 worker because:
+#
+#   * Each Uvicorn worker re-imports the full app: pandas, numpy,
+#     pdfplumber, the auto-seeder, APScheduler, the in-memory
+#     cache. That's ~200MB resident per worker, so 4 workers blows
+#     past Render's 512MB Starter tier and clips the 2GB Standard
+#     tier once the cache fills.
+#   * FastAPI/Uvicorn is async — a single worker handles dozens of
+#     concurrent I/O-bound requests (DB queries, HTTP fetches) on
+#     one event loop. The bottleneck for this app is RAM, not CPU.
+#   * If you do hit CPU saturation, bump to 2 via the env var
+#     (``WEB_CONCURRENCY=2``) instead of editing this Dockerfile.
 CMD ["gunicorn", "main:app", \
-     "--workers", "4", \
+     "--workers", "1", \
      "--worker-class", "uvicorn.workers.UvicornWorker", \
      "--bind", "0.0.0.0:8000", \
      "--access-logfile", "-", \


### PR DESCRIPTION
## Summary
- Lowers `--workers 4` → `--workers 1` in `backend/Dockerfile.prod`
- Adds a comment block explaining the reasoning + the `WEB_CONCURRENCY` env var as the override path

## Why
Render's latest alert (`audit_app exceeded its memory limit`) was caused by 4 Uvicorn workers each re-importing the full app (pandas, numpy, pdfplumber, auto-seeder, APScheduler, in-memory cache) — about 200MB resident per worker, ~800MB total. That's over Render's Starter (512MB) and clips Standard (2GB) once the cache fills.

For this app's traffic profile (≤20 req/s, all I/O-bound) a single async worker is plenty. If a real CPU bottleneck shows up later, bumping to 2 via `WEB_CONCURRENCY=2` in Render env vars is a one-click change.

## Pre-deploy reminder
Render is currently configured to build from `backend/Dockerfile` (the dev one with `--reload`). After this merges, also flip the **Dockerfile Path** in Render's service settings to `backend/Dockerfile.prod` so this change actually takes effect.

## Test plan
- [ ] Merge → flip Render Dockerfile path to `backend/Dockerfile.prod` → manual redeploy
- [ ] Watch Render memory chart — should drop ~30-50% within 5 min
- [ ] Watch p95 latency — should be flat or better
- [ ] If CPU pins at 100% under traffic, set `WEB_CONCURRENCY=2` (no rebuild needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)