### PR TITLE
fix(seeding): persist live OAG audits + quiet transient health-check noise

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -158,10 +158,17 @@ jobs:
 
             HTTP_CODE=$(probe "$PRIMARY_UA" "$url")
             # On a block-style code, re-probe once with a browser UA before
-            # concluding the source is unhealthy.
+            # concluding the source is unhealthy. Adopt the retry code
+            # whenever it is DEFINITIVE (i.e. not itself transient): a
+            # success (2xx/3xx) means the source is reachable and the block
+            # was just our UA, while a genuine 4xx-gone (404/410) revealed
+            # past the WAF means the URL migrated and must still surface via
+            # the critical-flag branch — not be masked behind the original
+            # transient code. Keep the original code only when the re-probe
+            # is also transient (the block is real/IP-based, not UA-based).
             if is_transient "$HTTP_CODE"; then
               RETRY_CODE=$(probe "$BROWSER_UA" "$url")
-              if [[ "$RETRY_CODE" =~ ^[23] ]]; then
+              if ! is_transient "$RETRY_CODE"; then
                 HTTP_CODE="$RETRY_CODE"
               fi
             fi

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -125,11 +125,24 @@ jobs:
 
           # $1 = User-Agent, $2 = URL. Follow redirects; 60s timeout (COB's
           # HTML listings legitimately take 30-50s); curl --retry covers
-          # connection resets / timeouts (not 4xx). Prints the HTTP code.
+          # connection resets / timeouts (not 4xx). Prints exactly one
+          # 3-digit HTTP code.
+          #
+          # curl writes the code via -w; on a connection failure it prints
+          # "000" AND exits non-zero. The old `... || echo "000"` appended a
+          # SECOND "000" → "000000", which no longer matches is_transient
+          # ("000" exactly) and wrongly escalated genuine outages to the
+          # critical branch (see Treasury "000000" in issue #124). Capture
+          # stdout, keep the assignment from tripping `set -e` on curl's
+          # non-zero exit (|| true), then normalise anything that isn't a
+          # bare 3-digit code to "000".
           probe() {
-            curl -s -o /dev/null -w "%{http_code}" \
+            local code
+            code=$(curl -s -o /dev/null -w "%{http_code}" \
               -L --max-time 60 --retry 2 --retry-delay 3 \
-              -A "$1" "$2" 2>/dev/null || echo "000"
+              -A "$1" "$2" 2>/dev/null) || true
+            [[ "$code" =~ ^[0-9]{3}$ ]] || code="000"
+            printf '%s' "$code"
           }
 
           # A "transient/blocked" code means the host answered but bot-blocked
@@ -644,7 +657,11 @@ jobs:
             const open = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'data-source-down',
