### PR TITLE
fix(seeding): cap slow PDF downloads by wall-clock + cache across runs (#119)

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -255,6 +255,22 @@ jobs:
       - run: sudo apt-get update -qq && sudo apt-get install -y -qq tesseract-ocr poppler-utils
       - run: pip install --upgrade pip && pip install -r backend/requirements.txt
 
+      # Persist downloaded source PDFs across runs. The COB county BIRR PDF is
+      # ~48MB and the CDN's throughput swings wildly (measured 50s → 556s for
+      # the same file); once a report is fetched, later runs reuse the cached
+      # copy and skip the download entirely, so a slow-CDN night can't eat the
+      # per-domain budget and abort the run (issue #119). The run-id key with a
+      # rolling restore-key means every run saves its (possibly newer) snapshot
+      # and always restores the most recent prior one — so a newly published
+      # report is picked up the first night and cached from then on.
+      - name: Cache downloaded source PDFs
+        uses: actions/cache@v4
+        with:
+          path: backend/data/seeding/cache/pdfs
+          key: seed-pdf-cache-${{ github.run_id }}
+          restore-keys: |
+            seed-pdf-cache-
+
       - name: Seed all domains
         if: github.event.inputs.domain == '' || github.event.inputs.domain == null
         # Step-level cap below the job's 30-min timeout so the

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -259,15 +259,23 @@ jobs:
       # ~48MB and the CDN's throughput swings wildly (measured 50s → 556s for
       # the same file); once a report is fetched, later runs reuse the cached
       # copy and skip the download entirely, so a slow-CDN night can't eat the
-      # per-domain budget and abort the run (issue #119). The run-id key with a
-      # rolling restore-key means every run saves its (possibly newer) snapshot
-      # and always restores the most recent prior one — so a newly published
-      # report is picked up the first night and cached from then on.
+      # per-domain budget and abort the run (issue #119).
+      #
+      # Key rotates weekly (ISO year-week) rather than per-run so we don't mint
+      # a new ~48MB Actions cache on every nightly run (cache churn / quota).
+      # The rolling restore-key means the first run of a week still restores the
+      # previous week's snapshot, then re-saves under the new weekly key. BIRR
+      # reports are quarterly, so a report published mid-week is at worst
+      # re-downloaded (safely, under the wall-clock cap) until the next week's
+      # key rotates it into the cache.
+      - name: Compute PDF cache period (ISO year-week)
+        id: pdf_cache_period
+        run: echo "period=$(date -u +%G-w%V)" >> "$GITHUB_OUTPUT"
       - name: Cache downloaded source PDFs
         uses: actions/cache@v4
         with:
           path: backend/data/seeding/cache/pdfs
-          key: seed-pdf-cache-${{ github.run_id }}
+          key: seed-pdf-cache-${{ steps.pdf_cache_period.outputs.period }}
           restore-keys: |
             seed-pdf-cache-
 

--- a/backend/seeding/config.py
+++ b/backend/seeding/config.py
@@ -85,6 +85,48 @@ class SeedingSettings(BaseSettings):
         default=True,
         description="Whether HTTP client should automatically follow redirects.",
     )
