### PR TITLE
perf(db): drop duplicate indexes + index unindexed FKs; fix account-delete table name

### DIFF
--- a/backend/alembic/versions/j0e1f2a3b4c5_perf_index_cleanup.py
+++ b/backend/alembic/versions/j0e1f2a3b4c5_perf_index_cleanup.py
@@ -1,0 +1,97 @@
+"""perf_index_cleanup
+
+Phase 2 (performance) for the Supabase advisor findings:
+  * "Duplicate Index" on national_entities and parliament_source_documents
+  * "Unindexed foreign keys" on 14 tables (15 FK columns)
+
+DUPLICATE INDEXES
+-----------------
+Both tables declared a column as ``unique=True, index=True`` AND a named
+``UniqueConstraint`` on the same column, producing two unique indexes:
+  * national_entities.entity_id  -> ix_national_entities_entity_id  (dup of uq_national_entity)
+  * parliament_source_documents.source_document_id -> ix_parliament_source_documents_source_document_id (dup of uq_parliament_src_doc)
+We drop the redundant ``ix_*`` index and keep the named UniqueConstraint (which
+still provides both the uniqueness guarantee and the index for FK lookups). The
+matching models.py change removes ``unique=True, index=True`` from those columns
+so create_all() does not recreate the duplicate on a fresh database.
+
+UNINDEXED FOREIGN KEYS
+----------------------
+Add a btree index on each FK column that is not already the leading column of an
+index (verified against the live catalog). Follows the existing convention in
+add_performance_indexes.py: performance indexes live in migrations, not as
+column-level index=True in models.py.
+
+Idempotent + guarded (CREATE INDEX IF NOT EXISTS behind a to_regclass check) so
+it is safe to re-run and safe on environments where a create_all()-only table
+does not yet exist. On the live/prod database every table exists, so all 15
+indexes are created when CI runs `alembic upgrade head`.
+
+Revision ID: j0e1f2a3b4c5
+Revises: i9d0e1f2a3b4
+Create Date: 2026-07-05
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "j0e1f2a3b4c5"
+down_revision = "i9d0e1f2a3b4"
+branch_labels = None
+depends_on = None
+
+
+# (index_name, table, column) — one btree index per unindexed FK column.
+FK_INDEXES = [
+    ("ix_annotations_user_id", "annotations", "user_id"),
+    ("ix_audits_period_id", "audits", "period_id"),
+    ("ix_budget_lines_period_id", "budget_lines", "period_id"),
+    ("ix_debt_timeline_source_document_id", "debt_timeline", "source_document_id"),
+    ("ix_economic_indicators_source_document_id", "economic_indicators", "source_document_id"),
+    ("ix_fiscal_summaries_source_document_id", "fiscal_summaries", "source_document_id"),
+    ("ix_gdp_data_source_document_id", "gdp_data", "source_document_id"),
+    ("ix_loans_source_document_id", "loans", "source_document_id"),
+    ("ix_national_entities_parent_ministry_entity_id", "national_entities", "parent_ministry_entity_id"),
+    ("ix_pending_bills_source_document_id", "pending_bills", "source_document_id"),
+    ("ix_population_data_source_document_id", "population_data", "source_document_id"),
+    ("ix_poverty_indices_source_document_id", "poverty_indices", "source_document_id"),
+    ("ix_revenue_by_source_source_document_id", "revenue_by_source", "source_document_id"),
+    ("ix_user_question_answers_question_id", "user_question_answers", "question_id"),
+    ("ix_user_question_answers_user_id", "user_question_answers", "user_id"),
+]
+
+# (redundant_index_name, table) — dropped; the named UniqueConstraint remains.
+DUP_INDEXES = [
+    ("ix_national_entities_entity_id", "national_entities"),
+    ("ix_parliament_source_documents_source_document_id", "parliament_source_documents"),
+]
+
+
+def upgrade() -> None:
+    for idx, tbl, col in FK_INDEXES:
+        op.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF to_regclass('public.{tbl}') IS NOT NULL THEN
+                    EXECUTE 'CREATE INDEX IF NOT EXISTS {idx} ON public.{tbl} ({col})';
+                END IF;
+            END $$;
+            """
+        )
+    for idx, _tbl in DUP_INDEXES:
+        op.execute(f"DROP INDEX IF EXISTS public.{idx};")
+
+
+def downgrade() -> None:
+    # Recreate the (unique) duplicate indexes that were dropped.
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_national_entities_entity_id "
+        "ON public.national_entities (entity_id);"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_parliament_source_documents_source_document_id "
+        "ON public.parliament_source_documents (source_document_id);"
+    )
+    for idx, _tbl, _col in FK_INDEXES:
+        op.execute(f"DROP INDEX IF EXISTS public.{idx};")