+              // Require BOTH labels (comma = AND) so we only auto-close
+              // issues THIS workflow created — every generated outage issue
+              // carries data-source-down + automated. A human-filed
+              // investigative issue using only data-source-down is spared.
+              labels: 'data-source-down,automated',
               state: 'open',
             });
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -113,26 +113,54 @@ jobs:
           TOTAL=${#SOURCES[@]}
           OK_COUNT=0
 
+          # Primary UA must start with a known HTTP-client identifier
+          # (python-httpx / python-requests / curl) so the IMF DataMapper
+          # API doesn't 403 us — it filters non-canonical UAs. We append
+          # our own identifier + a contact URL for site operators.
+          PRIMARY_UA="python-httpx/0.27 KenyaAuditApp-HealthCheck/1.0 (+https://github.com/Rodgers31/audit_app)"
+          # Some government WAFs (COB, OAG) intermittently bot-block that UA
+          # from datacenter IPs with 403/415/429; a browser UA sometimes
+          # gets through, so we re-probe blocked sources with it.
+          BROWSER_UA="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+          # $1 = User-Agent, $2 = URL. Follow redirects; 60s timeout (COB's
+          # HTML listings legitimately take 30-50s); curl --retry covers
+          # connection resets / timeouts (not 4xx). Prints the HTTP code.
+          probe() {
+            curl -s -o /dev/null -w "%{http_code}" \
+              -L --max-time 60 --retry 2 --retry-delay 3 \
+              -A "$1" "$2" 2>/dev/null || echo "000"
+          }
+
+          # A "transient/blocked" code means the host answered but bot-blocked
+          # or rate-limited us (403/415/429), timed out (000), or had a server
+          # error (5xx). That is NOT a URL migration — the nightly retry
+          # usually clears it — so it never escalates to CRITICAL, even for a
+          # source flagged critical. Only genuine 4xx-gone codes (404/410/…)
+          # honour the per-source critical flag and can page us.
+          is_transient() { [[ "$1" =~ ^(403|415|429|000)$ || "$1" =~ ^5[0-9][0-9]$ ]]; }
+
           for entry in "${SOURCES[@]}"; do
             IFS='|' read -r label url critical <<< "$entry"
 
-            # Curl: follow redirects, 60s timeout (COB's HTML listings
-            # legitimately take 30-50s), accept any 2xx/3xx.
-            #
-            # User-Agent: must start with a known HTTP-client identifier
-            # (python-httpx / python-requests / curl) so the IMF
-            # DataMapper API does not 403 us — it filters out
-            # non-canonical UAs. We then append our own identifier + a
-            # contact URL for site operators who want to reach us.
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-              -L --max-time 60 --retry 2 --retry-delay 3 \
-              -A "python-httpx/0.27 KenyaAuditApp-HealthCheck/1.0 (+https://github.com/Rodgers31/audit_app)" \
-              "$url" 2>/dev/null || echo "000")
+            HTTP_CODE=$(probe "$PRIMARY_UA" "$url")
+            # On a block-style code, re-probe once with a browser UA before
+            # concluding the source is unhealthy.
+            if is_transient "$HTTP_CODE"; then
+              RETRY_CODE=$(probe "$BROWSER_UA" "$url")
+              if [[ "$RETRY_CODE" =~ ^[23] ]]; then
+                HTTP_CODE="$RETRY_CODE"
+              fi
+            fi
 
             if [[ "$HTTP_CODE" =~ ^[23] ]]; then
               echo "  [OK]   $label ($HTTP_CODE)"
               REPORT="${REPORT}OK|${label}|${url}|${HTTP_CODE}\n"
               OK_COUNT=$((OK_COUNT + 1))
+            elif is_transient "$HTTP_CODE"; then
+              echo "  [WARNING] $label → HTTP $HTTP_CODE (transient/blocked) ($url)"
+              REPORT="${REPORT}WARNING|${label}|${url}|${HTTP_CODE}\n"
+              FAILED_WARN=$((FAILED_WARN + 1))
             else
               severity="WARNING"
               if [ "$critical" = "true" ]; then
@@ -393,12 +421,21 @@ jobs:
                 400)
 
           # ── Audit data ──
+          # Thresholds are REGRESSION FLOORS, not targets. The honest
+          # post-purge baseline is 25 real national/ministry audits (the
+          # 512 fabricated county rows were removed 2026-07-07); the live
+          # OAG OCR path adds real findings on top over time. Floors sit
+          # below 25 so a catastrophic loss still fails the gate, without
+          # demanding growth the upstream can't guarantee on any one night.
+          # (Pipeline health — did live ingestion actually persist? — is
+          # tracked by the ingestion-job counts + the audits-domain
+          # fetch↔parse WARN, not by inflating this floor.)
           total_audits = session.query(Audit).count()
-          check('Audit Records', total_audits, 50)
+          check('Audit Records', total_audits, 20)
           audits_with_year = session.query(Audit).filter(Audit.audit_year.isnot(None)).count()
-          check('Audits with audit_year', audits_with_year, 50)
+          check('Audits with audit_year', audits_with_year, 20)
           audits_with_type = session.query(Audit).filter(Audit.query_type.isnot(None)).count()
-          check('Audits with query_type', audits_with_type, 30)
+          check('Audits with query_type', audits_with_type, 20)
 
           # ── Population data ──
           check('Population Records',
@@ -594,6 +631,38 @@ jobs:
                 labels: ['bug', 'data-pipeline', 'data-source-down', 'automated'],
               });
               console.log('Created new health-check failure issue');
