### PR TITLE
fix(deploy): add gunicorn to requirements.txt (fixes status 127 on Render)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,11 @@
 fastapi>=0.115.5
 uvicorn[standard]>=0.32.0
+# Production process manager for the FastAPI app — Dockerfile.prod runs
+# ``gunicorn main:app --worker-class uvicorn.workers.UvicornWorker``.
+# Uvicorn alone works for dev / single-process; gunicorn adds graceful
+# worker recycling (--max-requests), proper SIGTERM handling, and a
+# single supervisor process so OOM restarts are clean.
+gunicorn>=23.0.0
 sqlalchemy>=2.0.23
 alembic>=1.12.1
 pydantic>=2.10.2


### PR DESCRIPTION
## Summary

Render deploy was failing with:

\`\`\`
sh: 1: exec: gunicorn: not found
==> Exited with status 127
\`\`\`

Root cause: \`backend/Dockerfile.prod\` has been calling \`gunicorn main:app\` since it was first added, but \`gunicorn\` was never declared in \`requirements.txt\`. The bug was hidden because the dev Dockerfile (\`uvicorn --reload\`) is what Render was actually running until the recent path flip to \`Dockerfile.prod\`.

This was also the underlying cause of the earlier \`Port scan timeout reached, no open ports detected\` failures — the JSON-form CMD silently exited when the binary wasn't found, so nothing was bound to any port. Wrapping the CMD in \`sh -c\` (PR #100) made the shell surface the real error.

## Change

Adds one line to requirements.txt:

\`\`\`
gunicorn>=23.0.0
\`\`\`

23.x is current stable.

## Test plan

- [ ] Merge → automatic Render redeploy
- [ ] Build picks up gunicorn into the wheels stage
- [ ] Container start logs should show:
  \`\`\`
  [INFO] Starting gunicorn 23.x
  [INFO] Listening at: http://0.0.0.0:10000
  [INFO] Using worker: uvicorn.workers.UvicornWorker
  [INFO] Booting worker with pid: ...
  \`\`\`
- [ ] No more \`gunicorn: not found\` or \`Exited with status 127\`
- [ ] Memory should stay flat (1 worker from PR #99)

🤖 Generated with [Claude Code](https://claude.com/claude-code)