### PR TITLE
fix(seeding): stop domain-timeout being swallowed by fetcher except Exception

### DIFF
--- a/backend/seeding/cli.py
+++ b/backend/seeding/cli.py
@@ -54,8 +54,19 @@ def _collect_domains(requested: Iterable[str], include_all: bool) -> Sequence[st
     return domains
 
 
-class DomainTimeoutError(RuntimeError):
-    """Raised when a single domain handler exceeds its time budget."""
+class DomainTimeoutError(BaseException):
+    """Raised when a single domain handler exceeds its time budget.
+
+    Subclasses ``BaseException`` (not ``Exception``) on purpose. Domain
+    fetchers wrap each upstream call in ``except Exception`` to fall back to a
+    fixture; a plain-``Exception`` timeout would be caught there, treated as
+    "this one item failed", and the domain would keep running. Since the
+    SIGALRM is one-shot, the budget would then be silently lost and the run
+    would overrun the CI step timeout (issues #105-#113). As a
+    ``BaseException`` it bypasses those handlers and propagates to
+    ``run_seed_command``'s own handler, which catches it explicitly — the same
+    reason ``KeyboardInterrupt``/``SystemExit`` are not ``Exception``s.
+    """
 
 
 @contextmanager
@@ -287,7 +298,10 @@ def run_seed_command(args: argparse.Namespace, settings: SeedingSettings) -> int
                         "Committed changes", extra={"domain": domain, "job_id": job_id}
                     )
 
-            except Exception as exc:  # pragma: no cover - requires integration tests
+            # DomainTimeoutError is a BaseException (so fetchers' ``except
+            # Exception`` can't swallow it), so catch it explicitly alongside
+            # Exception here — the handler below already branches on its type.
+            except (DomainTimeoutError, Exception) as exc:
                 session.rollback()
 
                 # A DomainTimeoutError raised because the *global* budget capped

