### PR TITLE
fix(seeding): global wall-clock budget so seed --all exits before CI step timeout

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -40,6 +40,10 @@ env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
   SEED_RATE_LIMIT: ${{ vars.SEED_RATE_LIMIT || '60/min' }}
   SEED_TIMEOUT_SECONDS: ${{ vars.SEED_TIMEOUT_SECONDS || '30.0' }}
+  # Global wall-clock budget for `seed --all` (seconds). Kept below the
+  # "Seed all domains" step timeout-minutes (25) so the CLI exits cleanly
+  # before GitHub SIGKILLs the step. Bump both together if domains are added.
+  SEED_TOTAL_TIMEOUT_SECONDS: ${{ vars.SEED_TOTAL_TIMEOUT_SECONDS || '1320' }}
   SEED_BUDGETS_DATASET_URL: ${{ secrets.SEED_BUDGETS_DATASET_URL }}
   SEED_AUDITS_DATASET_URL: ${{ secrets.SEED_AUDITS_DATASET_URL }}
   SEED_POPULATION_DATASET_URL: ${{ secrets.SEED_POPULATION_DATASET_URL }}

--- a/backend/seeding/cli.py
+++ b/backend/seeding/cli.py
@@ -6,6 +6,7 @@ import argparse
 import signal
 import sys
 import threading
+import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -128,7 +129,35 @@ def run_seed_command(args: argparse.Namespace, settings: SeedingSettings) -> int
 
     status = 0
 
-    for domain in domains:
+    # Materialise so we can index / slice / len for "remaining domains"
+    # reporting, regardless of what _collect_domains returned.
+    domains = list(domains)
+
+    # Global wall-clock budget for the whole `seed --all` run. The per-domain
+    # SIGALRM guard below caps any single stuck domain, but it does nothing
+    # about cumulative drift: enough slow-but-under-budget domains in a row
+    # still blow past the CI step timeout, which SIGKILLs the process — failing
+    # the step and skipping the downstream validation job. This deadline makes
+    # the run stop itself cleanly first: we quit starting new domains once it
+    # passes, and cap the in-flight domain's alarm at the time remaining.
+    total_budget = settings.total_timeout_seconds
+    loop_start = time.monotonic()
+    deadline = loop_start + total_budget if total_budget > 0 else None
+
+    for index, domain in enumerate(domains):
+        if deadline is not None and time.monotonic() >= deadline:
+            skipped = domains[index:]
+            logger.warning(
+                "Global seed budget of %ss exhausted after %.0fs; "
+                "skipping %d remaining domain(s): %s",
+                total_budget,
+                time.monotonic() - loop_start,
+                len(skipped),
+                ", ".join(skipped),
+                extra={"skipped_domains": skipped},
+            )
+            break
+
         handler = REGISTRY.get(domain)
         if handler is None:
             logger.error(
@@ -141,6 +170,9 @@ def run_seed_command(args: argparse.Namespace, settings: SeedingSettings) -> int
         started_at = datetime.now(timezone.utc)
         result: Optional[DomainRunResult] = None
         job_id: Optional[int] = None
+        # Set inside the try once we know the time left; referenced in the
+        # except handler, so it must exist even if we fail before computing it.
+        global_capped = False
 
         _ensure_db_sessionlocal()
         assert SessionLocal is not None  # for type-checkers
@@ -179,7 +211,20 @@ def run_seed_command(args: argparse.Namespace, settings: SeedingSettings) -> int
                 # `seed --all` run. Falls through to the except below,
                 # which rolls back the session, marks the job FAILED,
                 # and lets the outer loop move to the next domain.
-                with _domain_timeout(settings.domain_timeout_seconds):
+                #
+                # If a global budget is active, cap this domain's alarm at the
+                # time remaining so the in-flight domain can't push the run past
+                # the global deadline. `global_capped` records that the global
+                # budget (not this domain's own budget) is the binding limit, so
+                # a resulting timeout is treated as a clean stop, not a failure.
+                domain_budget = settings.domain_timeout_seconds
+                if deadline is not None:
+                    remaining = int(deadline - time.monotonic())
+                    if remaining < domain_budget:
+                        domain_budget = max(1, remaining)
+                        global_capped = True
+
+                with _domain_timeout(domain_budget):
                     result = handler(session=session, settings=settings, context=context)
 
                 # Update job with results
@@ -244,6 +289,39 @@ def run_seed_command(args: argparse.Namespace, settings: SeedingSettings) -> int
 
             except Exception as exc:  # pragma: no cover - requires integration tests
                 session.rollback()
+
+                # A DomainTimeoutError raised because the *global* budget capped
+                # this domain's alarm is an expected, clean "out of time" stop —
+                # not a domain failure. Record it as non-fatal so the CI step
+                # stays green (and the validation job still runs), then stop the
+                # loop. A timeout from the domain's *own* budget falls through to
+                # the failure handling below, exactly as before.
+                if global_capped and isinstance(exc, DomainTimeoutError):
+                    logger.warning(
+                        "Global seed budget exhausted during '%s' (%.0fs elapsed); "
+                        "stopping run cleanly",
+                        domain,
+                        time.monotonic() - loop_start,
+                    )
+                    if job_id:
+                        try:
+                            with SessionLocal() as budget_session:
+                                from models import IngestionJob, IngestionStatus
+
+                                stopped_job = budget_session.get(IngestionJob, job_id)
+                                if stopped_job:
+                                    stopped_job.status = (
+                                        IngestionStatus.COMPLETED_WITH_ERRORS
+                                    )
+                                    stopped_job.finished_at = datetime.now(timezone.utc)
+                                    stopped_job.errors = [
+                                        "stopped: global seed budget exhausted"
+                                    ]
+                                    budget_session.commit()
+                        except Exception:  # pragma: no cover - best-effort
+                            pass
+                    break
+
                 logger.exception(
                     "Domain run failed", extra={"domain": domain, "error": str(exc)}
                 )

--- a/backend/seeding/config.py
+++ b/backend/seeding/config.py
@@ -33,6 +33,18 @@ class SeedingSettings(BaseSettings):
         ge=1,
         description="Per-domain hard timeout; aborts one domain without killing the run.",
     )
