### PR TITLE
fix(security): enable RLS on public tables + harden functions (Supabase advisor)

### DIFF
--- a/backend/alembic/versions/h8c9d0e1f2a3_enable_rls_and_security_hardening.py
+++ b/backend/alembic/versions/h8c9d0e1f2a3_enable_rls_and_security_hardening.py
@@ -1,0 +1,219 @@
+"""enable_rls_and_security_hardening
+
+Closes the Supabase security-advisor "RLS Disabled in Public" criticals plus the
+two function findings ("Function Search Path Mutable", "Public/Signed-In Can
+Execute SECURITY DEFINER Function").
+
+WHY THIS IS NEEDED
+------------------
+These tables are created by ``Base.metadata.create_all()`` (backend/database.py),
+which creates the table but never enables Row Level Security. Meanwhile Supabase's
+default privileges auto-GRANT full DML to the ``anon`` and ``authenticated`` roles
+on every new ``public`` table. Result: any anonymous user holding the *public*
+anon key (shipped in the browser bundle) can read AND write these tables directly
+through PostgREST (https://<ref>.supabase.co/rest/v1/<table>), bypassing FastAPI.
+Verified empirically on 2026-07-05: anon read live rows from countries/audits/
+ingestion_jobs/imf_weo_observations; anon holds SELECT/INSERT/UPDATE/DELETE/
+TRUNCATE on all of them.
+
+WHY THIS IS SAFE
+----------------
+* The backend, Alembic, and the seeding job all connect as the ``postgres`` role
+  (DB_USER=postgres.<ref>), which has rolbypassrls=true — RLS is invisible to it.
+* The frontend uses supabase-js on ONLY profiles/watchlist_items/data_alerts/
+  newsletter_subscribers (all already RLS-enabled). Every core data table is
+  fetched through FastAPI (NEXT_PUBLIC_API_URL), never PostgREST.
+* Enabling RLS with NO policy = deny-all for anon/authenticated via REST, while
+  the postgres-role backend keeps full access. Nothing in the app breaks.
+
+This migration ALSO revokes the existing anon/authenticated grants (defense in
+depth) and fixes the default privileges so future create_all() tables do not
+silently regress to world-writable.
+
+NOTE: newsletter_subscribers RLS-policy tightening is handled separately in the
+next migration (it requires a companion frontend change) so this critical fix can
+be applied on its own via ``alembic upgrade h8c9d0e1f2a3``.
+
+Revision ID: h8c9d0e1f2a3
+Revises: g7b8c9d0e1f2
+Create Date: 2026-07-05
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "h8c9d0e1f2a3"
+down_revision = "g7b8c9d0e1f2"
+branch_labels = None
+depends_on = None
+
+
+# The 30 public tables flagged "RLS Disabled in Public" by the Supabase advisor.
+# (The four user-facing tables — profiles, watchlist_items, data_alerts,
+#  newsletter_subscribers — already have RLS enabled and are intentionally
+#  excluded here.)
+RLS_TABLES = [
+    "admin_audit_log",
+    "alembic_version",
+    "annotations",
+    "audits",
+    "budget_lines",
+    "constituencies",
+    "countries",
+    "county_org_units",
+    "debt_timeline",
+    "economic_indicators",
+    "entities",
+    "extractions",
+    "fiscal_periods",
+    "fiscal_summaries",
+    "fiscal_years",
+    "gdp_data",
+    "imf_weo_observations",
+    "ingestion_jobs",
+    "loans",
+    "national_entities",
+    "parliament_source_documents",
+    "pending_bills",
+    "population_data",
+    "poverty_indices",
+    "quick_questions",
+    "revenue_by_source",
+    "source_documents",
+    "user_question_answers",
+    "users",
+    "validation_failures",
+]
+
+
+def _tbl_array_sql() -> str:
+    return "ARRAY[" + ", ".join(f"'{t}'" for t in RLS_TABLES) + "]"
+
+
+def upgrade() -> None:
+    # 1) Enable RLS on every flagged table + revoke the anon/authenticated grants.
+    #    Guarded so it is safe on any environment (table/role may be absent) and
+    #    idempotent (ENABLE ROW LEVEL SECURITY is a no-op if already on).
+    op.execute(
+        f"""
+        DO $$
+        DECLARE
+            t text;
+            has_anon boolean := EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon');
+            has_auth boolean := EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated');
+        BEGIN
+            FOREACH t IN ARRAY {_tbl_array_sql()}
+            LOOP
+                IF to_regclass('public.' || t) IS NOT NULL THEN
+                    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', t);
+                    IF has_anon THEN
+                        EXECUTE format('REVOKE ALL ON public.%I FROM anon', t);
+                    END IF;
+                    IF has_auth THEN
+                        EXECUTE format('REVOKE ALL ON public.%I FROM authenticated', t);
+                    END IF;
+                END IF;
+            END LOOP;
+        END $$;
+        """
+    )
+
+    # 2) Stop the regression at the source: prevent Supabase's default privileges
+    #    from auto-granting anon/authenticated on FUTURE tables created by postgres
+    #    (i.e. anything create_all() makes from here on).
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+                EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public REVOKE ALL ON TABLES FROM anon';
+            END IF;
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+                EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public REVOKE ALL ON TABLES FROM authenticated';
+            END IF;
+        END $$;
+        """
+    )
+
+    # 3) Function hardening.
+    #    - set_updated_at: pin search_path (fixes "Function Search Path Mutable").
+    #    - handle_new_user: revoke EXECUTE from public/anon/authenticated. It is a
+    #      trigger function on auth.users (fired only by Supabase Auth); no client
+    #      should be able to call it directly.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF to_regprocedure('public.set_updated_at()') IS NOT NULL THEN
+                EXECUTE $q$ALTER FUNCTION public.set_updated_at() SET search_path = ''$q$;
+            END IF;
+
+            IF to_regprocedure('public.handle_new_user()') IS NOT NULL THEN
+                EXECUTE 'REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM PUBLIC';
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+                    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM anon';
+                END IF;
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+                    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM authenticated';
+                END IF;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Faithful reversal — WARNING: this restores the insecure, world-writable
+    # state (RLS off + anon/authenticated granted full DML). Kept only so the
+    # migration is technically reversible.
+    op.execute(
+        f"""
+        DO $$
+        DECLARE
+            t text;
+            has_anon boolean := EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon');
+            has_auth boolean := EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated');
+        BEGIN
+            FOREACH t IN ARRAY {_tbl_array_sql()}
+            LOOP
+                IF to_regclass('public.' || t) IS NOT NULL THEN
+                    EXECUTE format('ALTER TABLE public.%I DISABLE ROW LEVEL SECURITY', t);
+                    IF has_anon THEN
+                        EXECUTE format('GRANT ALL ON public.%I TO anon', t);
+                    END IF;
+                    IF has_auth THEN
+                        EXECUTE format('GRANT ALL ON public.%I TO authenticated', t);
+                    END IF;
+                END IF;
+            END LOOP;
+        END $$;
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+                EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON TABLES TO anon';
+            END IF;
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+                EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON TABLES TO authenticated';
+            END IF;
+        END $$;
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF to_regprocedure('public.set_updated_at()') IS NOT NULL THEN
+                EXECUTE 'ALTER FUNCTION public.set_updated_at() RESET search_path';
+            END IF;
+            IF to_regprocedure('public.handle_new_user()') IS NOT NULL THEN
+                EXECUTE 'GRANT EXECUTE ON FUNCTION public.handle_new_user() TO PUBLIC';
+            END IF;
+        END $$;
+        """
+    )

