### PR TITLE
fix(deploy): appuser-writable log path + home dir for gunicorn

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -22,8 +22,13 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# Create non-root user
-RUN groupadd -r appuser && useradd -r -g appuser appuser
+# Create non-root user with a writable home directory.
+# ``-m -d /home/appuser`` is required because gunicorn's control
+# server (and various other libs) write small files under ``$HOME``
+# at boot — without a real home dir gunicorn fails with
+# ``Permission denied: '/home/appuser'`` and the master exits.
+RUN groupadd -r appuser \
+    && useradd -r -g appuser -m -d /home/appuser -s /bin/bash appuser
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \

--- a/backend/main.py
+++ b/backend/main.py
@@ -33,11 +33,31 @@ from sqlalchemy import or_
 from sqlalchemy.orm import Session
 from starlette.responses import JSONResponse, Response
 
-# Initialize logger early (before Redis cache import)
+# Initialize logger early (before Redis cache import).
+#
+# Stream handler (stdout) is always on — that's what Render / Docker
+# capture and what shows up in the platform's log viewer.
+#
+# File handler is best-effort: write to ``logs/main_backend.log`` if
+# the directory exists and is writable, otherwise skip silently. The
+# previous default (``FileHandler("main_backend.log")``) wrote to the
+# CWD, which on Render is ``/app`` — a root-owned directory the
+# non-root ``appuser`` can't create files in, so the worker crashed
+# at import time with PermissionError. Writing under ``logs/`` (which
+# the Dockerfile chowns to ``appuser``) keeps the file log working
+# locally without breaking container starts.
+_log_handlers: list[logging.Handler] = [logging.StreamHandler()]
+try:
+    _log_handlers.append(logging.FileHandler("logs/main_backend.log"))
+except (OSError, PermissionError):
+    # No writable log dir (read-only FS, missing dir, etc.). Stream
+    # handler alone is fine — the platform captures stdout anyway.
+    pass
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    handlers=[logging.StreamHandler(), logging.FileHandler("main_backend.log")],
+    handlers=_log_handlers,
 )
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Render deploy got past the gunicorn-not-found stage but now hits two permission errors during worker boot:

\`\`\`
[ERROR] Control server error: [Errno 13] Permission denied: '/home/appuser'
PermissionError: [Errno 13] Permission denied: '/app/main_backend.log'
[ERROR] Worker (pid:7) exited with code 3.
[ERROR] Reason: Worker failed to boot.
\`\`\`

Both because the container runs as non-root \`appuser\` and the app/gunicorn try to write to root-owned paths.

## Two fixes

### 1. \`main_backend.log\` — write under appuser-owned dir

\`backend/main.py\` was opening \`FileHandler("main_backend.log")\` (relative path), which resolved to \`/app/main_backend.log\`. \`/app\` is the WORKDIR (root-owned); \`appuser\` can read its contents but can't create new files there.

Switched to:
\`\`\`python
_log_handlers = [logging.StreamHandler()]
try:
    _log_handlers.append(logging.FileHandler("logs/main_backend.log"))
except (OSError, PermissionError):
    pass
\`\`\`

\`logs/\` is already chowned to \`appuser\` in the Dockerfile. Stream handler stays unconditional — that's what Render's log viewer captures anyway. File handler is best-effort: if the dir isn't writable, we just skip it instead of crashing the worker.

### 2. \`/home/appuser\` — give gunicorn a real home dir

\`useradd -r -g appuser appuser\` creates a system user but skips home-dir creation. Gunicorn's control server (and various other libs) write small files under \`\$HOME\` at boot — without a home dir it errors and the master shuts down.

Switched to \`useradd -r -g appuser -m -d /home/appuser -s /bin/bash appuser\` so \`appuser\` has a real, writable home.

## Test plan

- [ ] Merge → automatic Render redeploy
- [ ] No more \`Permission denied: '/home/appuser'\` from gunicorn control server
- [ ] No more \`PermissionError: '/app/main_backend.log'\` from worker
- [ ] Worker boots cleanly
- [ ] Logs show normal startup: router registrations, auto-seeder, etc.
- [ ] \`/health\` and \`/api/*\` keep returning 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)