+            }
+
+      - name: Auto-close resolved health-check issues
+        if: needs.healthcheck.outputs.has_failures == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // All critical sources were reachable this run — close any
+            // open data-source-down issues so a transient WAF block (415)
+            // that self-heals overnight doesn't linger as an open bug.
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'data-source-down',
+              state: 'open',
+            });
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            for (const issue of open.data) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `✅ Resolved — all critical data sources were reachable in the latest run ([logs](${runUrl})). Auto-closing.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+              console.log(`Auto-closed resolved health-check issue #${issue.number}`);
             }
 
       - name: Create issue on seeding/validation failure

--- a/backend/seeding/domains/audits/__init__.py
+++ b/backend/seeding/domains/audits/__init__.py
@@ -39,6 +39,30 @@ def run(
             )
 
     records = parser.parse_audit_payload(payload)
+
+    # Fetch↔parse contract guard. A live OAG fetch can extract findings
+    # that the parser then drops for missing required fields (period,
+    # dates). That used to fail silently — the domain persisted 0, and
+    # only the nightly validation gate noticed, days later. Surface the
+    # mismatch here so a shape regression is obvious in the seed logs.
+    fetched = fetcher._count_findings(payload)
+    if fetched and not records:
+        logger.warning(
+            "Audit fetch returned %d finding(s) but the parser kept 0 — "
+            "every finding was dropped for missing required fields "
+            "(period_label/start_date/end_date). Persisting nothing; check "
+            "the fetcher↔parser field contract.",
+            fetched,
+        )
+    elif fetched and len(records) < fetched:
+        logger.warning(
+            "Audit parse kept %d of %d fetched finding(s); %d dropped for "
+            "missing required fields.",
+            len(records),
+            fetched,
+            fetched - len(records),
+        )
+
     stats = writer.persist_audit_records(session, records, settings, context)
     errors.extend(stats.errors)
 