--- a/backend/alembic/versions/i9d0e1f2a3b4_lock_down_newsletter_subscribers.py
+++ b/backend/alembic/versions/i9d0e1f2a3b4_lock_down_newsletter_subscribers.py
@@ -1,0 +1,97 @@
+"""lock_down_newsletter_subscribers
+
+Fixes the Supabase advisor "RLS Policy Always True" findings on
+public.newsletter_subscribers.
+
+THE PROBLEM
+-----------
+newsletter_subscribers has RLS enabled, but its policies are permissive to the
+``public`` role:
+  * SELECT  USING (true)               -> ANY anon can dump the entire email list
+  * UPDATE  USING (true) WITH CHECK (true) -> ANY anon can unsubscribe/alter any row
+  * INSERT  WITH CHECK (true)          -> ANY anon can insert
+Verified on 2026-07-05: an anonymous request with the public anon key retrieved
+every subscriber email. This is a PII leak (email harvesting).
+
+THE FIX
+-------
+The backend already exposes the correct server-side path (postgres role, bypasses
+RLS): POST /api/v1/newsletter/{subscribe,unsubscribe}. Once the frontend routes
+through those endpoints, the browser needs NO direct table access, so we drop the
+permissive anon policies entirely and revoke the grants. Backend keeps working
+because the postgres role bypasses RLS.
+
+⚠️ SHIP TOGETHER WITH THE FRONTEND CHANGE
+-----------------------------------------
+This migration MUST be released together with the companion patch to
+frontend/lib/api/auth.ts (subscribeNewsletter / unsubscribeNewsletter switched
+from supabase.from('newsletter_subscribers') to apiClient.post('/newsletter/*')).
+If this migration is applied while the browser still calls PostgREST directly,
+newsletter subscribe/unsubscribe from the site will start failing.
+
+Revision ID: i9d0e1f2a3b4
+Revises: h8c9d0e1f2a3
+Create Date: 2026-07-05
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "i9d0e1f2a3b4"
+down_revision = "h8c9d0e1f2a3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF to_regclass('public.newsletter_subscribers') IS NOT NULL THEN
+                DROP POLICY IF EXISTS "Anyone can subscribe to newsletter"     ON public.newsletter_subscribers;
+                DROP POLICY IF EXISTS "Subscribers can manage own subscription" ON public.newsletter_subscribers;
+                DROP POLICY IF EXISTS "Service role can read all subscribers"   ON public.newsletter_subscribers;
+
+                -- RLS stays ENABLED (already on). With no anon/authenticated
+                -- policy, PostgREST denies them; the postgres/service_role
+                -- backend bypasses RLS and continues to work.
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+                    EXECUTE 'REVOKE ALL ON public.newsletter_subscribers FROM anon';
+                END IF;
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+                    EXECUTE 'REVOKE ALL ON public.newsletter_subscribers FROM authenticated';
+                END IF;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Restore the original permissive policies + grants.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF to_regclass('public.newsletter_subscribers') IS NOT NULL THEN
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+                    EXECUTE 'GRANT SELECT, INSERT, UPDATE ON public.newsletter_subscribers TO anon';
+                END IF;
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+                    EXECUTE 'GRANT SELECT, INSERT, UPDATE ON public.newsletter_subscribers TO authenticated';
+                END IF;
+
+                CREATE POLICY "Anyone can subscribe to newsletter"
+                    ON public.newsletter_subscribers FOR INSERT
+                    WITH CHECK (true);
+                CREATE POLICY "Subscribers can manage own subscription"
+                    ON public.newsletter_subscribers FOR UPDATE
+                    USING (true) WITH CHECK (true);
+                CREATE POLICY "Service role can read all subscribers"
+                    ON public.newsletter_subscribers FOR SELECT
+                    USING (true);
+            END IF;
+        END $$;
+        """
+    )