+    # Global wall-clock budget for an entire `seed --all` run. The CLI stops
+    # *starting* new domains once this elapses and caps the in-flight domain's
+    # alarm at the time remaining, so the process always exits cleanly before
+    # the CI step timeout (25 min) rather than being SIGKILLed mid-run — a hard
+    # kill marks the step failed and skips the downstream validation job.
+    # 22 min leaves ~3 min of headroom under the 25 min step cap. Set to 0 to
+    # disable the global budget (rely on per-domain timeouts only).
+    total_timeout_seconds: int = Field(
+        default=1320,
+        ge=0,
+        description="Global wall-clock budget for `seed --all`; 0 disables it.",
+    )
     max_retries: int = Field(
         default=3, description="Maximum retry attempts for transient HTTP failures."
     )

--- a/backend/tests/test_seeding_cli_budget.py
+++ b/backend/tests/test_seeding_cli_budget.py
@@ -1,0 +1,167 @@
+"""Tests for the global wall-clock budget in ``run_seed_command``.
+
+These exercise ``seeding.cli.run_seed_command`` with a fake monotonic clock,
+a fake registry, and a sqlite DB. The fake clock drives all deadline logic, so
+no real ``time.sleep`` ever runs; handlers that need to "time out" raise
+``DomainTimeoutError`` directly rather than waiting for a real SIGALRM. The
+per-domain SIGALRM is still armed and cancelled, but with budgets far larger
+than the (instant) handlers, so it never fires — keeping the tests
+deterministic.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Iterator
+
+import pytest
+from models import Base, IngestionJob, IngestionStatus
+from seeding import cli as seed_cli
+from seeding.config import SeedingSettings
+from seeding.types import DomainRunResult
+from sqlalchemy import create_engine, select
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import sessionmaker
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_sqlite(type_, compiler, **kw):  # pragma: no cover - dialect shim
+    return "TEXT"
+
+
+class _Clock:
+    """Controllable stand-in for the ``time`` module used by the CLI."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class _FakeRegistry:
+    def __init__(self, handlers: dict) -> None:
+        self._handlers = handlers
+
+    def domains(self):
+        return list(self._handlers)
+
+    def get(self, name):
+        return self._handlers.get(name)
+
+
+@pytest.fixture()
+def sessionmaker_factory(tmp_path) -> Iterator[sessionmaker]:
+    engine = create_engine(f"sqlite:///{tmp_path / 'seed_cli.db'}")
+    Base.metadata.create_all(engine)
+    try:
+        yield sessionmaker(bind=engine)
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture()
+def clock(monkeypatch, sessionmaker_factory) -> _Clock:
+    """Wire the CLI to the sqlite DB, a no-op builtin loader, and a fake clock."""
+    fake = _Clock()
+    monkeypatch.setattr(seed_cli, "SessionLocal", sessionmaker_factory)
+    monkeypatch.setattr(seed_cli, "load_builtin_domains", lambda: None)
+    monkeypatch.setattr(seed_cli, "time", fake)
+    return fake
+
+
+def _args() -> argparse.Namespace:
+    return argparse.Namespace(domain=None, all=True, dry_run=False, since=None)
+
+
+def _jobs_by_domain(maker: sessionmaker) -> dict:
+    with maker() as session:
+        rows = session.execute(select(IngestionJob)).scalars().all()
+        return {row.domain: row for row in rows}
+
+
+def _make_handler(calls, name, *, work=0.0, raise_timeout=False, clock=None):
+    def _handler(*, session, settings, context):
+        calls.append(name)
+        if clock is not None and work:
+            clock.advance(work)
+        if raise_timeout:
+            raise seed_cli.DomainTimeoutError(
+                "domain exceeded Ns budget; aborted by the CLI"
+            )
+        return DomainRunResult(domain=name)
+
+    return _handler
+
+
+def test_global_budget_skips_remaining_domains_and_stays_green(
+    clock, sessionmaker_factory, monkeypatch
+):
+    calls: list[str] = []
+    handlers = {
+        "a": _make_handler(calls, "a", work=60, clock=clock),
+        "b": _make_handler(calls, "b", work=60, clock=clock),
+        "c": _make_handler(calls, "c", work=60, clock=clock),
+    }
+    monkeypatch.setattr(seed_cli, "REGISTRY", _FakeRegistry(handlers))
+    settings = SeedingSettings(total_timeout_seconds=100, domain_timeout_seconds=600)
+
+    status = seed_cli.run_seed_command(_args(), settings)
+
+    assert status == 0  # clean, green exit (no SIGKILL, validation can run)
+    assert calls == ["a", "b"]  # "c" never started — past the global deadline
+    jobs = _jobs_by_domain(sessionmaker_factory)
+    assert jobs["a"].status == IngestionStatus.COMPLETED
+    assert jobs["b"].status == IngestionStatus.COMPLETED
+    assert "c" not in jobs  # skipped domains get no job record
+
+
+def test_global_budget_truncates_in_flight_domain_cleanly(
+    clock, sessionmaker_factory, monkeypatch
+):
+    calls: list[str] = []
+    handlers = {
+        "a": _make_handler(calls, "a", work=60, clock=clock),
+        # Simulates the globally-capped alarm firing mid-domain.
+        "b": _make_handler(calls, "b", raise_timeout=True),
+        "c": _make_handler(calls, "c"),
+    }
+    monkeypatch.setattr(seed_cli, "REGISTRY", _FakeRegistry(handlers))
+    settings = SeedingSettings(total_timeout_seconds=100, domain_timeout_seconds=600)
+
+    status = seed_cli.run_seed_command(_args(), settings)
+
+    assert status == 0  # a global-budget truncation is NOT a failure
+    assert calls == ["a", "b"]  # "c" never started
+    jobs = _jobs_by_domain(sessionmaker_factory)
+    assert jobs["a"].status == IngestionStatus.COMPLETED
+    assert jobs["b"].status == IngestionStatus.COMPLETED_WITH_ERRORS
+    assert any("budget" in str(e).lower() for e in (jobs["b"].errors or []))
+    assert "c" not in jobs
+
+
+def test_per_domain_timeout_still_fails_and_continues(
+    clock, sessionmaker_factory, monkeypatch
+):
+    # Global budget disabled: a domain blowing its OWN budget is a real failure
+    # (status 1, job FAILED) and the run continues to the next domain — exactly
+    # the behaviour that existed before the global budget was added.
+    calls: list[str] = []
+    handlers = {
+        "a": _make_handler(calls, "a", raise_timeout=True),
+        "b": _make_handler(calls, "b"),
+    }
+    monkeypatch.setattr(seed_cli, "REGISTRY", _FakeRegistry(handlers))
+    settings = SeedingSettings(total_timeout_seconds=0, domain_timeout_seconds=600)
+
+    status = seed_cli.run_seed_command(_args(), settings)
+
+    assert status == 1
+    assert calls == ["a", "b"]  # per-domain failure does not stop the whole run
+    jobs = _jobs_by_domain(sessionmaker_factory)
+    assert jobs["a"].status == IngestionStatus.FAILED
+    assert jobs["b"].status == IngestionStatus.COMPLETED