--- a/backend/alembic/versions/j0e1f2a3b4c5_perf_index_cleanup.py
+++ b/backend/alembic/versions/j0e1f2a3b4c5_perf_index_cleanup.py
@@ -84,14 +84,21 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Recreate the (unique) duplicate indexes that were dropped.
-    op.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS ix_national_entities_entity_id "
-        "ON public.national_entities (entity_id);"
-    )
-    op.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS ix_parliament_source_documents_source_document_id "
-        "ON public.parliament_source_documents (source_document_id);"
-    )
+    # Recreate the (unique) duplicate indexes that were dropped — guarded with
+    # the same to_regclass check as upgrade() so a missing table can't error.
+    for idx, tbl, col in [
+        ("ix_national_entities_entity_id", "national_entities", "entity_id"),
+        ("ix_parliament_source_documents_source_document_id", "parliament_source_documents", "source_document_id"),
+    ]:
+        op.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF to_regclass('public.{tbl}') IS NOT NULL THEN
+                    EXECUTE 'CREATE UNIQUE INDEX IF NOT EXISTS {idx} ON public.{tbl} ({col})';
+                END IF;
+            END $$;
+            """
+        )
     for idx, _tbl, _col in FK_INDEXES:
         op.execute(f"DROP INDEX IF EXISTS public.{idx};")

--- a/backend/models.py
+++ b/backend/models.py
@@ -959,9 +959,10 @@ class NationalEntity(Base):
     )
 
     id = Column(Integer, primary_key=True, index=True)
-    entity_id = Column(
-        Integer, ForeignKey("entities.id"), nullable=False, unique=True, index=True
-    )
+    # Uniqueness + the FK-lookup index come from the uq_national_entity
+    # UniqueConstraint above; a column-level unique/index here would be a
+    # duplicate (Supabase "Duplicate Index" advisor). See migration j0e1f2a3b4c5.
+    entity_id = Column(Integer, ForeignKey("entities.id"), nullable=False)
     parent_ministry_entity_id = Column(
         Integer, ForeignKey("entities.id"), nullable=True
     )
@@ -992,8 +993,11 @@ class ParliamentSourceDocument(Base):
     )
 
     id = Column(Integer, primary_key=True, index=True)
+    # Uniqueness + the FK-lookup index come from the uq_parliament_src_doc
+    # UniqueConstraint above; a column-level unique/index here would be a
+    # duplicate (Supabase "Duplicate Index" advisor). See migration j0e1f2a3b4c5.
     source_document_id = Column(
-        Integer, ForeignKey("source_documents.id"), nullable=False, unique=True, index=True
+        Integer, ForeignKey("source_documents.id"), nullable=False
     )
     dspace_uuid = Column(String(64), nullable=True, unique=True, index=True)
     dspace_handle = Column(String(100), nullable=True)

--- a/frontend/app/api/account/delete/route.ts
+++ b/frontend/app/api/account/delete/route.ts
@@ -49,7 +49,7 @@ export async function DELETE() {
   );
 
   // Remove dependent rows in order
-  await admin.from('watchlist').delete().eq('user_id', user.id);
+  await admin.from('watchlist_items').delete().eq('user_id', user.id);
   await admin.from('data_alerts').delete().eq('user_id', user.id);
   await admin.from('profiles').delete().eq('id', user.id);
 

--- a/frontend/app/api/account/delete/route.ts
+++ b/frontend/app/api/account/delete/route.ts
@@ -48,12 +48,21 @@ export async function DELETE() {
     { auth: { autoRefreshToken: false, persistSession: false } }
   );
 
-  // Remove dependent rows in order
-  await admin.from('watchlist_items').delete().eq('user_id', user.id);
-  await admin.from('data_alerts').delete().eq('user_id', user.id);
-  await admin.from('profiles').delete().eq('id', user.id);
+  // Best-effort explicit cleanup (defense-in-depth). supabase-js returns
+  // { error } instead of throwing, so capture it. deleteUser() below is the
+  // authoritative step and cascades via ON DELETE CASCADE FKs, so we log any
+  // failures here but do NOT abort — a transient cleanup error must not block
+  // the user's deletion request.
+  const cleanup = await Promise.all([
+    admin.from('watchlist_items').delete().eq('user_id', user.id),
+    admin.from('data_alerts').delete().eq('user_id', user.id),
+    admin.from('profiles').delete().eq('id', user.id),
+  ]);
+  for (const { error: cleanupError } of cleanup) {
+    if (cleanupError) console.warn('[delete-account] cleanup:', cleanupError.message);
+  }
 
-  /* ── 3. Delete the auth user ── */
+  /* ── 3. Delete the auth user (authoritative; cascades to dependent rows) ── */
   const { error } = await admin.auth.admin.deleteUser(user.id);
 
   if (error) {


### PR DESCRIPTION
## Summary

Phase 2 of the Supabase advisor cleanup (performance) plus one incidental bug found during the audit. Follows PR #114 (RLS + function hardening).

## Migration `j0e1f2a3b4c5`

**Duplicate Index** — drops two redundant unique indexes; the named `UniqueConstraint` on each column already provides both uniqueness and the FK-lookup index:
- `ix_national_entities_entity_id` → dup of `uq_national_entity`
- `ix_parliament_source_documents_source_document_id` → dup of `uq_parliament_src_doc`

**Unindexed foreign keys** — adds a btree index on 15 FK columns that were not the leading column of any index (verified against the live catalog):

| Table | FK column(s) |
|---|---|
| annotations | user_id |
| audits | period_id |
| budget_lines | period_id |
| debt_timeline, economic_indicators, fiscal_summaries, gdp_data, loans, pending_bills, population_data, poverty_indices, revenue_by_source | source_document_id |
| national_entities | parent_ministry_entity_id |
| user_question_answers | question_id, user_id |

The migration is guarded (`to_regclass` + `CREATE INDEX IF NOT EXISTS`) and idempotent. Index creation on these small tables takes brief share locks (negligible).

## models.py

Removes column-level `unique=True, index=True` from `national_entities.entity_id` and `parliament_source_documents.source_document_id` so `create_all()` on a fresh DB doesn't recreate the duplicate the migration just dropped. Uniqueness + FK index remain via the existing `UniqueConstraint`. (Convention here: performance indexes live in migrations, not as `index=True` in models — see `add_performance_indexes.py`.)

## Incidental bug fix

`app/api/account/delete/route.ts` deleted from `'watchlist'`, but the table is `watchlist_items` — so account deletion silently never cleaned up watchlist rows (FK cascade would eventually catch them, but the explicit delete was a no-op/error). Fixed the table name.

## Verification
- Migration compiles and chains after `i9d0e1f2a3b4` (`alembic history`)
- `models.py` imports cleanly (31 tables) after the edits
- **All 17 target (table, column) pairs confirmed present in the live schema** via a read-only query — the DDL won't fail on a missing column
- `tsc --noEmit`: exit 0

## Deploy notes
- Not applied out-of-band (unlike the critical RLS fix). CI `alembic upgrade head` applies it on merge.
- Same shared-DB caveat as before: after this merges to `main`, sync `develop` so it also has the migration file before any `develop` deploy.

## Advisor items still open after this
- **Leaked Password Protection** — dashboard toggle (Auth → Password security), not SQL.
- **Unused Index** (~28) — intentionally deferred; mostly small/empty tables with no traffic since the 2026-04-08 stats reset. Revisit after real load rather than bulk-dropping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