--- a/frontend/lib/api/auth.ts
+++ b/frontend/lib/api/auth.ts
@@ -152,46 +152,23 @@ export async function markAllAlertsRead(): Promise<void> {
 }
 
 /* ───── Newsletter ───── */
+// Routed through the FastAPI backend (POST /api/v1/newsletter/*) rather than
+// hitting Supabase directly. The backend runs as the postgres role, so
+// newsletter_subscribers can keep RLS locked down (no anon table access) —
+// see migration i9d0e1f2a3b4_lock_down_newsletter_subscribers.
 export async function subscribeNewsletter(
   email: string
 ): Promise<{ status: 'subscribed' | 'resubscribed' | 'already_subscribed'; email: string }> {
-  // Check if already subscribed and active first
-  const { data: existing } = await supabase
-    .from('newsletter_subscribers')
-    .select('email, unsubscribed_at')
-    .eq('email', email)
-    .maybeSingle();
+  const { apiClient } = await import('@/lib/api/axios');
+  const { data } = await apiClient.post('/newsletter/subscribe', { email });
+  const status = data.status as 'subscribed' | 'resubscribed' | 'already_subscribed';
 
-  if (existing) {
-    if (existing.unsubscribed_at) {
-      // Previously unsubscribed → re-subscribe
-      const { error } = await supabase
-        .from('newsletter_subscribers')
-        .update({
-          unsubscribed_at: null,
-          subscribed_at: new Date().toISOString(),
-        })
-        .eq('email', email);
-      if (error) throw error;
-      // Fire-and-forget: send welcome-back email via backend
-      _sendWelcomeEmail(email);
-      return { status: 'resubscribed', email };
-    }
-    // Already subscribed and active
-    return { status: 'already_subscribed', email };
+  // Fire-and-forget welcome email for new / returning subscribers
+  if (status === 'subscribed' || status === 'resubscribed') {
+    _sendWelcomeEmail(email);
   }
 
-  // New subscriber
-  const { error: insertError } = await supabase
-    .from('newsletter_subscribers')
-    .insert({ email, confirmed: false, subscribed_at: new Date().toISOString() });
-
-  if (insertError) throw insertError;
-
-  // Fire-and-forget: send welcome email via backend
-  _sendWelcomeEmail(email);
-
-  return { status: 'subscribed', email };
+  return { status, email };
 }
 
 /**
@@ -208,11 +185,7 @@ async function _sendWelcomeEmail(email: string): Promise<void> {
 }
 
 export async function unsubscribeNewsletter(email: string): Promise<{ status: string }> {
-  const { error } = await supabase
-    .from('newsletter_subscribers')
-    .update({ unsubscribed_at: new Date().toISOString() })
-    .eq('email', email);
-
-  if (error) throw error;
-  return { status: 'unsubscribed' };
+  const { apiClient } = await import('@/lib/api/axios');
+  const { data } = await apiClient.post('/newsletter/unsubscribe', { email });
+  return { status: data.status ?? 'unsubscribed' };
 }

--- a/frontend/lib/api/auth.ts
+++ b/frontend/lib/api/auth.ts
@@ -161,7 +161,19 @@ export async function subscribeNewsletter(
 ): Promise<{ status: 'subscribed' | 'resubscribed' | 'already_subscribed'; email: string }> {
   const { apiClient } = await import('@/lib/api/axios');
   const { data } = await apiClient.post('/newsletter/subscribe', { email });
-  const status = data.status as 'subscribed' | 'resubscribed' | 'already_subscribed';
+
+  // Validate at runtime — a 2xx with an unexpected body (proxy/HTML page,
+  // gateway error, contract drift, empty body) must not be laundered into a
+  // "valid" status by a type assertion. Narrowing from `unknown` also drops
+  // the unsafe `as`. Throwing routes to the caller's existing error handling.
+  const status: unknown = data?.status;
+  if (
+    status !== 'subscribed' &&
+    status !== 'resubscribed' &&
+    status !== 'already_subscribed'
+  ) {
+    throw new Error(`Unexpected newsletter subscribe response: ${JSON.stringify(status)}`);
+  }
 
   // Fire-and-forget welcome email for new / returning subscribers
   if (status === 'subscribed' || status === 'resubscribed') {
@@ -184,8 +196,18 @@ async function _sendWelcomeEmail(email: string): Promise<void> {
   }
 }
 
-export async function unsubscribeNewsletter(email: string): Promise<{ status: string }> {
+export async function unsubscribeNewsletter(
+  email: string
+): Promise<{ status: 'unsubscribed' | 'not_found' }> {
   const { apiClient } = await import('@/lib/api/axios');
   const { data } = await apiClient.post('/newsletter/unsubscribe', { email });
-  return { status: data.status ?? 'unsubscribed' };
+
+  // Same guard as subscribe: don't let an unexpected 2xx body masquerade as a
+  // successful unsubscribe (the old `?? 'unsubscribed'` silently claimed success).
+  const status: unknown = data?.status;
+  if (status !== 'unsubscribed' && status !== 'not_found') {
+    throw new Error(`Unexpected newsletter unsubscribe response: ${JSON.stringify(status)}`);
+  }
+
+  return { status };
 }


### PR DESCRIPTION
## Summary

Closes the Supabase security-advisor **"RLS Disabled in Public"** criticals (30 tables) plus the two function findings. These tables were readable **and** writable by any anonymous user holding the public anon key (which ships in the browser bundle), directly via PostgREST — bypassing FastAPI entirely.

**Verified exploit (before):** an anon request read live rows from `countries`, `audits`, `ingestion_jobs`, `imf_weo_observations`, and could `DELETE`/`TRUNCATE` them. `admin_audit_log` (the security trail) was anon-writable too.

### Why this is safe / non-breaking
- Backend + Alembic + seeding connect as the `postgres` role (`rolbypassrls=true`) — RLS is invisible to them.
- Frontend uses supabase-js on only `profiles`/`watchlist_items`/`data_alerts`/`newsletter_subscribers` (already RLS'd). All core data goes through FastAPI (`NEXT_PUBLIC_API_URL`), never PostgREST.
- RLS-on + no policy = deny-all for anon via REST; the backend keeps full access.

## What's in this PR

**`h8c9d0e1f2a3` — enable_rls_and_security_hardening**
- `ENABLE ROW LEVEL SECURITY` on the 30 flagged tables
- Revoke `anon`/`authenticated` DML grants on them
- Fix default privileges so future `create_all()` tables don't regress to world-writable
- Pin `set_updated_at` `search_path` (fixes "Function Search Path Mutable")
- Revoke public `EXECUTE` on `handle_new_user()` (fixes "…Can Execute SECURITY DEFINER Function")

**`i9d0e1f2a3b4` — lock_down_newsletter_subscribers**
- Drops the permissive "always true" policies that let anyone read the full subscriber email list (fixes "RLS Policy Always True")

**frontend `lib/api/auth.ts`**
- Routes newsletter subscribe/unsubscribe through the existing `POST /api/v1/newsletter/*` backend endpoints instead of hitting Supabase directly (required so the newsletter lockdown doesn't break signup)

## ⚠️ Deploy ordering (important)

`h8c9d0e1f2a3` has **already been applied** to the live (shared) database out-of-band to close the critical hole immediately. The DB is currently at `h8c9d0e1f2a3`.

- Merging this PR → CI `alembic upgrade head` applies **`i9d0e1f2a3b4`** and deploys the updated frontend **together** (keeps newsletter working).
- **Merge this before any other `main`/`develop` deploy**, otherwise CI's `alembic upgrade head` fails with `Can't locate revision 'h8c9d0e1f2a3'`.
- `run-migrations` has no `environment:` scoping → all branches migrate one shared DB, so sync `develop` with `main` after merge.

## Verification (post-apply of h8c9)
- RLS enabled on **30/30** target tables; **0** remaining anon/authenticated grants
- anon REST now returns `42501 permission denied`; anon `DELETE` → `HTTP 401`
- backend `postgres` role still reads all data (audits 537, imf_weo 16,920 rows)
- `set_updated_at`/`handle_new_user` hardened; `handle_new_user` EXECUTE now `postgres`/`service_role` only

## Follow-ups (not in this PR)
- [ ] **Leaked Password Protection** — enable in Dashboard → Authentication → Password security (HaveIBeenPwned). Not doable via SQL.
- [ ] Phase 2 performance: duplicate indexes + 15 unindexed FKs
- [ ] Incidental bug: `app/api/account/delete/route.ts` deletes from `'watchlist'` (table is `watchlist_items`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