--- a/backend/tests/test_seeding_cli_budget.py
+++ b/backend/tests/test_seeding_cli_budget.py
@@ -165,3 +165,78 @@ def test_per_domain_timeout_still_fails_and_continues(
     jobs = _jobs_by_domain(sessionmaker_factory)
     assert jobs["a"].status == IngestionStatus.FAILED
     assert jobs["b"].status == IngestionStatus.COMPLETED
+
+
+def _make_swallowing_handler(calls, swallowed, name):
+    """A handler mimicking a real domain fetcher: it wraps the (timing-out)
+    upstream call in ``except Exception`` and falls back to a fixture.
+
+    This is the exact shape that made the SIGALRM budget silently useless in
+    production (issues #105-#113): the alarm fired, the fetcher caught the
+    ``DomainTimeoutError`` here as if a single item had failed, "recovered",
+    and the domain kept running until the CI step SIGKILL. If the timeout is a
+    plain ``Exception`` it is swallowed here; as a ``BaseException`` it must
+    propagate to the CLI.
+    """
+
+    def _handler(*, session, settings, context):
+        calls.append(name)
+        try:
+            raise seed_cli.DomainTimeoutError(
+                "domain exceeded Ns budget; aborted by the CLI"
+            )
+        except Exception:  # noqa: BLE001 - intentionally broad; mirrors fetchers
+            swallowed.append(name)
+            return DomainRunResult(domain=name)  # pretend the fixture fallback won
+
+    return _handler
+
+
+def test_global_budget_timeout_survives_fetcher_except_exception(
+    clock, sessionmaker_factory, monkeypatch
+):
+    """Regression: a globally-capped timeout must not be swallowed by a
+    fetcher's ``except Exception``. It should stop the run cleanly (green)."""
+    calls: list[str] = []
+    swallowed: list[str] = []
+    handlers = {
+        "a": _make_handler(calls, "a", work=60, clock=clock),
+        "b": _make_swallowing_handler(calls, swallowed, "b"),
+        "c": _make_handler(calls, "c"),
+    }
+    monkeypatch.setattr(seed_cli, "REGISTRY", _FakeRegistry(handlers))
+    settings = SeedingSettings(total_timeout_seconds=100, domain_timeout_seconds=600)
+
+    status = seed_cli.run_seed_command(_args(), settings)
+
+    assert swallowed == []  # the fetcher's except Exception did NOT catch it
+    assert status == 0  # clean global-budget stop, not a failure
+    assert calls == ["a", "b"]  # timeout stopped the run at b; c never started
+    jobs = _jobs_by_domain(sessionmaker_factory)
+    assert jobs["b"].status == IngestionStatus.COMPLETED_WITH_ERRORS
+    assert "c" not in jobs
+
+
+def test_own_budget_timeout_survives_fetcher_except_exception(
+    clock, sessionmaker_factory, monkeypatch
+):
+    """Regression: a domain's own-budget timeout must not be swallowed by a
+    fetcher's ``except Exception`` either — it should fail that domain (status
+    1, job FAILED) and continue to the next one."""
+    calls: list[str] = []
+    swallowed: list[str] = []
+    handlers = {
+        "a": _make_swallowing_handler(calls, swallowed, "a"),
+        "b": _make_handler(calls, "b"),
+    }
+    monkeypatch.setattr(seed_cli, "REGISTRY", _FakeRegistry(handlers))
+    settings = SeedingSettings(total_timeout_seconds=0, domain_timeout_seconds=600)
+
+    status = seed_cli.run_seed_command(_args(), settings)
+
+    assert swallowed == []  # not swallowed by the fetcher's except Exception
+    assert status == 1
+    assert calls == ["a", "b"]  # failed domain does not stop the whole run
+    jobs = _jobs_by_domain(sessionmaker_factory)
+    assert jobs["a"].status == IngestionStatus.FAILED
+    assert jobs["b"].status == IngestionStatus.COMPLETED


### PR DESCRIPTION
## Summary

Fixes the recurring **"Data pipeline failed: Seeding"** issues (#105, #106, #107, #108, #113). They are not data problems — they're CI step timeouts, and the safety mechanism designed to prevent them was silently defeated.

## Root cause

The seed CLI has a global wall-clock budget (`total_timeout_seconds=1320`, ~22 min) meant to stop the run cleanly ~3 min before GitHub's 25-min step cap. It's enforced by a one-shot `SIGALRM` that raises `DomainTimeoutError`.

But `DomainTimeoutError` subclassed `RuntimeError`, and the domain fetchers wrap every upstream call in `except Exception` to fall back to fixtures (e.g. [economic_indicators/fetcher.py:168](backend/seeding/domains/economic_indicators/fetcher.py#L168), [fiscal_summary/fetcher.py:156](backend/seeding/domains/fiscal_summary/fetcher.py#L156)). So when the World Bank API was slow and the alarm fired, the fetcher **caught the timeout as if a single indicator had failed**, logged `"Failed to fetch … domain exceeded 14s budget; aborted by the CLI"`, and kept going. SIGALRM being one-shot, the budget was then gone and the domain ran unbounded until GitHub SIGKILL'd the step.

Intermittent (World-Bank-driven; the pipeline succeeds when the API is healthy) and no data is lost (fixtures are used) — but every slow-WB night produced a red step and an auto-issue.

## Fix (small, surgical)

- **`DomainTimeoutError` now subclasses `BaseException`** (not `RuntimeError`), so the fetchers' `except Exception` can no longer swallow it — it propagates and actually aborts the domain, exactly like `KeyboardInterrupt`/`SystemExit`.
- **`run_seed_command` catches it explicitly** via `except (DomainTimeoutError, Exception)`; the existing handler already branches on the type (global-budget cap → clean green stop; a domain's own budget → domain failure + continue).

No config/tuning changes — this makes the already-well-designed budget actually work.

## Tests (fail-before / pass-after)

Two regression tests in `test_seeding_cli_budget.py` reproduce the exact bug shape — a handler that raises the timeout inside its own `except Exception` fallback:
- `test_global_budget_timeout_survives_fetcher_except_exception`
- `test_own_budget_timeout_survives_fetcher_except_exception`

Both **FAIL on the pre-fix code** (proving they catch the bug) and **PASS with the fix**. The 3 pre-existing budget tests stay green — **5 passed** total.

## Notes
- Applies automatically; nothing to run.
- Once merged, I'll close #105–#108 and #113 referencing this fix, and sync `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