+    # ── Large-PDF streaming download + cross-run PDF cache ─────────────
+    # Government BIRR/audit PDFs are 12-50MB and the COB CDN's throughput
+    # swings wildly night to night (the same 48MB county file measured
+    # ~50s one night and ~556s the next). The two guards below stop a
+    # slow-CDN night from consuming the whole per-domain SIGALRM budget
+    # and aborting the run mid-parse (issue #119).
+    pdf_download_timeout_seconds: float = Field(
+        default=180.0,
+        ge=1.0,
+        description=(
+            "TOTAL wall-clock cap for a single streamed large-PDF download. "
+            "Unlike timeout_seconds (a per-operation httpx timeout — the max "
+            "gap between chunks), this bounds the whole transfer, so a "
+            "slow-but-steady trickle cannot run unbounded. On breach the "
+            "downloader raises a plain Exception and the domain falls back to "
+            "its fixture instead of the per-domain budget aborting mid-parse. "
+            "Kept well under domain_timeout_seconds (600s) minus the ~254s a "
+            "county-PDF parse needs."
+        ),
+    )
+    pdf_download_max_bytes: int = Field(
+        default=120 * 1024 * 1024,
+        ge=1,
+        description=(
+            "Defensive size ceiling for a streamed PDF download. COB county "
+            "BIRR PDFs are ~48MB; 120MB leaves headroom while still catching "
+            "a runaway or wrong-content-type body before it fills the disk."
+        ),
+    )
+    pdf_cache_ttl_seconds: int = Field(
+        default=30 * 86_400,
+        ge=0,
+        description=(
+            "How long a downloaded source PDF stays reusable in the on-disk "
+            "PDF cache. A published BIRR report is immutable for a quarter, so "
+            "30 days lets a slow-CDN night reuse the last good download instead "
+            "of re-pulling ~48MB; when COB publishes the next report its URL "
+            "changes and the stale entry is simply never requested again. "
+            "Persist the cache dir across CI runs (actions/cache) for this to "
+            "help the nightly job. 0 disables the PDF cache."
+        ),
+    )
     population_dataset_url: str = Field(
         default="file://seeding/real_data/population.json",
         description=(

--- a/backend/seeding/domains/counties_budget/fetcher.py
+++ b/backend/seeding/domains/counties_budget/fetcher.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import logging
 import re
-import tempfile
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -202,7 +201,7 @@ def _fetch_from_cob_county_pdf(
         return None
 
     logger.info("Downloading COB county BIRR PDF: %s", pdf_url)
-    return _download_and_parse_county_pdf(client, pdf_url)
+    return _download_and_parse_county_pdf(client, pdf_url, settings)
 
 
 def _discover_latest_county_birr_via_wp_api(
@@ -425,57 +424,51 @@ def _discover_latest_county_birr_pdf(
 
 
 def _download_and_parse_county_pdf(
-    client: SeedingHttpClient, pdf_url: str
+    client: SeedingHttpClient, pdf_url: str, settings: SeedingSettings
 ) -> Optional[List[Dict[str, Any]]]:
     """Download a COB county BIRR PDF, parse it, return budget records."""
-    tmp_path: Optional[Path] = None
     try:
         from ...pdf_parsers import CoBQuarterlyReportParser
+        from ...pdf_download import get_or_download_pdf
 
         # Use a browser-shaped UA for the PDF download — the same CDN
         # rule that rejects the HTML landing with 415 can block `*/*`
         # downloads too. `Accept: application/pdf` is what real browsers
         # send on direct-PDF clicks.
-        #
-        # Timeout: COB BIRR PDFs are ~30-50MB and the CDN is slow —
-        # measured ~45s end-to-end in production. The default seeder
-        # timeout (30s) times out here, so extend to 180s for this
-        # single request only.
         pdf_headers = {
             "User-Agent": _BROWSER_UA,
             "Accept": "application/pdf,*/*;q=0.8",
         }
-        # Explicit phase logging — this domain stalled in CI without any
-        # signal between fetch-start and job timeout, so we couldn't tell
-        # whether the CDN was slow or the parser hung. The download and
-        # parse lines below bracket each phase and time them so future
-        # stalls point at the real culprit.
+        # get_or_download_pdf enforces a TOTAL wall-clock cap on the transfer
+        # (not httpx's per-chunk timeout, which a slow-but-steady 48MB body
+        # never trips) and reuses a cached copy across runs. So a slow-CDN
+        # night either reuses the last good download or bails to the fixture,
+        # instead of eating the 600s domain budget and aborting mid-parse
+        # (issue #119). Phase logging brackets each phase so a future stall
+        # still points at the real culprit (CDN vs parser).
         logger.info("Starting COB county BIRR PDF download: %s", pdf_url)
         download_start = time.monotonic()
-        response = client.get(
+        pdf_path = get_or_download_pdf(
+            client,
             pdf_url,
-            raise_for_status=True,
+            cache_dir=Path(settings.cache_path) / "pdfs",
+            ttl_seconds=settings.pdf_cache_ttl_seconds,
+            max_seconds=settings.pdf_download_timeout_seconds,
+            max_bytes=settings.pdf_download_max_bytes,
             headers=pdf_headers,
-            timeout=180.0,
         )
         download_elapsed = time.monotonic() - download_start
 
-        with tempfile.NamedTemporaryFile(
-            suffix=".pdf", delete=False, prefix="cob_county_birr_"
-        ) as tmp:
-            tmp.write(response.content)
-            tmp_path = Path(tmp.name)
-
         logger.info(
-            "Downloaded COB county BIRR PDF (%d bytes, %.1fs) to %s",
-            len(response.content),
+            "COB county BIRR PDF ready (%d bytes, %.1fs) at %s",
+            pdf_path.stat().st_size,
             download_elapsed,
-            tmp_path,
+            pdf_path,
         )
 
-        logger.info("Parsing COB county BIRR PDF: %s", tmp_path)
+        logger.info("Parsing COB county BIRR PDF: %s", pdf_path)
         parse_start = time.monotonic()
-        parser = CoBQuarterlyReportParser(tmp_path)
+        parser = CoBQuarterlyReportParser(pdf_path)
         parsed_records = parser.parse()
         parse_elapsed = time.monotonic() - parse_start
         logger.info(
@@ -563,12 +556,8 @@ def _download_and_parse_county_pdf(
             "install pdfplumber for live PDF parsing"
         )
         return None
-    finally:
-        if tmp_path and tmp_path.exists():
-            try:
-                tmp_path.unlink()
-            except OSError:
-                pass
+    # No temp-file cleanup: get_or_download_pdf() returns a path in the
+    # persistent PDF cache (reused across runs), so it must NOT be unlinked.
 
 
 __all__ = ["fetch_budget_payload"]

--- a/backend/seeding/domains/national_budget/fetcher.py
+++ b/backend/seeding/domains/national_budget/fetcher.py
@@ -12,7 +12,7 @@ quarterly NG-BIRR reports.
 from __future__ import annotations
 
 import logging
-import tempfile
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -86,7 +86,7 @@ def _fetch_from_cob_ng_pdf(
         return None
 
     logger.info("Downloading COB NG-BIRR PDF: %s", pdf_url)
-    return _download_and_parse_ng_pdf(client, pdf_url)
+    return _download_and_parse_ng_pdf(client, pdf_url, settings)
 
 
 _NG_BIRR_KEYWORDS = (
@@ -112,7 +112,7 @@ def _discover_latest_ng_birr_pdf(
 
 
 def _download_and_parse_ng_pdf(
-    client: SeedingHttpClient, pdf_url: str
+    client: SeedingHttpClient, pdf_url: str, settings: SeedingSettings
 ) -> Optional[List[Dict[str, Any]]]:
     """Download a COB NG-BIRR PDF, parse it, return budget execution records.
 
@@ -126,24 +126,34 @@ def _download_and_parse_ng_pdf(
     they include ``start_date``/``end_date`` (the writer keys
     ``BudgetLine`` on entity+period+category+subcategory).
     """
-    tmp_path: Optional[Path] = None
     try:
         from .pdf_parser import NgBirrSectoralParser
+        from ...pdf_download import get_or_download_pdf
 
-        response = client.get(pdf_url, raise_for_status=True)
-
-        with tempfile.NamedTemporaryFile(
-            suffix=".pdf", delete=False, prefix="cob_ng_birr_"
-        ) as tmp:
-            tmp.write(response.content)
-            tmp_path = Path(tmp.name)
+        # get_or_download_pdf enforces a TOTAL wall-clock cap on the transfer
+        # (not httpx's per-chunk timeout, which a slow-but-steady body never
+        # trips) and reuses a cached copy across runs. So a slow-CDN night
+        # either reuses the last good download or bails to the fixture,
+        # instead of eating the 600s domain budget and aborting mid-parse
+        # (issue #119) — same guard the counties_budget domain uses.
+        logger.info("Starting COB NG-BIRR PDF download: %s", pdf_url)
+        download_start = time.monotonic()
+        pdf_path = get_or_download_pdf(
+            client,
+            pdf_url,
+            cache_dir=Path(settings.cache_path) / "pdfs",
+            ttl_seconds=settings.pdf_cache_ttl_seconds,
+            max_seconds=settings.pdf_download_timeout_seconds,
+            max_bytes=settings.pdf_download_max_bytes,
+        )
+        download_elapsed = time.monotonic() - download_start
 
         logger.info(
-            "Downloaded COB NG-BIRR PDF (%d bytes) to %s",
-            len(response.content), tmp_path,
+            "COB NG-BIRR PDF ready (%d bytes, %.1fs) at %s",
+            pdf_path.stat().st_size, download_elapsed, pdf_path,
         )
 
-        parser = NgBirrSectoralParser(tmp_path)
+        parser = NgBirrSectoralParser(pdf_path)
         period, sectoral_records = parser.parse()
 
         if not sectoral_records:
@@ -188,9 +198,5 @@ def _download_and_parse_ng_pdf(
             "pdfplumber not available — install it for live NG-BIRR parsing"
         )
         return None
-    finally:
-        if tmp_path and tmp_path.exists():
-            try:
-                tmp_path.unlink()
-            except OSError:
-                pass
+    # No temp-file cleanup: get_or_download_pdf() returns a path in the
+    # persistent PDF cache (reused across runs), so it must NOT be unlinked.

--- a/backend/seeding/http_client.py
+++ b/backend/seeding/http_client.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import tempfile
 import time
 from contextlib import AbstractContextManager
 from pathlib import Path
@@ -169,6 +171,12 @@ class SeedingHttpClient(AbstractContextManager["SeedingHttpClient"]):
         if the full body is not received within ``max_seconds`` or if it
         exceeds ``max_bytes``.
 
+        Writes atomically: the body streams to a sibling temp file that is
+        ``os.replace``-d into ``dest_path`` only after the full transfer
+        succeeds, and the temp is removed on any failure. So a timeout,
+        byte-cap breach, or transport error never leaves a truncated file at
+        ``dest_path`` for a later run to mistake for a complete download.
+
         Why not ``request()``: ``request()`` reads the whole body eagerly with
         httpx's *per-operation* timeout — a read timeout only bounds the gap
         *between* chunks, so a slow-but-steady 48MB body streams for minutes
@@ -188,28 +196,43 @@ class SeedingHttpClient(AbstractContextManager["SeedingHttpClient"]):
         timeout = httpx.Timeout(per_op, connect=min(float(max_seconds), 15.0))
         start = time.monotonic()
         written = 0
-        with self._rate_limiter.context():
-            with self._client.stream(
-                "GET", url, headers=request_headers, timeout=timeout
-            ) as response:
-                if raise_for_status:
-                    response.raise_for_status()
-                with dest.open("wb") as handle:
-                    for chunk in response.iter_bytes():
-                        if time.monotonic() - start > max_seconds:
-                            raise PdfDownloadError(
-                                f"download exceeded {max_seconds:.0f}s "
-                                f"wall-clock cap after {written} bytes: {url}"
-                            )
-                        if (
-                            max_bytes is not None
-                            and written + len(chunk) > max_bytes
-                        ):
-                            raise PdfDownloadError(
-                                f"download exceeded {max_bytes}-byte cap: {url}"
-                            )
-                        handle.write(chunk)
-                        written += len(chunk)
+        # Stream to a sibling temp and atomically promote on success so a
+        # partial transfer never lands at dest_path (see docstring).
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=dest.name + ".", suffix=".part", dir=str(dest.parent)
+        )
+        os.close(fd)
+        tmp = Path(tmp_name)
+        try:
+            with self._rate_limiter.context():
+                with self._client.stream(
+                    "GET", url, headers=request_headers, timeout=timeout
+                ) as response:
+                    if raise_for_status:
+                        response.raise_for_status()
+                    with tmp.open("wb") as handle:
+                        for chunk in response.iter_bytes():
+                            if time.monotonic() - start > max_seconds:
+                                raise PdfDownloadError(
+                                    f"download exceeded {max_seconds:.0f}s "
+                                    f"wall-clock cap after {written} bytes: {url}"
+                                )
+                            if (
+                                max_bytes is not None
+                                and written + len(chunk) > max_bytes
+                            ):
+                                raise PdfDownloadError(
+                                    f"download exceeded {max_bytes}-byte cap: {url}"
+                                )
+                            handle.write(chunk)
+                            written += len(chunk)
+            os.replace(tmp, dest)
+        except BaseException:
+            # Clean up the partial temp on ANY failure (incl. a SIGALRM-driven
+            # BaseException) — then re-raise unchanged.
+            tmp.unlink(missing_ok=True)
+            raise
         return written
 
 

--- a/backend/seeding/http_client.py
+++ b/backend/seeding/http_client.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
+import time
 from contextlib import AbstractContextManager
-from typing import Any, Optional
+from pathlib import Path
+from typing import Any, Dict, Optional
 
 import httpx
 from tenacity import (
@@ -20,6 +22,16 @@ from .rate_limiter import RateLimiter
 from .storage import SimpleHTTPCache
 
 logger = logging.getLogger("seeding.http")
+
+
+class PdfDownloadError(Exception):
+    """A streamed PDF download failed (timeout, oversize, or non-PDF body).
+
+    Deliberately a plain ``Exception`` — unlike the CLI's ``DomainTimeoutError``
+    (a ``BaseException``) — so a domain fetcher's ``except Exception`` fixture
+    fallback catches it and recovers cleanly, instead of the per-domain SIGALRM
+    firing mid-parse and hard-failing the whole run (issue #119).
+    """
 
 
 def _is_retryable(exception: BaseException) -> bool:
@@ -140,6 +152,65 @@ class SeedingHttpClient(AbstractContextManager["SeedingHttpClient"]):
 
     def head(self, url: str, **kwargs: Any) -> httpx.Response:
         return self.request("HEAD", url, **kwargs)
+
+    def download_to_file(
+        self,
+        url: str,
+        dest_path: Path,
+        *,
+        max_seconds: float,
+        max_bytes: Optional[int] = None,
+        headers: Optional[Dict[str, str]] = None,
+        raise_for_status: bool = True,
+    ) -> int:
+        """Stream a GET body to ``dest_path`` under a TOTAL wall-clock cap.
+
+        Returns the number of bytes written. Raises :class:`PdfDownloadError`
+        if the full body is not received within ``max_seconds`` or if it
+        exceeds ``max_bytes``.
+
+        Why not ``request()``: ``request()`` reads the whole body eagerly with
+        httpx's *per-operation* timeout — a read timeout only bounds the gap
+        *between* chunks, so a slow-but-steady 48MB body streams for minutes
+        without ever tripping it. This streams chunk-by-chunk and checks a
+        monotonic deadline each iteration, so total elapsed time is bounded.
+
+        Single attempt, no tenacity retry: re-pulling a large, already-slow
+        body on a transient error would blow the very budget this guards. The
+        per-operation timeout below still fails a fully-stalled socket fast;
+        the loop deadline handles a slow trickle.
+        """
+        dest = Path(dest_path)
+        request_headers = dict(headers or {})
+        # Fail a dead connection fast (no bytes at all / no handshake), but let
+        # a slow steady stream run up to the wall-clock cap the loop enforces.
+        per_op = min(float(max_seconds), 30.0)
+        timeout = httpx.Timeout(per_op, connect=min(float(max_seconds), 15.0))
+        start = time.monotonic()
+        written = 0
+        with self._rate_limiter.context():
+            with self._client.stream(
+                "GET", url, headers=request_headers, timeout=timeout
+            ) as response:
+                if raise_for_status:
+                    response.raise_for_status()
+                with dest.open("wb") as handle:
+                    for chunk in response.iter_bytes():
+                        if time.monotonic() - start > max_seconds:
+                            raise PdfDownloadError(
+                                f"download exceeded {max_seconds:.0f}s "
+                                f"wall-clock cap after {written} bytes: {url}"
+                            )
+                        if (
+                            max_bytes is not None
+                            and written + len(chunk) > max_bytes
+                        ):
+                            raise PdfDownloadError(
+                                f"download exceeded {max_bytes}-byte cap: {url}"
+                            )
+                        handle.write(chunk)
+                        written += len(chunk)
+        return written
 
 
 def create_http_client(settings: SeedingSettings) -> SeedingHttpClient:

--- a/backend/seeding/pdf_download.py
+++ b/backend/seeding/pdf_download.py
@@ -149,10 +149,20 @@ def get_or_download_pdf(
         tmp_path.unlink(missing_ok=True)
         raise
 
-    meta_path.write_text(
-        json.dumps({"url": url, "created_at": time.time(), "bytes": size}),
-        encoding="utf-8",
-    )
+    # Metadata is best-effort. The PDF is already safely in place, so a failed
+    # sidecar write must NOT turn a successful download into an exception (which
+    # the domain would catch and fall back to the fixture for). Without the
+    # sidecar the next run simply treats it as a cache miss and re-downloads.
+    try:
+        meta_path.write_text(
+            json.dumps({"url": url, "created_at": time.time(), "bytes": size}),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        logger.warning(
+            "PDF cached but metadata sidecar write failed (%s); next run will "
+            "re-download: %s", exc, pdf_path,
+        )
     logger.info("PDF downloaded and cached (%d bytes): %s", size, pdf_path)
     return pdf_path
 

--- a/backend/seeding/pdf_download.py
+++ b/backend/seeding/pdf_download.py
@@ -1,0 +1,160 @@
+"""Streaming download + cross-run disk cache for large source PDFs.
+
+Government BIRR/audit PDFs are 12-50MB and the COB CDN's throughput is wildly
+variable (the same 48MB county file measured ~50s one night and ~556s the
+next). Two problems this module addresses — see issue #119:
+
+(a) ``httpx``'s request timeout is *per-operation* (the max gap between
+    received chunks), not total elapsed, so a slow-but-steady 48MB body can
+    stream for ~9 minutes and consume the entire per-domain SIGALRM budget,
+    aborting the run mid-parse. :meth:`SeedingHttpClient.download_to_file`
+    enforces a TOTAL wall-clock cap and raises :class:`PdfDownloadError` (a
+    plain ``Exception``) so the caller's fixture fallback recovers cleanly.
+
+(b) The download dominates the domain's time budget. :func:`get_or_download_pdf`
+    caches the fetched file on disk keyed by URL; once a report is fetched,
+    later runs reuse it and skip the download entirely. The "latest report"
+    URL embeds a WordPress Download Manager id that changes only when COB
+    publishes a new report, so a long TTL is safe and a new report naturally
+    misses the cache. Persist the cache dir across CI runs (actions/cache) for
+    this to help the nightly job.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+from .http_client import PdfDownloadError, SeedingHttpClient
+
+logger = logging.getLogger("seeding.pdf_download")
+
+# A real PDF starts with "%PDF-". Cheap magic-byte check to avoid caching an
+# HTML error page / CDN challenge that was served with a 200 + wrong body.
+_PDF_MAGIC = b"%PDF-"
+
+
+def _cache_paths(cache_dir: Path, url: str) -> Tuple[Path, Path]:
+    """Return (pdf_path, meta_path) for ``url`` inside ``cache_dir``.
+
+    Keyed on a SHA-256 of the *request* URL (the ``?wpdmdl=NNN`` link), which
+    is stable for a given report and changes when a new report is published.
+    """
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()
+    return cache_dir / f"{digest}.pdf", cache_dir / f"{digest}.json"
+
+
+def _fresh_cache_hit(
+    pdf_path: Path, meta_path: Path, ttl_seconds: int
+) -> Optional[Tuple[int, float]]:
+    """Return (size_bytes, age_seconds) if a usable cache entry exists.
+
+    A hit requires a non-empty ``.pdf`` and a ``.json`` sidecar whose recorded
+    ``created_at`` is within ``ttl_seconds``. Any missing/corrupt/expired state
+    is treated as a miss (returns ``None``) so the caller re-downloads.
+    """
+    if ttl_seconds <= 0 or not pdf_path.exists() or not meta_path.exists():
+        return None
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        created_at = float(meta.get("created_at", 0.0))
+        size = pdf_path.stat().st_size
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+    age = time.time() - created_at
+    if size <= 0 or age > ttl_seconds:
+        return None
+    return size, age
+
+
+def _verify_pdf_magic(path: Path, url: str) -> None:
+    """Raise :class:`PdfDownloadError` unless ``path`` starts with ``%PDF-``."""
+    try:
+        with path.open("rb") as handle:
+            head = handle.read(len(_PDF_MAGIC))
+    except OSError as exc:  # pragma: no cover - defensive
+        raise PdfDownloadError(
+            f"could not read downloaded file for {url}: {exc}"
+        ) from exc
+    if head != _PDF_MAGIC:
+        raise PdfDownloadError(
+            f"downloaded content is not a PDF (starts with {head!r}): {url}"
+        )
+
+
+def get_or_download_pdf(
+    client: SeedingHttpClient,
+    url: str,
+    *,
+    cache_dir: Path,
+    ttl_seconds: int,
+    max_seconds: float,
+    max_bytes: Optional[int] = None,
+    headers: Optional[Dict[str, str]] = None,
+) -> Path:
+    """Return a path to the PDF at ``url``, downloading only on a cache miss.
+
+    On a hit (a non-empty cached file younger than ``ttl_seconds``) the cached
+    path is returned with no network call. On a miss the body is streamed to a
+    temp file *inside* ``cache_dir`` under a total ``max_seconds`` wall-clock
+    cap, validated as a real PDF, then atomically moved into place so a partial
+    or aborted download never poisons the cache.
+
+    Raises :class:`PdfDownloadError` on timeout, oversize, or non-PDF content.
+    The returned file lives in the persistent cache — callers must NOT delete
+    it.
+    """
+    cache_dir = Path(cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    pdf_path, meta_path = _cache_paths(cache_dir, url)
+
+    hit = _fresh_cache_hit(pdf_path, meta_path, ttl_seconds)
+    if hit is not None:
+        size, age = hit
+        logger.info(
+            "PDF cache hit (%d bytes, age %.0fs): %s", size, age, url
+        )
+        return pdf_path
+
+    logger.info(
+        "PDF cache miss; streaming download (cap %.0fs): %s", max_seconds, url
+    )
+    # Temp file in the same directory as the cache so os.replace() is atomic
+    # (a rename across filesystems is not).
+    fd, tmp_name = tempfile.mkstemp(
+        suffix=".pdf", prefix="pdf_dl_", dir=str(cache_dir)
+    )
+    os.close(fd)
+    tmp_path = Path(tmp_name)
+    try:
+        size = client.download_to_file(
+            url,
+            tmp_path,
+            max_seconds=max_seconds,
+            max_bytes=max_bytes,
+            headers=headers,
+        )
+        _verify_pdf_magic(tmp_path, url)
+        os.replace(tmp_path, pdf_path)
+    except BaseException:
+        # Clean up the partial temp on ANY failure (incl. a SIGALRM-driven
+        # DomainTimeoutError) — then re-raise unchanged so the caller's
+        # fallback / the CLI handler still sees the original exception.
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+    meta_path.write_text(
+        json.dumps({"url": url, "created_at": time.time(), "bytes": size}),
+        encoding="utf-8",
+    )
+    logger.info("PDF downloaded and cached (%d bytes): %s", size, pdf_path)
+    return pdf_path
+
+
+__all__ = ["get_or_download_pdf"]

--- a/backend/seeding/pdf_download.py
+++ b/backend/seeding/pdf_download.py
@@ -56,8 +56,9 @@ def _fresh_cache_hit(
     """Return (size_bytes, age_seconds) if a usable cache entry exists.
 
     A hit requires a non-empty ``.pdf`` and a ``.json`` sidecar whose recorded
-    ``created_at`` is within ``ttl_seconds``. Any missing/corrupt/expired state
-    is treated as a miss (returns ``None``) so the caller re-downloads.
+    ``created_at`` is within ``[now - ttl_seconds, now]``. Any missing, corrupt,
+    expired, or future-dated state is treated as a miss (returns ``None``) so
+    the caller re-downloads.
     """
     if ttl_seconds <= 0 or not pdf_path.exists() or not meta_path.exists():
         return None
@@ -68,7 +69,10 @@ def _fresh_cache_hit(
     except (OSError, ValueError, json.JSONDecodeError):
         return None
     age = time.time() - created_at
-    if size <= 0 or age > ttl_seconds:
+    # A negative age means created_at is in the future — a skewed clock or a
+    # corrupted sidecar. Fail closed and re-download rather than trusting a
+    # future timestamp as "fresh" indefinitely.
+    if size <= 0 or age < 0 or age > ttl_seconds:
         return None
     return size, age
 

--- a/backend/tests/test_counties_budget_fetcher.py
+++ b/backend/tests/test_counties_budget_fetcher.py
@@ -20,7 +20,7 @@ import httpx
 import pytest
 from seeding.config import SeedingSettings
 from seeding.domains.counties_budget import fetcher as cb_fetcher
-from seeding.http_client import SeedingHttpClient
+from seeding.http_client import PdfDownloadError, SeedingHttpClient
 
 
 @pytest.fixture()
@@ -424,3 +424,35 @@ class TestFetchBudgetPayloadStrategyOrder:
         assert not any(
             "/publications/" in u or "/reports/" in u for u in seen_urls
         )
+
+
+class TestSlowDownloadFallsBackToFixture:
+    """Issue #119: a slow-CDN PDF download must fall back to the fixture, not
+    hard-fail the domain. The download cap raises a plain PdfDownloadError,
+    which fetch_budget_payload's `except Exception` catches — unlike the CLI's
+    DomainTimeoutError (a BaseException) which would abort the whole run."""
+
+    def test_download_timeout_recovers_via_fixture(self, settings):
+        def handler(request: httpx.Request) -> httpx.Response:
+            # Discovery/probe traffic is stubbed out below; nothing should
+            # actually reach the network for the download itself.
+            return httpx.Response(200, json=[], request=request)
+
+        fake_pdf_url = "https://cob.go.ke/download/county-birr?wpdmdl=16378"
+        with _make_client(settings, handler) as client:
+            with patch.object(
+                cb_fetcher,
+                "_discover_latest_county_birr_via_wp_api",
+                return_value=fake_pdf_url,
+            ), patch.object(
+                client,
+                "download_to_file",
+                side_effect=PdfDownloadError(
+                    "download exceeded 180s wall-clock cap after 4096 bytes"
+                ),
+            ):
+                payload = cb_fetcher.fetch_budget_payload(client, settings)
+
+        # Recovered cleanly with real fixture rows — no exception propagated.
+        assert isinstance(payload, list)
+        assert len(payload) > 0

--- a/backend/tests/test_national_budget_fetcher.py
+++ b/backend/tests/test_national_budget_fetcher.py
@@ -1,0 +1,112 @@
+"""Tests for the national_budget fetcher's live-PDF path (issue #119 guard).
+
+Mirrors the counties_budget coverage: a slow-CDN NG-BIRR download must fall
+back to the fixture — via the wall-clock-capped, cross-run-cached
+get_or_download_pdf helper — rather than hard-failing the domain, and the
+happy path must route through that helper (not an eager, uncapped client.get).
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+from seeding.config import SeedingSettings
+from seeding.domains.national_budget import fetcher as nb_fetcher
+from seeding.http_client import PdfDownloadError, SeedingHttpClient
+
+
+@pytest.fixture()
+def settings(tmp_path) -> SeedingSettings:
+    s = SeedingSettings(
+        storage_path=tmp_path / "storage",
+        cache_path=tmp_path / "cache",
+        log_path=tmp_path / "logs" / "seed.log",
+        retry_backoff=0.01,
+        max_retries=1,
+        http_cache_enabled=False,
+        live_pdf_fetch_enabled=True,
+        rate_limit="1000/sec",
+    )
+    s.ensure_directories()
+    return s
+
+
+def _make_client(settings: SeedingSettings, handler) -> SeedingHttpClient:
+    transport = httpx.MockTransport(handler)
+    inner = httpx.Client(transport=transport, headers=settings.default_headers)
+    return SeedingHttpClient(settings, cache=None, client=inner)
+
+
+def _page_handler(request: httpx.Request) -> httpx.Response:
+    # The COB reports-page fetch; discovery is patched, so any 200 is fine.
+    return httpx.Response(200, text="<html></html>", request=request)
+
+
+def test_download_timeout_recovers_via_fixture(settings):
+    """A wall-clock-capped download raises a plain PdfDownloadError, which
+    fetch_national_budget_payload's `except Exception` catches → fixture.
+    (Unlike the CLI's BaseException DomainTimeoutError, which would abort the
+    whole run — the exact issue #119 failure mode.)"""
+    fake_pdf_url = "https://cob.go.ke/download/ng-birr?wpdmdl=16376"
+    with _make_client(settings, _page_handler) as client:
+        with patch.object(
+            nb_fetcher, "_discover_latest_ng_birr_pdf", return_value=fake_pdf_url
+        ), patch.object(
+            client,
+            "download_to_file",
+            side_effect=PdfDownloadError(
+                "download exceeded 180s wall-clock cap after 4096 bytes"
+            ),
+        ):
+            payload = nb_fetcher.fetch_national_budget_payload(client, settings)
+
+    # Recovered cleanly with real fixture rows — no exception propagated.
+    assert isinstance(payload, list)
+    assert len(payload) > 0
+
+
+def test_live_path_routes_through_cached_download_helper(settings, tmp_path):
+    """The happy path must fetch via get_or_download_pdf (cross-run cache +
+    wall-clock cap) and pass the settings-derived cache dir / TTL / cap — not
+    an eager uncapped client.get."""
+    fake_pdf = tmp_path / "ng.pdf"
+    fake_pdf.write_bytes(b"%PDF-1.7\nx")
+    fake_pdf_url = "https://cob.go.ke/download/ng-birr?wpdmdl=16376"
+
+    class _Rec:
+        sector = "Health"
+        subcategory = None
+        net_estimates = 100
+        exchequer_issues = 90
+
+    period = type(
+        "_Period",
+        (),
+        {
+            "label": "FY 2025/26 9M",
+            "start_date": datetime.date(2025, 7, 1),
+            "end_date": datetime.date(2026, 3, 31),
+        },
+    )()
+
+    with _make_client(settings, _page_handler) as client:
+        with patch.object(
+            nb_fetcher, "_discover_latest_ng_birr_pdf", return_value=fake_pdf_url
+        ), patch(
+            "seeding.pdf_download.get_or_download_pdf", return_value=fake_pdf
+        ) as mock_dl, patch(
+            "seeding.domains.national_budget.pdf_parser.NgBirrSectoralParser"
+        ) as MockParser:
+            MockParser.return_value.parse.return_value = (period, [_Rec()])
+            payload = nb_fetcher.fetch_national_budget_payload(client, settings)
+
+    assert mock_dl.called, "expected the fetcher to use get_or_download_pdf"
+    kwargs = mock_dl.call_args.kwargs
+    assert kwargs["cache_dir"] == settings.cache_path / "pdfs"
+    assert kwargs["max_seconds"] == settings.pdf_download_timeout_seconds
+    assert kwargs["ttl_seconds"] == settings.pdf_cache_ttl_seconds
+    assert [r["category"] for r in payload] == ["Health"]

--- a/backend/tests/test_pdf_download.py
+++ b/backend/tests/test_pdf_download.py
@@ -79,6 +79,11 @@ class TestDownloadToFile:
                         max_seconds=180,
                     )
 
+        # No truncated file at dest, and no leftover temp — a failed download
+        # must not poison a later run that reuses the path (Copilot #120).
+        assert not dest.exists()
+        assert list(tmp_path.glob("*.part")) == []
+
     def test_raises_when_max_bytes_exceeded(self, settings, tmp_path):
         def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=_PDF_BODY, request=request)
@@ -92,6 +97,9 @@ class TestDownloadToFile:
                     max_seconds=180,
                     max_bytes=8,
                 )
+
+        assert not dest.exists()
+        assert list(tmp_path.glob("*.part")) == []
 
 
 class TestGetOrDownloadPdf:

--- a/backend/tests/test_pdf_download.py
+++ b/backend/tests/test_pdf_download.py
@@ -11,6 +11,7 @@ Locks in the two guards added for issue #119:
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import patch
 
 import httpx
@@ -159,6 +160,41 @@ class TestGetOrDownloadPdf:
 
         # No cached .pdf, and no leftover temp files poisoning the dir.
         assert list(cache_dir.glob("*.pdf")) == []
+
+    def test_metadata_write_failure_does_not_discard_download(self, settings):
+        """A failed sidecar write must not turn a successful download into an
+        exception (which the domain would treat as a reason to fall back to the
+        fixture). The PDF stays available; only the cache bookkeeping is lost
+        (Copilot #120)."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=_PDF_BODY, request=request)
+
+        url = "https://cob.go.ke/download/county-birr?wpdmdl=16378"
+        cache_dir = self._cache_dir(settings)
+        real_write_text = Path.write_text
+
+        def flaky_write_text(self, *args, **kwargs):
+            # Only the JSON sidecar uses write_text; the PDF is streamed to disk
+            # and os.replace-d, so this targets the metadata write alone.
+            if self.suffix == ".json":
+                raise OSError("simulated disk full")
+            return real_write_text(self, *args, **kwargs)
+
+        with _make_client(settings, handler) as client:
+            with patch.object(Path, "write_text", flaky_write_text):
+                pdf_path = get_or_download_pdf(
+                    client,
+                    url,
+                    cache_dir=cache_dir,
+                    ttl_seconds=30 * 86_400,
+                    max_seconds=180,
+                )
+
+        assert pdf_path.exists()
+        assert pdf_path.read_bytes() == _PDF_BODY
+        # No sidecar written → the next run just re-downloads (cache miss).
+        assert list(cache_dir.glob("*.json")) == []
 
     def test_expired_entry_triggers_redownload(self, settings):
         calls = {"n": 0}

--- a/backend/tests/test_pdf_download.py
+++ b/backend/tests/test_pdf_download.py
@@ -11,6 +11,8 @@ Locks in the two guards added for issue #119:
 
 from __future__ import annotations
 
+import json
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -195,6 +197,35 @@ class TestGetOrDownloadPdf:
         assert pdf_path.read_bytes() == _PDF_BODY
         # No sidecar written → the next run just re-downloads (cache miss).
         assert list(cache_dir.glob("*.json")) == []
+
+    def test_future_timestamp_forces_redownload(self, settings):
+        """A future created_at (clock skew / corrupted sidecar) must NOT count
+        as fresh, or a stale entry could be reused forever (Copilot #120)."""
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(200, content=_PDF_BODY, request=request)
+
+        url = "https://cob.go.ke/download/county-birr?wpdmdl=16378"
+        cache_dir = self._cache_dir(settings)
+        with _make_client(settings, handler) as client:
+            get_or_download_pdf(
+                client, url, cache_dir=cache_dir,
+                ttl_seconds=30 * 86_400, max_seconds=180,
+            )
+            # Corrupt the sidecar with a created_at 10 days in the future.
+            meta = next(cache_dir.glob("*.json"))
+            data = json.loads(meta.read_text(encoding="utf-8"))
+            data["created_at"] = time.time() + 10 * 86_400
+            meta.write_text(json.dumps(data), encoding="utf-8")
+
+            get_or_download_pdf(
+                client, url, cache_dir=cache_dir,
+                ttl_seconds=30 * 86_400, max_seconds=180,
+            )
+
+        assert calls["n"] == 2, "future-dated entry should force a re-download"
 
     def test_expired_entry_triggers_redownload(self, settings):
         calls = {"n": 0}

--- a/backend/tests/test_pdf_download.py
+++ b/backend/tests/test_pdf_download.py
@@ -1,0 +1,173 @@
+"""Tests for the streaming PDF downloader and cross-run PDF cache.
+
+Locks in the two guards added for issue #119:
+  * download_to_file enforces a TOTAL wall-clock cap (not httpx's per-chunk
+    timeout) and raises a plain PdfDownloadError on breach, so a slow-CDN
+    night falls back to the fixture instead of the per-domain SIGALRM firing
+    mid-parse.
+  * get_or_download_pdf reuses a cached PDF across runs and never caches a
+    partial or non-PDF body.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from seeding.config import SeedingSettings
+from seeding.http_client import PdfDownloadError, SeedingHttpClient
+from seeding.pdf_download import get_or_download_pdf
+
+_PDF_BODY = b"%PDF-1.7\n" + b"county budget rows\n" * 64
+
+
+@pytest.fixture()
+def settings(tmp_path) -> SeedingSettings:
+    s = SeedingSettings(
+        storage_path=tmp_path / "storage",
+        cache_path=tmp_path / "cache",
+        log_path=tmp_path / "logs" / "seed.log",
+        retry_backoff=0.01,
+        max_retries=1,
+        http_cache_enabled=False,
+        # Keep the rate limiter from sleeping during the test.
+        rate_limit="1000/sec",
+    )
+    s.ensure_directories()
+    return s
+
+
+def _make_client(settings: SeedingSettings, handler) -> SeedingHttpClient:
+    transport = httpx.MockTransport(handler)
+    inner = httpx.Client(transport=transport, headers=settings.default_headers)
+    return SeedingHttpClient(settings, cache=None, client=inner)
+
+
+class TestDownloadToFile:
+    def test_streams_body_to_disk_and_returns_size(self, settings, tmp_path):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=_PDF_BODY, request=request)
+
+        dest = tmp_path / "out.pdf"
+        with _make_client(settings, handler) as client:
+            written = client.download_to_file(
+                "https://cob.go.ke/download/x?wpdmdl=1", dest, max_seconds=180
+            )
+
+        assert written == len(_PDF_BODY)
+        assert dest.read_bytes() == _PDF_BODY
+
+    def test_raises_when_total_wallclock_cap_exceeded(self, settings, tmp_path):
+        """A slow-but-steady stream that never trips httpx's per-chunk read
+        timeout must still be aborted by the total wall-clock deadline."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=_PDF_BODY, request=request)
+
+        # start=0, then every per-chunk check sees 10_000s elapsed > cap.
+        clock = iter([0.0] + [10_000.0] * 64)
+        dest = tmp_path / "slow.pdf"
+        with _make_client(settings, handler) as client:
+            with patch(
+                "seeding.http_client.time.monotonic", lambda: next(clock)
+            ):
+                with pytest.raises(PdfDownloadError, match="wall-clock cap"):
+                    client.download_to_file(
+                        "https://cob.go.ke/download/x?wpdmdl=1",
+                        dest,
+                        max_seconds=180,
+                    )
+
+    def test_raises_when_max_bytes_exceeded(self, settings, tmp_path):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=_PDF_BODY, request=request)
+
+        dest = tmp_path / "big.pdf"
+        with _make_client(settings, handler) as client:
+            with pytest.raises(PdfDownloadError, match="byte cap"):
+                client.download_to_file(
+                    "https://cob.go.ke/download/x?wpdmdl=1",
+                    dest,
+                    max_seconds=180,
+                    max_bytes=8,
+                )
+
+
+class TestGetOrDownloadPdf:
+    def _cache_dir(self, settings):
+        return settings.cache_path / "pdfs"
+
+    def test_downloads_then_serves_from_cache(self, settings):
+        """Second call for the same URL must be a cache hit — no second
+        network round-trip."""
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(200, content=_PDF_BODY, request=request)
+
+        url = "https://cob.go.ke/download/county-birr?wpdmdl=16378"
+        with _make_client(settings, handler) as client:
+            first = get_or_download_pdf(
+                client,
+                url,
+                cache_dir=self._cache_dir(settings),
+                ttl_seconds=30 * 86_400,
+                max_seconds=180,
+            )
+            second = get_or_download_pdf(
+                client,
+                url,
+                cache_dir=self._cache_dir(settings),
+                ttl_seconds=30 * 86_400,
+                max_seconds=180,
+            )
+
+        assert first == second
+        assert first.read_bytes() == _PDF_BODY
+        assert calls["n"] == 1, "expected the second call to hit the cache"
+
+    def test_rejects_and_does_not_cache_non_pdf_body(self, settings):
+        """A 200 that returns an HTML error page must raise and leave nothing
+        in the cache (so the next run retries rather than reusing junk)."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, content=b"<html>blocked</html>", request=request
+            )
+
+        url = "https://cob.go.ke/download/county-birr?wpdmdl=16378"
+        cache_dir = self._cache_dir(settings)
+        with _make_client(settings, handler) as client:
+            with pytest.raises(PdfDownloadError, match="not a PDF"):
+                get_or_download_pdf(
+                    client,
+                    url,
+                    cache_dir=cache_dir,
+                    ttl_seconds=30 * 86_400,
+                    max_seconds=180,
+                )
+
+        # No cached .pdf, and no leftover temp files poisoning the dir.
+        assert list(cache_dir.glob("*.pdf")) == []
+
+    def test_expired_entry_triggers_redownload(self, settings):
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(200, content=_PDF_BODY, request=request)
+
+        url = "https://cob.go.ke/download/county-birr?wpdmdl=16378"
+        cache_dir = self._cache_dir(settings)
+        with _make_client(settings, handler) as client:
+            get_or_download_pdf(
+                client, url, cache_dir=cache_dir, ttl_seconds=3600, max_seconds=180
+            )
+            # ttl_seconds=0 disables reuse → forces a fresh download.
+            get_or_download_pdf(
+                client, url, cache_dir=cache_dir, ttl_seconds=0, max_seconds=180
+            )
+
+        assert calls["n"] == 2


### PR DESCRIPTION
## Summary

Fixes the recurring nightly **Seed Data Domains** failure (#119). The `counties_budget` domain hard-failed when the ~48MB COB county BIRR PDF downloaded slowly: httpx's request timeout is *per-operation* (the max gap between chunks), **not** total elapsed, so a slow-but-steady trickle (556s on 2026-07-08 vs ~50s on a healthy night) consumed the entire 600s per-domain SIGALRM budget and aborted the pdfplumber parse (which needs ~254s) mid-run. Because `DomainTimeoutError` subclasses `BaseException`, it bypassed the fixture fallback and failed the whole run.

### (a) True total-elapsed download cap
`SeedingHttpClient.download_to_file()` streams the body chunk-by-chunk against a monotonic **wall-clock deadline** and raises `PdfDownloadError` (a plain `Exception`, unlike the `BaseException` `DomainTimeoutError`) on breach — so a slow-CDN night falls back to the fixture **cleanly** instead of hard-failing.

### (c) Cross-run PDF cache
`seeding/pdf_download.get_or_download_pdf()` caches the fetched PDF on disk keyed by URL (validated `%PDF` magic, atomic move so a partial download never poisons the cache). Once a report is fetched, later runs reuse it and skip the download entirely. An `actions/cache` step in `seed.yml` persists the cache dir across nightly runs.

New env-overridable settings (`SEED_*`): `pdf_download_timeout_seconds` (180s — leaves ≥395s of the 600s budget for the ~254s parse), `pdf_download_max_bytes` (120MB), `pdf_cache_ttl_seconds` (30d — a published report is immutable for a quarter).

### Both live-PDF domains covered
Both `counties_budget` and `national_budget` now fetch via `get_or_download_pdf`. `national_budget` had the identical eager-`client.get` + tempfile pattern; its PDF is smaller (~12MB) so it hadn't failed yet, but the failure mode was the same.

## Behavior after this change
- **Slow night, no cache** → download bails at 180s → fixture fallback (no failure, no issue filed).
- **Slow night, cached** → skips the download, parses the cached PDF → **real** data, not fixture.

## Testing
- New + broader seeding tests pass (89 in the touched suites); no regressions.
- **Real-socket integration run** (no mocks): a server that would take ~10s to finish was aborted at exactly **2.0s** by the cap; a full PDF downloaded, passed the magic check, cached, and was reused on the second call with no re-download.
- End-to-end tests for **both** domains confirm a download timeout recovers via the fixture through the real `fetch_*_payload` path, and the happy path routes through `get_or_download_pdf` with the settings-derived cache dir / TTL / cap.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
