### PR TITLE
fix(deploy): bind gunicorn to $PORT (fixes Render port scan timeout)

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -52,39 +52,42 @@ ENV PYTHONPATH=/app
 ENV PYTHONUNBUFFERED=1
 ENV ENVIRONMENT=production
 
-# Expose port
+# Expose the default port so platforms that auto-detect from EXPOSE
+# (Render, Railway, Fly.io) still see 8000 when ``$PORT`` isn't set.
+# At runtime we bind to ``$PORT`` if the platform set one — see CMD.
 EXPOSE 8000
 
-# Health check
+# Health check — uses the same ``$PORT`` env var as the server bind so
+# it works whether the platform sets PORT or not.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+    CMD curl -f http://localhost:${PORT:-8000}/health || exit 1
 
 # Run with Gunicorn for production.
 #
-# Worker count is intentionally NOT specified on the command line so
-# gunicorn falls back to the ``WEB_CONCURRENCY`` env var (its native
-# default lookup), which in turn defaults to 1 if unset. That makes
-# the worker count tunable from Render's env-vars panel without a
-# rebuild — set ``WEB_CONCURRENCY=2`` (or higher) when CPU saturates,
-# revert to ``1`` to drop memory.
+# Two things make this CMD slightly unusual:
 #
-# Why we err on the low side:
+# 1. Worker count is intentionally NOT specified on the command line so
+#    gunicorn falls back to the ``WEB_CONCURRENCY`` env var (its native
+#    default lookup), which in turn defaults to 1 if unset. That makes
+#    the worker count tunable from the host's env-vars panel without a
+#    rebuild — set ``WEB_CONCURRENCY=2`` (or higher) when CPU saturates,
+#    revert to ``1`` to drop memory. Each Uvicorn worker re-imports the
+#    full app (pandas, numpy, pdfplumber, the auto-seeder, APScheduler,
+#    the in-memory cache) — about ~200MB resident per worker — so a
+#    single async worker is the right default for this codebase.
 #
-#   * Each Uvicorn worker re-imports the full app: pandas, numpy,
-#     pdfplumber, the auto-seeder, APScheduler, the in-memory
-#     cache. That's ~200MB resident per worker, so 4 workers blows
-#     past Render's 512MB Starter tier and clips the 2GB Standard
-#     tier once the cache fills.
-#   * FastAPI/Uvicorn is async — a single worker handles dozens of
-#     concurrent I/O-bound requests (DB queries, HTTP fetches) on
-#     one event loop. The bottleneck for this app is RAM, not CPU.
-CMD ["gunicorn", "main:app", \
-     "--worker-class", "uvicorn.workers.UvicornWorker", \
-     "--bind", "0.0.0.0:8000", \
-     "--access-logfile", "-", \
-     "--error-logfile", "-", \
-     "--log-level", "info", \
-     "--timeout", "120", \
-     "--keep-alive", "5", \
-     "--max-requests", "1000", \
-     "--max-requests-jitter", "100"]
+# 2. The bind address uses ``${PORT:-8000}`` so the server listens on
+#    whatever port the host expects. Render in particular sets
+#    ``PORT=10000`` by default and runs a port scan against that
+#    address; binding to a hardcoded 8000 would make the deploy fail
+#    with ``no open ports detected``. The ``${...}`` expansion needs a
+#    shell, so we wrap in ``sh -c "exec gunicorn ..."``. The ``exec``
+#    is important: it replaces the shell with gunicorn so SIGTERM (used
+#    for graceful shutdown) reaches gunicorn directly instead of dying
+#    at the shell wrapper.
+CMD ["sh", "-c", "exec gunicorn main:app \
+  --worker-class uvicorn.workers.UvicornWorker \
+  --bind 0.0.0.0:${PORT:-8000} \
+  --access-logfile - --error-logfile - --log-level info \
+  --timeout 120 --keep-alive 5 \
+  --max-requests 1000 --max-requests-jitter 100"]


### PR DESCRIPTION
## Summary

Render's deploy was failing with:

```
==> Port scan timeout reached, no open ports detected.
==> Exited with status 128
```

even though gunicorn was starting up successfully and saying it was listening. Root cause: Render's port scanner checks the port specified by the `PORT` env var (default `10000`), not whatever the Dockerfile binds to. With `--bind 0.0.0.0:8000` hardcoded, every deploy was technically up but unreachable from Render's edge.

## Why we didn't notice sooner

The old container kept serving traffic on its existing port the whole time, masking failed deploys. PR #98 was big enough to force a real redeploy and the failure surfaced as the production-OOM symptom.

## What changes

- `--bind 0.0.0.0:${PORT:-8000}` — Render sets `PORT=10000`, server listens there. Local docker runs without `PORT` set still get 8000.
- Wrap CMD in `sh -c "exec gunicorn ..."` so `${PORT:-8000}` expands. The `exec` is critical — it replaces the shell with gunicorn so SIGTERM lands directly on the worker for graceful shutdown.
- Healthcheck updated to match: `curl localhost:${PORT:-8000}/health`.
- `EXPOSE 8000` kept so auto-detection by Railway/Fly/etc. still works without `PORT` set.

## Test plan

- [ ] Merge → automatic Render redeploy
- [ ] Watch deploy logs for `[INFO] Listening at: http://0.0.0.0:10000` (or whatever `PORT` is on your service)
- [ ] No more `Port scan timeout reached` message
- [ ] Old `/health` UptimeRobot check on the public URL keeps returning 200
- [ ] Memory chart should also drop now since 1 worker (from PR #99) actually runs in the new container

🤖 Generated with [Claude Code](https://claude.com/claude-code)