--- a/backend/seeding/domains/audits/__init__.py
+++ b/backend/seeding/domains/audits/__init__.py
@@ -49,15 +49,18 @@ def run(
     if fetched and not records:
         logger.warning(
             "Audit fetch returned %d finding(s) but the parser kept 0 — "
-            "every finding was dropped for missing required fields "
-            "(period_label/start_date/end_date). Persisting nothing; check "
-            "the fetcher↔parser field contract.",
+            "every finding was dropped for a missing required field "
+            "(the parser requires entity_slug/entity/severity/finding_text "
+            "and period_label/start_date/end_date; the fiscal-period fields "
+            "are the usual suspect). Persisting nothing; check the "
+            "fetcher↔parser field contract.",
             fetched,
         )
     elif fetched and len(records) < fetched:
         logger.warning(
-            "Audit parse kept %d of %d fetched finding(s); %d dropped for "
-            "missing required fields.",
+            "Audit parse kept %d of %d fetched finding(s); %d dropped for a "
+            "missing required field (entity/severity/finding_text or "
+            "period_label/start_date/end_date).",
             len(records),
             fetched,
             fetched - len(records),

--- a/backend/seeding/domains/audits/fetcher.py
+++ b/backend/seeding/domains/audits/fetcher.py
@@ -40,7 +40,7 @@ import logging
 import re
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import quote_plus, urljoin
 
 from ...config import SeedingSettings
@@ -388,6 +388,78 @@ def _ocr_pdf_text(pdf_path: Path, max_pages: int = 30) -> str:
     return text
 
 
+# ── Fiscal-period derivation ──────────────────────────────────────────
+# Kenya's fiscal year runs 1 July → 30 June. Every persisted audit
+# finding MUST carry a period_label + start/end dates (the parser drops
+# any finding missing them, and the writer keys a FiscalPeriod off them).
+# The FY the accounts cover is reliably present in the OAG report
+# filename ("...-Homa-Bay-2021-2022.pdf",
+# "...-NATIONAL-GOVERNMENT-2024-2025.pdf") and, failing that, on the
+# cover page ("...for the year ended 30 June 2022"). We derive it from
+# the source URL first, then the report text.
+
+# FY spans as they appear in filenames/URLs and inline text:
+# 2021-2022, 2021_2022, 2021/2022, 2021-22, 2022/23, 2021–2022 (en-dash).
+_FY_SPAN_RE = re.compile(r"(20\d{2})\s*[/_–-]\s*(20\d{2}|\d{2})")
+# Cover-page phrasing: "for the year ended 30 June 2022".
+_YEAR_ENDED_RE = re.compile(
+    r"year\s+ended\s+\d{1,2}(?:st|nd|rd|th)?\s+june\s+(20\d{2})",
+    re.IGNORECASE,
+)
+
+
+def _fy_from_span(
+    y1: int, y2: int
+) -> Optional[Tuple[str, str, str, int]]:
+    """Build (period_label, start_date, end_date, audit_year) for a
+    consecutive-year Kenyan FY (July y1 → June y2).
+
+    Returns None when y1/y2 aren't a consecutive pair — this guards
+    against multi-year ranges (e.g. a "2019-2023" strategic-plan span)
+    being mistaken for a single fiscal year. audit_year is the END year
+    (the "year ended 30 June {y2}" the report audits).
+    """
+    if y2 == y1 + 1:
+        return (f"{y1}/{y2}", f"{y1}-07-01", f"{y2}-06-30", y2)
+    return None
+
+
+def _derive_fiscal_period(
+    source: str, text: str
+) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[int]]:
+    """Best-effort fiscal period for an OAG report.
+
+    Order of preference: source URL/filename (most reliable) → an FY
+    span in the first pages of text → a "year ended 30 June YYYY" cover
+    line. Returns (period_label, start_date, end_date, audit_year); each
+    element is None when the FY cannot be determined, in which case the
+    finding is intentionally left unattributed (and dropped downstream)
+    rather than stamped with a guessed period.
+    """
+    head = text[:4000] if text else ""
+    for candidate in (source or "", head):
+        # Scan ALL spans, not just the first: an OAG upload URL embeds a
+        # publish date ("/wp-content/uploads/2023/11/") that matches the
+        # span shape but isn't a fiscal year — the consecutive-year check
+        # in _fy_from_span rejects it, so we keep looking for the real FY.
+        for match in _FY_SPAN_RE.finditer(candidate):
+            y1 = int(match.group(1))
+            y2_raw = match.group(2)
+            # "2021-22" → 2022; "2021-2022" → 2022.
+            y2 = int(y2_raw) if len(y2_raw) == 4 else (y1 // 100) * 100 + int(y2_raw)
+            fy = _fy_from_span(y1, y2)
+            if fy:
+                return fy
+    if text:
+        match = _YEAR_ENDED_RE.search(text)
+        if match:
+            y2 = int(match.group(1))
+            fy = _fy_from_span(y2 - 1, y2)
+            if fy:
+                return fy
+    return (None, None, None, None)
+
+
 def _extract_findings_from_text(
     text: str, source_url: str
 ) -> List[Dict[str, Any]]:
@@ -400,6 +472,13 @@ def _extract_findings_from_text(
       "pending", "variance", "over-expenditure"
     """
     findings: List[Dict[str, Any]] = []
+
+    # Fiscal period is document-level: derive it once from the source
+    # filename / report text and stamp every finding with it. Without a
+    # period_label + start/end dates the parser drops the finding.
+    period_label, start_date, end_date, audit_year = _derive_fiscal_period(
+        source_url, text
+    )
 
     # Try to find county-specific sections
     county_pattern = re.compile(
@@ -475,7 +554,9 @@ def _extract_findings_from_text(
             findings.append({
                 "entity_slug": entity_slug,
                 "entity": f"{entity} County" if current_county else entity,
-                "period_label": "",  # Will be extracted from context
+                "period_label": period_label or "",
+                "start_date": start_date,
+                "end_date": end_date,
                 "finding_text": finding_text,
                 "severity": severity,
                 "recommended_action": "",
@@ -483,7 +564,7 @@ def _extract_findings_from_text(
                 "query_type": "financial_audit",
                 "amount": amount,
                 "status": "pending",
-                "audit_year": None,
+                "audit_year": audit_year,
                 "source_url": source_url,
                 "source": "Office of the Auditor General",
                 "data_quality": "official",

--- a/backend/tests/test_audit_fetcher_period.py
+++ b/backend/tests/test_audit_fetcher_period.py
@@ -1,0 +1,145 @@
+"""Regression tests for OAG audit-report fiscal-period derivation.
+
+Root-cause context (nightly "Validation failed" issues #121-132): the
+live OAG fetcher extracted real findings every night but emitted them
+with ``period_label=""`` and no ``start_date``/``end_date``/``audit_year``.
+The parser drops any finding missing those fields, so 100% of live
+findings were silently discarded (``processed=0``) and the audit table
+stayed frozen at 25 rows — below the validation gate's ``>= 50``.
+
+These tests lock in that a fetched finding now carries a fiscal period
+derived from the report filename / text, and — critically — that such a
+finding SURVIVES the parser end-to-end.
+"""
+
+from __future__ import annotations
+
+from seeding.domains.audits.fetcher import (
+    _derive_fiscal_period,
+    _extract_findings_from_text,
+    _fy_from_span,
+)
+from seeding.domains.audits.parser import parse_audit_payload
+
+
+class TestDeriveFiscalPeriod:
+    def test_from_filename_four_digit_span(self):
+        url = (
+            "https://www.oagkenya.go.ke/wp-content/uploads/2023/11/"
+            "County-Assembly-of-Homa-Bay-2021-2022.pdf"
+        )
+        assert _derive_fiscal_period(url, "") == (
+            "2021/2022",
+            "2021-07-01",
+            "2022-06-30",
+            2022,
+        )
+
+    def test_from_filename_two_digit_span(self):
+        url = "https://www.oagkenya.go.ke/x/Nakuru-County-2021-22.pdf"
+        assert _derive_fiscal_period(url, "") == (
+            "2021/2022",
+            "2021-07-01",
+            "2022-06-30",
+            2022,
+        )
+
+    def test_national_report_filename(self):
+        url = (
+            "https://www.oagkenya.go.ke/wp-content/uploads/2026/05/"
+            "AUDITOR-GENERALS-REPORT-ON-NATIONAL-GOVERNMENT-2024-2025.pdf"
+        )
+        assert _derive_fiscal_period(url, "") == (
+            "2024/2025",
+            "2024-07-01",
+            "2025-06-30",
+            2025,
+        )
+
+    def test_upload_path_date_is_not_mistaken_for_fy(self):
+        # "/uploads/2023/11/" is a publish date, not a fiscal year — the
+        # real FY is later in the filename.
+        url = "https://www.oagkenya.go.ke/wp-content/uploads/2023/11/Kisumu-2020-2021.pdf"
+        label, start, end, year = _derive_fiscal_period(url, "")
+        assert (label, year) == ("2020/2021", 2021)
+
+    def test_fallback_to_year_ended_text(self):
+        text = "Report on the Financial Statements for the year ended 30 June 2022."
+        assert _derive_fiscal_period("no-year-here.pdf", text) == (
+            "2021/2022",
+            "2021-07-01",
+            "2022-06-30",
+            2022,
+        )
+
+    def test_inline_fy_span_in_text(self):
+        text = "County Government of Mombasa\nFinancial Year 2022/23\nQualified Opinion"
+        assert _derive_fiscal_period("x.pdf", text)[0] == "2022/2023"
+
+    def test_source_preferred_over_text(self):
+        url = "Bomet-2021-2022.pdf"
+        text = "for the year ended 30 June 2019"
+        # Filename wins.
+        assert _derive_fiscal_period(url, text)[3] == 2022
+
+    def test_no_fiscal_year_returns_none_tuple(self):
+        assert _derive_fiscal_period("performance-audit.pdf", "no dates at all") == (
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+class TestFyFromSpan:
+    def test_consecutive_years_accepted(self):
+        assert _fy_from_span(2021, 2022) == (
+            "2021/2022",
+            "2021-07-01",
+            "2022-06-30",
+            2022,
+        )
+
+    def test_multi_year_range_rejected(self):
+        # A "2019-2023" strategic-plan span is not a fiscal year.
+        assert _fy_from_span(2019, 2023) is None
+
+    def test_same_year_rejected(self):
+        assert _fy_from_span(2022, 2022) is None
+
+
+class TestFetcherOutputSurvivesParser:
+    """The end-to-end regression: findings the fetcher emits must now be
+    KEPT by the parser (previously 100% were dropped)."""
+
+    SOURCE = (
+        "https://www.oagkenya.go.ke/wp-content/uploads/2023/11/"
+        "County-Government-of-Nakuru-2021-2022.pdf"
+    )
+    TEXT = (
+        "County Government of Nakuru\n\n"
+        "The audit revealed irregular expenditure of KSh 12,500,000 that was "
+        "unaccounted for during the financial year. The payments lacked "
+        "supporting documentation and were not authorised in accordance with "
+        "the PFM Act, an unsupported and irregular use of public funds.\n\n"
+    )
+
+    def test_extracted_findings_carry_period(self):
+        findings = _extract_findings_from_text(self.TEXT, self.SOURCE)
+        assert findings, "expected at least one finding"
+        f = findings[0]
+        assert f["period_label"] == "2021/2022"
+        assert f["start_date"] == "2021-07-01"
+        assert f["end_date"] == "2022-06-30"
+        assert f["audit_year"] == 2022
+
+    def test_findings_are_not_dropped_by_parser(self):
+        findings = _extract_findings_from_text(self.TEXT, self.SOURCE)
+        records = parse_audit_payload(findings)
+        # The bug was: len(records) == 0 for len(findings) >= 1.
+        assert len(records) == len(findings) >= 1
+        rec = records[0]
+        assert rec.period_label == "2021/2022"
+        assert rec.audit_year == 2022
+        assert rec.start_date.isoformat() == "2021-07-01"
+        assert rec.end_date.isoformat() == "2022-06-30"


### PR DESCRIPTION
## Root cause

The nightly **"Data pipeline failed: Validation"** issues (#121–132) all share one cause. Since PR #120 (the slow-PDF fix) let seeding pass, the pipeline advanced to the validation gate — which fails every night on:

```
[FAIL] Audit Records: 25 rows (expected >= 50)
[FAIL] Audits with audit_year: 25 rows (expected >= 50)
[FAIL] Audits with query_type: 25 rows (expected >= 30)
```

The audits domain **fetches real OAG findings every night but silently drops 100% of them.** From a live run: `Successfully fetched audit data from OAG (14 findings)` → `[OK] audits: completed | created=0 updated=0 processed=0`.

The fetcher emitted each finding with `period_label=""` and **no** `start_date`/`end_date`/`audit_year` (`"Will be extracted from context"` — never implemented). The parser drops any finding missing those fields, so nothing persisted and the audits table stayed frozen at the 25 real records kept after the 2026-07-07 fabricated-data purge — below the stale `>= 50` threshold (calibrated against the old, partly-fabricated 537-row volume).

## Fixes

1. **Fetcher — derive the fiscal period** (`period_label`, July→June `start_date`/`end_date`, end-year `audit_year`) from the OAG report filename first (`…-Homa-Bay-2021-2022.pdf`, `…-NATIONAL-GOVERNMENT-2024-2025.pdf`), then the report text (`for the year ended 30 June 2022`). `finditer` scans past the `/uploads/2023/11/` publish date in the URL; a consecutive-year guard rejects multi-year ranges. Findings now survive the parser and persist.
2. **Fetch↔parse guard** — the audits domain now WARNs when findings are fetched but the parser keeps fewer (or zero), so a shape regression can't hide for days behind `processed=0`.
3. **Recalibrated validation thresholds** — audit gates are now regression *floors* (20) matching the honest post-purge baseline (25), not the stale `>= 50`. Pipeline health (did ingestion persist?) is tracked by the ingestion-job counts + the new WARN, not by inflating the floor.
4. **Health-check noise (#124)** — blocked sources are re-probed with a browser UA; WAF/transient codes (`403/415/429/000/5xx`) are classified WARNING instead of CRITICAL so an intermittent WAF block on the GitHub Actions runner IP stops filing issues; open `data-source-down` issues auto-close on a green run. Genuine `404/410` still honour the per-source critical flag so real URL migrations still page.

## Tests

`backend/tests/test_audit_fetcher_period.py` — proves fetcher output now survives the parser (the exact regression), plus fiscal-period derivation edge cases (2-/4-digit spans, upload-path date, `year ended` fallback, multi-year rejection). `104 passed` across the audit/seeding/validation unit files.

## Notes

- The nightly only stops failing once this reaches `main` (runs 02:00 UTC). A run before merge can still file one more duplicate.
- Extraction *quality* of the naive regex parser is unchanged and out of scope here; this PR fixes the persistence contract so real findings land.

Closes #121, #122, #123, #125, #126, #127, #128, #129, #130, #131, #132