### PR DESCRIPTION
## What & why

The nightly **Seed all domains** step ([run 26861716070](https://github.com/Rodgers31/audit_app/actions/runs/26861716070/job/79216693431)) was hitting GitHub's 25-min step timeout and getting SIGKILLed. Domains run sequentially with only a **per-domain 600s** SIGALRM guard and **no cap on total runtime**, so cumulative drift — a stalled COB county PDF download eating its full 600s budget, other slow COB downloads (~50–150 KB/s), and a few World Bank read-timeouts — pushed the run just past 25 min. The hard kill fails the step **and skips the downstream `validate` job**, even though all 14 domains had actually committed.

## Change

A **global wall-clock budget** for `seed --all`:

- **config**: `total_timeout_seconds` (default **1320s / 22 min**, env `SEED_TOTAL_TIMEOUT_SECONDS`, `0` disables) — sits below the 25-min step cap.
- **cli**: once the deadline passes, stop starting new domains (logging which were skipped, by name — no silent cap); cap the in-flight domain's SIGALRM at the time remaining so the run can't overrun by a full per-domain budget. A global-budget stop is recorded `COMPLETED_WITH_ERRORS` and exits **0** (green → `validate` still runs). A genuine *per-domain* timeout still `FAIL`s and the run continues, exactly as before.
- **seed.yml**: passes `SEED_TOTAL_TIMEOUT_SECONDS` (default 1320), tunable via repo vars.

## Tests

- New `backend/tests/test_seeding_cli_budget.py` — 3 deterministic tests (fake clock, no real sleeps/signals): skip-remaining (green), global clean-stop (green), per-domain-timeout-still-FAILs.
- Full seeding-related regression: **132 passed**.

## Out of scope (follow-ups)

- **COB download deadline** (turn the worst-case 600s stall into ~120s) and the **audits write loop** (~5 min re-writing 512 rows for zero changes). Those let *all* domains fit comfortably; this PR just guarantees a clean, green finish.
- `develop` is behind `main` on the whole seeding module (missing the SIGALRM guard, WP-API counties fetcher, config fields). Recommend a `main → develop` back-merge to heal the divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)